### PR TITLE
avoid postgres errors pre migration run

### DIFF
--- a/netbox_custom_objects/__init__.py
+++ b/netbox_custom_objects/__init__.py
@@ -1,7 +1,6 @@
 import sys
 import warnings
 
-from django.db import transaction
 from django.db.utils import DatabaseError, OperationalError, ProgrammingError
 from netbox.plugins import PluginConfig
 
@@ -33,7 +32,7 @@ def check_custom_object_type_table_exists():
             table_name = CustomObjectType._meta.db_table
             cursor.execute("""
                 SELECT EXISTS (
-                    SELECT FROM information_schema.tables 
+                    SELECT FROM information_schema.tables
                     WHERE table_name = %s
                 )
             """, [table_name])


### PR DESCRIPTION
### Fixes: #172 

Avoid postgresql errors pre migration run.  The root issue is the init code trying to access the COT table before migrations have been run.  To avoid this the check has been changed from using Django ORM (which will cause an error) to RAW SQL to check for the existence of the table.