### PR TITLE
35 fix group name on edit form

### DIFF
--- a/netbox_custom_objects/templates/netbox_custom_objects/customobject_edit.html
+++ b/netbox_custom_objects/templates/netbox_custom_objects/customobject_edit.html
@@ -1,4 +1,5 @@
 {% extends 'generic/object_edit.html' %}
+{% load form_helpers %}
 {% load i18n %}
 
 {% block title %}
@@ -10,3 +11,24 @@
     {% endblocktrans %}
   {% endif %}
 {% endblock title %}
+
+{% block form %}
+  {# Render hidden fields #}
+  {% for field in form.hidden_fields %}
+    {{ field }}
+  {% endfor %}
+
+  {# Render all fields grouped by group_name #}
+  <div class="field-group mb-5">
+    {% for group, fields in form.custom_field_groups.items %}
+      {% if group %}
+      <div class="row">
+        <h3 class="col-9 offset-3 mb-3 h4">{{ group }}</h3>
+      </div>
+      {% endif %}
+      {% for name in fields %}
+        {% render_field form|getfield:name %}
+      {% endfor %}
+    {% endfor %}
+  </div>
+{% endblock form %}

--- a/netbox_custom_objects/views.py
+++ b/netbox_custom_objects/views.py
@@ -347,7 +347,7 @@ class CustomObjectEditView(generic.ObjectEditView):
             "custom_field_groups": {},
         }
 
-        for field in self.object.custom_object_type.fields.all():
+        for field in self.object.custom_object_type.fields.all().order_by('group_name', 'weight', 'name'):
             field_type = field_types.FIELD_TYPE_CLASS[field.type]()
             try:
                 field_name = field.name

--- a/netbox_custom_objects/views.py
+++ b/netbox_custom_objects/views.py
@@ -352,10 +352,10 @@ class CustomObjectEditView(generic.ObjectEditView):
             try:
                 field_name = field.name
                 attrs[field_name] = field_type.get_annotated_form_field(field)
-                
+
                 # Annotate the field in the list of CustomField form fields
                 attrs["custom_fields"][field_name] = field
-                
+
                 # Group fields by group_name (similar to NetBox custom fields)
                 group_name = field.group_name or None  # Use None for ungrouped fields
                 if group_name not in attrs["custom_field_groups"]:
@@ -369,9 +369,9 @@ class CustomObjectEditView(generic.ObjectEditView):
         def custom_init(self, *args, **kwargs):
             super(form_class, self).__init__(*args, **kwargs)
             # Set the grouping info as instance attributes from the outer scope
-            self.custom_fields = attrs["custom_fields"] 
+            self.custom_fields = attrs["custom_fields"]
             self.custom_field_groups = attrs["custom_field_groups"]
-        
+
         attrs["__init__"] = custom_init
 
         form_class = type(


### PR DESCRIPTION
### Fixes: #35 

Groups edit items under group_name and also takes into account weight of fields.

<img width="1220" height="893" alt="xMonosnap Editing cot1 cot1 1 | NetBox 2025-07-24 15-13-24" src="https://github.com/user-attachments/assets/cbff39e3-c2f7-47c7-a8a0-ab88e4def228" />
