### PR TITLE
183 delete cot

### DIFF
--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -553,14 +553,14 @@ class CustomObjectType(PrimaryModel):
         self.clear_model_cache(self.id)
 
         model = self.get_model()
+
+        # Delete all CustomObjectTypeFields that reference this CustomObjectType
+        for field in CustomObjectTypeField.objects.filter(related_object_type=self.content_type):
+            field.delete()
+
         object_type = ObjectType.objects.get_for_model(model)
         ObjectChange.objects.filter(changed_object_type=object_type).delete()
         super().delete(*args, **kwargs)
-
-        # Delete all CustomObjectTypeFields that reference this CustomObjectType
-        CustomObjectTypeField.objects.filter(
-            related_object_type=self.content_type
-        ).delete()
 
         # Temporarily disconnect the pre_delete handler to skip the ObjectType deletion
         # TODO: Remove this disconnect/reconnect after ObjectType has been exempted from handle_deleted_object

--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -557,6 +557,11 @@ class CustomObjectType(PrimaryModel):
         ObjectChange.objects.filter(changed_object_type=object_type).delete()
         super().delete(*args, **kwargs)
 
+        # Delete all CustomObjectTypeFields that reference this CustomObjectType
+        CustomObjectTypeField.objects.filter(
+            related_object_type=self.content_type
+        ).delete()
+
         # Temporarily disconnect the pre_delete handler to skip the ObjectType deletion
         # TODO: Remove this disconnect/reconnect after ObjectType has been exempted from handle_deleted_object
         pre_delete.disconnect(handle_deleted_object)

--- a/netbox_custom_objects/views.py
+++ b/netbox_custom_objects/views.py
@@ -9,7 +9,7 @@ from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import View
-from extras.choices import CustomFieldUIVisibleChoices
+from extras.choices import CustomFieldTypeChoices, CustomFieldUIVisibleChoices
 from extras.forms import JournalEntryForm
 from extras.models import JournalEntry
 from extras.tables import JournalEntryTable
@@ -189,6 +189,16 @@ class CustomObjectTypeDeleteView(generic.ObjectDeleteView):
         dependent_objects = super()._get_dependent_objects(obj)
         model = obj.get_model()
         dependent_objects[model] = list(model.objects.all())
+        
+        # Find CustomObjectTypeFields that reference this CustomObjectType
+        referencing_fields = CustomObjectTypeField.objects.filter(
+            related_object_type=obj.content_type
+        )
+        
+        # Add the CustomObjectTypeFields that reference this CustomObjectType
+        if referencing_fields.exists():
+            dependent_objects[CustomObjectTypeField] = list(referencing_fields)
+        
         return dependent_objects
 
 

--- a/netbox_custom_objects/views.py
+++ b/netbox_custom_objects/views.py
@@ -9,7 +9,7 @@ from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import View
-from extras.choices import CustomFieldTypeChoices, CustomFieldUIVisibleChoices
+from extras.choices import CustomFieldUIVisibleChoices
 from extras.forms import JournalEntryForm
 from extras.models import JournalEntry
 from extras.tables import JournalEntryTable
@@ -189,16 +189,16 @@ class CustomObjectTypeDeleteView(generic.ObjectDeleteView):
         dependent_objects = super()._get_dependent_objects(obj)
         model = obj.get_model()
         dependent_objects[model] = list(model.objects.all())
-        
+
         # Find CustomObjectTypeFields that reference this CustomObjectType
         referencing_fields = CustomObjectTypeField.objects.filter(
             related_object_type=obj.content_type
         )
-        
+
         # Add the CustomObjectTypeFields that reference this CustomObjectType
         if referencing_fields.exists():
             dependent_objects[CustomObjectTypeField] = list(referencing_fields)
-        
+
         return dependent_objects
 
 


### PR DESCRIPTION
### Fixes: #183

When deleting a custom object type, all CustomObjectTypeField that have related_object pointing to it also need to be removed.