### PR TITLE
Remove inline object table

### DIFF
--- a/netbox_custom_objects/templates/netbox_custom_objects/customobjecttype.html
+++ b/netbox_custom_objects/templates/netbox_custom_objects/customobjecttype.html
@@ -107,51 +107,6 @@
   <div class="row mb-3">
     <div class="col col-md-12">
       {% plugin_full_width_page object %}
-      <div class="card">
-        <h2 class="card-header">
-          <a href="{{ object.get_list_url }}">{{ object.get_verbose_name_plural }}</a>
-            <div class="card-actions">
-              {% if request.user|can_add:object %}
-                <a href="{% url 'plugins:netbox_custom_objects:customobject_add' custom_object_type=object.name.lower %}?return_url={{ object.get_absolute_url }}" class="btn btn-ghost-primary btn-sm">
-                  <span class="mdi mdi-plus-thick" aria-hidden="true"></span> {% trans "Add" %} {{ object.get_title_case_name }}
-                </a>
-              {% endif %}
-            </div>
-          </h2>
-          {% include 'htmx/table.html' %}
-      {% comment %}
-        <table class="table table-hover attr-table">
-            <thead>
-                <tr>
-                    <th>{{ object.name }}</th>
-                    {% for field in object.fields.all %}
-                        <th>{{ field }}</th>
-                    {% endfor %}
-                </tr>
-            </thead>
-            {% for instance in custom_objects %}
-                <tr>
-                    <td>{{ instance|linkify }}</td>
-                    {% for field in object.fields.all %}
-                        {% if field.is_single_value %}
-                            {% if field.type == 'object' %}
-                                <td>{{ instance|get_field_value:field|linkify }}</td>
-                            {% else %}
-                                <td>{{ instance|get_field_value:field }}</td>
-                            {% endif %}
-                        {% else %}
-{#                            {% with instance|get_child_relations:field as relations %}#}
-{#                                <td>{{ relations.count }}</td>#}
-{#                            {% endwith %}#}
-                        {% endif %}
-{#                        <td>{% if field.field_type == "object" %}{{ field|get_field_object_type }}{% endif %}</td>#}
-{#                        <td>{% if field.many %}(Many){% endif %}</td>#}
-                    {% endfor %}
-                </tr>
-            {% endfor %}
-        </table>
-      {% endcomment %}
-      </div>
     </div>
   </div>
 {% endblock %}

--- a/netbox_custom_objects/templatetags/custom_object_buttons.py
+++ b/netbox_custom_objects/templatetags/custom_object_buttons.py
@@ -105,6 +105,7 @@ def custom_object_edit_button(instance):
 
     return {
         "url": url,
+        "label": "Edit",
     }
 
 


### PR DESCRIPTION
Removes the inline table of Custom Objects from the Custom Object Type detail page.

Also adds the "Edit" label to the toolbar edit button on the Custom Object detail page.