### PR TITLE
Closes: #89 - Render the primary field name as a link to the object

### DIFF
--- a/netbox_custom_objects/field_types.py
+++ b/netbox_custom_objects/field_types.py
@@ -146,6 +146,12 @@ class TextFieldType(FieldType):
             required=False,
         )
 
+    def render_table_column(self, value, record, bound_column):
+        primary_field = record._field_objects.get(record._primary_field_id, None)
+        if primary_field and bound_column.name == primary_field["name"]:
+            return mark_safe(f'<a href="{record.get_absolute_url()}">{value}</a>')
+        return value
+
 
 class LongTextFieldType(FieldType):
     def get_model_field(self, field, **kwargs):


### PR DESCRIPTION
## Closes: #89 

Adds a `render_table_column` method to `TextFieldType` which renders the column value as a link to the object's detail page, if that column is the primary name field on the Custom Object Type.

Does not change the behavior of any other field types.

<img width="1092" height="275" alt="Screenshot 2025-09-08 at 7 29 16 PM" src="https://github.com/user-attachments/assets/710062cb-6fb8-4bb5-8b28-b4b4307323ee" />
