### PR TITLE
#299 add model to reserved CO field names

### DIFF
--- a/netbox_custom_objects/constants.py
+++ b/netbox_custom_objects/constants.py
@@ -7,43 +7,37 @@ INCLUDE_MODELS = (
 
 APP_LABEL = "netbox_custom_objects"
 
-# Field names that are reserved and cannot be used for custom object fields
+# Field names that are reserved and cannot be used for custom object fields.
+# Keep in alphabetical order for ease of reading error message.
 RESERVED_FIELD_NAMES = [
-    # Django model internals
     "_meta",
     "_state",
     "DoesNotExist",
     "MultipleObjectsReturned",
-    "objects",
-    # Primary key fields
-    "id",
-    "pk",
-    # Django model methods
+    "bookmarks",
     "clean",
-    "delete",
-    "full_clean",
-    "refresh_from_db",
-    "save",
-    # Custom object specific
     "clone",
+    "contacts",
+    "created",
+    "custom_field_data",
     "custom_object_type",
     "custom_object_type_id",
-    "custom_field_data",
-    "model",
-    # Change logging
-    "created",
-    "last_updated",
-    "serialize_object",
-    "snapshot",
-    "to_objectchange",
-    # Generic relations from mixins
-    "bookmarks",
-    "contacts",
+    "delete",
+    "full_clean",
+    "get_absolute_url",
+    "id",
     "images",
     "jobs",
     "journal_entries",
+    "last_updated",
+    "model",
+    "objects",
+    "pk",
+    "refresh_from_db",
+    "save",
+    "serialize_object",
+    "snapshot",
     "subscriptions",
     "tags",
-    # URL methods
-    "get_absolute_url",
+    "to_objectchange",
 ]


### PR DESCRIPTION
### Fixes: #299 

Added "model" to the reserved keywords for field names, also did an AI pass for other reserved words that would cause issues and added those as well. 

Put in alphabetical order as now the list is longer and they are all shown in the error message so easier to read.