### PR TITLE
Handle deletion of all linked ObjectChanges for CustomObjects when deleting a CustomObjectType

### DIFF
--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -506,6 +506,7 @@ class CustomObjectType(PrimaryModel):
         super().delete(*args, **kwargs)
 
         # Temporarily disconnect the pre_delete handler to skip the ObjectType deletion
+        # TODO: Remove this disconnect/reconnect after ObjectType has been exempted from handle_deleted_object
         pre_delete.disconnect(handle_deleted_object)
         object_type.delete()
         with connection.schema_editor() as schema_editor:

--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -14,8 +14,10 @@ from django.core.validators import RegexValidator, ValidationError
 from django.db import connection, models
 from django.db.models import Q
 from django.db.models.functions import Lower
+from django.db.models.signals import pre_delete
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
+from core.signals import handle_deleted_object
 from extras.choices import (
     CustomFieldFilterLogicChoices,
     CustomFieldTypeChoices,
@@ -501,14 +503,14 @@ class CustomObjectType(PrimaryModel):
         model = self.get_model()
         object_type = ObjectType.objects.get_for_model(model)
         ObjectChange.objects.filter(changed_object_type=object_type).delete()
-        object_type_qs = ObjectType.objects.filter(pk=object_type.pk)
-        # _raw_delete is necessary to avoid post_delete signal handling
-        object_type_qs._raw_delete(object_type_qs.db)
         super().delete(*args, **kwargs)
+
+        # Temporarily disconnect the pre_delete handler to skip the ObjectType deletion
+        pre_delete.disconnect(handle_deleted_object)
+        object_type.delete()
         with connection.schema_editor() as schema_editor:
             schema_editor.delete_model(model)
-        # TODO: The ContentType should be cleaned up as well but it throws an error in this flow
-        # ContentType.objects.get(pk=object_type.id).delete()
+        pre_delete.connect(handle_deleted_object)
 
 
 class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedModel):


### PR DESCRIPTION
Ensures clean deletion of a CustomObjectType by deleting all ObjectChanges linked to CustomObjects within the COT.