### PR TITLE
NPL-400 remove comments

### DIFF
--- a/netbox_custom_objects/templates/netbox_custom_objects/customobject.html
+++ b/netbox_custom_objects/templates/netbox_custom_objects/customobject.html
@@ -104,7 +104,6 @@
       {% plugin_left_page object %}
     </div>
     <div class="col col-md-6">
-      {% include 'inc/panels/comments.html' %}
       {% plugin_right_page object %}
       {% for field in fields %}
           {% if field.many %}


### PR DESCRIPTION
### Fixes: #400

Just removes the comment panel - if they want comments they can add a field type, it will display a bit different (inline instead of a separate box) but I dont' think we want to have a separate comments checkbox on CO Type and special logic around adding that field and display.

Also, right now the right hand side is empty if you don't have field relations, but when tagging support comes in we can move it to the right.