### PR TITLE
Fixes: #278 - Add bulk import buttons to custom objects in nav menu

### DIFF
--- a/netbox_custom_objects/navigation.py
+++ b/netbox_custom_objects/navigation.py
@@ -39,10 +39,21 @@ class CustomObjectTypeMenuItems:
                     "custom_object_type": custom_object_type.slug
                 },
             )
+            bulk_import_button = PluginMenuButton(
+                None,
+                _('Import'),
+                'mdi mdi-upload'
+            )
+            bulk_import_button.url = reverse_lazy(
+                f"plugins:{APP_LABEL}:customobject_bulk_import",
+                kwargs={
+                    "custom_object_type": custom_object_type.slug
+                },
+            )
             menu_item = PluginMenuItem(
                 link=None,
                 link_text=_(title(model._meta.verbose_name_plural)),
-                buttons=(add_button,),
+                buttons=(add_button, bulk_import_button),
                 auth_required=True,
             )
             menu_item.url = reverse_lazy(


### PR DESCRIPTION
### Fixes: #278

Adds bulk import buttons alongside single add buttons in Custom Object nav menu items.

<img width="1308" height="870" alt="Screenshot 2025-11-14 at 2 27 57 PM" src="https://github.com/user-attachments/assets/d538370f-bc22-4d6e-abb1-1a80ad590570" />
