### PR TITLE
Fixes #115: Add support for REST API filtering

### DIFF
--- a/netbox_custom_objects/api/views.py
+++ b/netbox_custom_objects/api/views.py
@@ -2,6 +2,7 @@ from django.http import Http404
 from rest_framework.routers import APIRootView
 from rest_framework.viewsets import ModelViewSet
 
+from netbox_custom_objects.filtersets import get_filterset_class
 from netbox_custom_objects.models import CustomObjectType, CustomObjectTypeField
 
 from . import serializers
@@ -38,6 +39,10 @@ class CustomObjectViewSet(ModelViewSet):
             raise Http404
         self.model = custom_object_type.get_model()
         return self.model.objects.all()
+
+    @property
+    def filterset_class(self):
+        return get_filterset_class(self.model)
 
     def list(self, request, *args, **kwargs):
         return super().list(request, *args, **kwargs)


### PR DESCRIPTION
### Fixes: #115

- Move filterset construction logic from `CustomObjectListView.get_filterset()` to a `get_filterset_class()` utility function
- Introduce the `filter_class` property on `CustomObjectViewSet` to call `get_filterset_class()`
- Removed unused definition for `CustomObjectFilterSet`