### PR TITLE
NPL-280 Add delete confirmation for CustomObject Field

### DIFF
--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -264,7 +264,7 @@ class CustomObjectType(NetBoxModel):
                 "app_label": APP_LABEL,
                 "ordering": ["id"],
                 "indexes": indexes,
-                # "verbose_name": self.get_verbose_name(),
+                "verbose_name": self.get_verbose_name(),
                 "verbose_name_plural": self.get_verbose_name_plural(),
             },
         )

--- a/netbox_custom_objects/templates/netbox_custom_objects/field_delete.html
+++ b/netbox_custom_objects/templates/netbox_custom_objects/field_delete.html
@@ -1,0 +1,30 @@
+{% extends 'generic/_base.html' %}
+{% load helpers %}
+{% load form_helpers %}
+{% load i18n %}
+
+{% comment %}
+Blocks:
+  - title:      Page title
+  - content:    Primary page content
+
+Context:
+  - object:      Python instance of the object being deleted
+  - form:        The delete confirmation form
+  - form_url:    URL for form submission (optional; defaults to current path)
+  - return_url:  The URL to which the user is redirected after submitting the form
+{% endcomment %}
+
+{% block title %}
+  {% trans "Delete" %} {{ object|meta:"verbose_name" }}?
+{% endblock %}
+
+{% block content %}
+  <div class="modal" tabindex="-1" style="display: block; position: static">
+    <div class="modal-dialog">
+      <div class="modal-content border-1 border-danger">
+        {% include 'netbox_custom_objects/htmx/delete_form.html' %}
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/netbox_custom_objects/templates/netbox_custom_objects/htmx/delete_form.html
+++ b/netbox_custom_objects/templates/netbox_custom_objects/htmx/delete_form.html
@@ -1,0 +1,30 @@
+{% load form_helpers %}
+{% load i18n %}
+
+<form action="{{ form_url }}" method="post">
+  {% csrf_token %}
+  <div class="modal-header">
+    <h5 class="modal-title">{% trans "Confirm Deletion" %}</h5>
+  </div>
+  <div class="modal-body">
+    <p>
+      {% blocktrans trimmed %}
+        Are you sure you want to <strong class="text-danger">delete</strong> {{ object_type }} <strong>{{ object }}</strong>?
+      {% endblocktrans %}
+    </p>
+      <p>
+        {% blocktrans trimmed %}
+          You are deleting a field that is in use on {{ num_dependent_objects }} Custom Objects. This will lead to irreversible data loss. Are you sure?
+        {% endblocktrans %}
+        </p>
+    {% render_form form %}
+  </div>
+  <div class="modal-footer">
+    {% if return_url %}
+      <a href="{{ return_url }}" class="btn btn-outline-secondary">{% trans "Cancel" %}</a>
+    {% else %}
+      <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">{% trans "Cancel" %}</button>
+    {% endif %}
+    <button type="submit" class="btn btn-danger">{% trans "Delete" %}</button>
+  </div>
+</form>


### PR DESCRIPTION
Creates a special delete confirmation form for deleting a field:

![Monosnap Delete custom object type field? | NetBox 2025-06-20 15-08-04](https://github.com/user-attachments/assets/f29e4e1f-643f-438c-9ebf-e9b267957697)
