### PR TITLE
Add group_name to CustomObjectTypeFieldSerializer.fields

### DIFF
--- a/netbox_custom_objects/api/serializers.py
+++ b/netbox_custom_objects/api/serializers.py
@@ -57,6 +57,7 @@ class CustomObjectTypeFieldSerializer(NetBoxModelSerializer):
             "related_object_type",
             "app_label",
             "model",
+            "group_name",
         )
 
     def validate(self, attrs):


### PR DESCRIPTION
### Fixes: #273

Adds `group_name` to `CustomObjectTypeFieldSerializer.fields`.