### PR TITLE
Refresh stale model if field is missing in get_field_value template tag

### DIFF
--- a/netbox_custom_objects/templatetags/custom_object_utils.py
+++ b/netbox_custom_objects/templatetags/custom_object_utils.py
@@ -28,12 +28,7 @@ def get_field_type_verbose_name(field: CustomObjectTypeField) -> str:
 
 @register.filter(name="get_field_value")
 def get_field_value(obj, field: CustomObjectTypeField) -> str:
-    try:
-        return getattr(obj, field.name)
-    except AttributeError:
-        model = obj.custom_object_type.get_model()
-        new_obj = model.objects.get(pk=obj.pk)
-        return getattr(new_obj, field.name)
+    return getattr(obj, field.name, "")
 
 
 @register.filter(name="get_field_is_ui_visible")

--- a/netbox_custom_objects/templatetags/custom_object_utils.py
+++ b/netbox_custom_objects/templatetags/custom_object_utils.py
@@ -28,7 +28,12 @@ def get_field_type_verbose_name(field: CustomObjectTypeField) -> str:
 
 @register.filter(name="get_field_value")
 def get_field_value(obj, field: CustomObjectTypeField) -> str:
-    return getattr(obj, field.name)
+    try:
+        return getattr(obj, field.name)
+    except AttributeError:
+        model = obj.custom_object_type.get_model()
+        new_obj = model.objects.get(pk=obj.pk)
+        return getattr(new_obj, field.name)
 
 
 @register.filter(name="get_field_is_ui_visible")


### PR DESCRIPTION
In the `get_field_value` template tag, If `field` is not present on `obj`, generate a fresh version of the model from the current state and retry the operation.
