### PR TITLE
NPL-415 fix detail page when custom object links is null

### DIFF
--- a/netbox_custom_objects/template_content.py
+++ b/netbox_custom_objects/template_content.py
@@ -39,21 +39,34 @@ class CustomObjectLink(PluginTemplateExtension):
 
     def left_page(self):
         # TODO: Improve performance of these nested queries
-        content_type = ContentType.objects.get_for_model(self.context['object']._meta.model)
-        custom_object_type_fields = CustomObjectTypeField.objects.filter(related_object_type=content_type)
+        content_type = ContentType.objects.get_for_model(
+            self.context["object"]._meta.model
+        )
+        custom_object_type_fields = CustomObjectTypeField.objects.filter(
+            related_object_type=content_type
+        )
         linked_custom_objects = []
         for field in custom_object_type_fields:
             model = field.custom_object_type.get_model()
             for model_object in model.objects.all():
                 model_field = getattr(model_object, field.name)
                 if model_field:
-                  if field.type == CustomFieldTypeChoices.TYPE_MULTIOBJECT:
-                      if model_field.filter(id=self.context["object"].pk).exists():
-                          linked_custom_objects.append(LinkedCustomObject(custom_object=model_object, field=field))
-                  else:
-                      if model_field.id == self.context["object"].pk:
-                          linked_custom_objects.append(LinkedCustomObject(custom_object=model_object, field=field))
-        return render_jinja2("""
+                    if field.type == CustomFieldTypeChoices.TYPE_MULTIOBJECT:
+                        if model_field.filter(id=self.context["object"].pk).exists():
+                            linked_custom_objects.append(
+                                LinkedCustomObject(
+                                    custom_object=model_object, field=field
+                                )
+                            )
+                    else:
+                        if model_field.id == self.context["object"].pk:
+                            linked_custom_objects.append(
+                                LinkedCustomObject(
+                                    custom_object=model_object, field=field
+                                )
+                            )
+        return render_jinja2(
+            """
           <div class="card">
             <h2 class="card-header">Custom Objects linking to this object</h2>
             <table class="table table-hover attr-table">
@@ -73,7 +86,9 @@ class CustomObjectLink(PluginTemplateExtension):
               {% endfor %}
             </table>
           </div>
-          """, {'linked_custom_objects': linked_custom_objects})
+          """,
+            {"linked_custom_objects": linked_custom_objects},
+        )
 
 
 template_extensions = (

--- a/netbox_custom_objects/template_content.py
+++ b/netbox_custom_objects/template_content.py
@@ -46,12 +46,13 @@ class CustomObjectLink(PluginTemplateExtension):
             model = field.custom_object_type.get_model()
             for model_object in model.objects.all():
                 model_field = getattr(model_object, field.name)
-                if field.type == CustomFieldTypeChoices.TYPE_MULTIOBJECT:
-                    if model_field.filter(id=self.context["object"].pk).exists():
-                        linked_custom_objects.append(LinkedCustomObject(custom_object=model_object, field=field))
-                else:
-                    if model_field.id == self.context["object"].pk:
-                        linked_custom_objects.append(LinkedCustomObject(custom_object=model_object, field=field))
+                if model_field:
+                  if field.type == CustomFieldTypeChoices.TYPE_MULTIOBJECT:
+                      if model_field.filter(id=self.context["object"].pk).exists():
+                          linked_custom_objects.append(LinkedCustomObject(custom_object=model_object, field=field))
+                  else:
+                      if model_field.id == self.context["object"].pk:
+                          linked_custom_objects.append(LinkedCustomObject(custom_object=model_object, field=field))
         return render_jinja2("""
           <div class="card">
             <h2 class="card-header">Custom Objects linking to this object</h2>


### PR DESCRIPTION
Fixes viewing detail page of an object when you have a custom object linked to it via object field and there are no object assignments.