### PR TITLE
Closes NPL-497: Add author name & email to PluginConfig

### DIFF
--- a/netbox_custom_objects/__init__.py
+++ b/netbox_custom_objects/__init__.py
@@ -46,6 +46,8 @@ class CustomObjectsPluginConfig(PluginConfig):
     verbose_name = "Custom Objects"
     description = "A plugin to manage custom objects in NetBox"
     version = "0.3.1"
+    author = 'Netbox Labs'
+    author_email = 'support@netboxlabs.com'
     base_url = "custom-objects"
     min_version = "4.4.0"
     default_settings = {}


### PR DESCRIPTION
Annotate the plugin author's name & email address in the plugin config, to ensure the author is displayed in the plugins list despite not having a catalog entry.