### PR TITLE
use no_cache and get_model_with_serializer for api calls

### DIFF
--- a/netbox_custom_objects/api/views.py
+++ b/netbox_custom_objects/api/views.py
@@ -50,7 +50,7 @@ class CustomObjectViewSet(ModelViewSet):
             )
         except CustomObjectType.DoesNotExist:
             raise Http404
-        self.model = custom_object_type.get_model()
+        self.model = custom_object_type.get_model_with_serializer(no_cache=True)
         return self.model.objects.all()
 
     @property

--- a/netbox_custom_objects/api/views.py
+++ b/netbox_custom_objects/api/views.py
@@ -50,7 +50,7 @@ class CustomObjectViewSet(ModelViewSet):
             )
         except CustomObjectType.DoesNotExist:
             raise Http404
-        self.model = custom_object_type.get_model_with_serializer(no_cache=True)
+        self.model = custom_object_type.get_model_with_serializer()
         return self.model.objects.all()
 
     @property

--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -454,6 +454,8 @@ class CustomObjectType(PrimaryModel):
 
         :param skip_object_fields: Don't add object or multiobject fields to the model
         :type skip_object_fields: bool
+        :param no_cache: Force regeneration of the model, bypassing cache
+        :type no_cache: bool
         :return: The generated model.
         :rtype: Model
         """


### PR DESCRIPTION
use the get_model_with_serializer and no_cache for CO API calls.