### PR TITLE
Conditionally disable object selector on object fields if model is Custom Object

### DIFF
--- a/netbox_custom_objects/field_types.py
+++ b/netbox_custom_objects/field_types.py
@@ -517,7 +517,7 @@ class ObjectFieldType(FieldType):
                     if hasattr(field, "related_object_filter")
                     else None
                 ),
-                selector=True,
+                selector=model._meta.app_label != APP_LABEL,
             )
 
     def get_filterform_field(self, field, **kwargs):
@@ -839,7 +839,7 @@ class MultiObjectFieldType(FieldType):
                     if hasattr(field, "related_object_filter")
                     else None
                 ),
-                selector=True,
+                selector=model._meta.app_label != APP_LABEL,
             )
 
     def get_filterform_field(self, field, **kwargs):


### PR DESCRIPTION
This PR simply disables the Quick Add selector for object/multiobject fields where the related model is a Custom Object.

Fully implementing Quick Add for Custom Objects may be best handled as a separate post-release effort, but this fixes the crash.