### PR TITLE
284 Add "tags" to table columns for Custom Objects

### DIFF
--- a/netbox_custom_objects/tables.py
+++ b/netbox_custom_objects/tables.py
@@ -9,7 +9,6 @@ from django.utils.translation import gettext_lazy as _
 from netbox.tables import NetBoxTable, columns
 from utilities.permissions import get_permission_for_model
 
-from netbox_custom_objects.constants import APP_LABEL
 from netbox_custom_objects.models import CustomObject, CustomObjectType
 from netbox_custom_objects.utilities import get_viewname
 
@@ -95,8 +94,13 @@ class CustomObjectTagColumn(columns.TagColumn):
     template_code = """
     {% load helpers %}
     {% for tag in value.all %}
-        <a href="{% url 'plugins:netbox_custom_objects:customobject_list' custom_object_type=record.custom_object_type.slug %}?tag={{ tag.slug }}">
-            <span {% if tag.description %}title="{{ tag.description }}"{% endif %} class="badge" style="color: {{ tag.color|fgcolor }}; background-color: #{{ tag.color }}">{{ tag }}</span>
+        <a href="{% url 'plugins:netbox_custom_objects:customobject_list'
+                  custom_object_type=record.custom_object_type.slug %}?tag={{ tag.slug }}">
+            <span {% if tag.description %}title="{{ tag.description }}"{% endif %}
+                  class="badge"
+                  style="color: {{ tag.color|fgcolor }}; background-color: #{{ tag.color }}">
+                {{ tag }}
+            </span>
         </a>
     {% empty %}
         <span class="text-muted">&mdash;</span>

--- a/netbox_custom_objects/tables.py
+++ b/netbox_custom_objects/tables.py
@@ -9,6 +9,7 @@ from django.utils.translation import gettext_lazy as _
 from netbox.tables import NetBoxTable, columns
 from utilities.permissions import get_permission_for_model
 
+from netbox_custom_objects.constants import APP_LABEL
 from netbox_custom_objects.models import CustomObject, CustomObjectType
 from netbox_custom_objects.utilities import get_viewname
 
@@ -56,7 +57,7 @@ class CustomObjectTypeTable(NetBoxTable):
         verbose_name=_('Comments'),
     )
     tags = columns.TagColumn(
-        url_name='circuits:provider_list'
+        url_name='plugins:netbox_custom_objects:customobjecttype_list'
     )
     name = tables.Column(
         verbose_name=_('Name'),
@@ -84,6 +85,31 @@ class CustomObjectTypeTable(NetBoxTable):
             "name",
             "created",
             "last_updated",
+        )
+
+
+class CustomObjectTagColumn(columns.TagColumn):
+    """
+    Custom TagColumn that generates tag filter URLs with the custom_object_type slug.
+    """
+    template_code = """
+    {% load helpers %}
+    {% for tag in value.all %}
+        <a href="{% url 'plugins:netbox_custom_objects:customobject_list' custom_object_type=record.custom_object_type.slug %}?tag={{ tag.slug }}">
+            <span {% if tag.description %}title="{{ tag.description }}"{% endif %} class="badge" style="color: {{ tag.color|fgcolor }}; background-color: #{{ tag.color }}">{{ tag }}</span>
+        </a>
+    {% empty %}
+        <span class="text-muted">&mdash;</span>
+    {% endfor %}
+    """
+
+    def __init__(self):
+        # Override parent __init__ to use our custom template
+        tables.TemplateColumn.__init__(
+            self,
+            orderable=False,
+            template_code=self.template_code,
+            verbose_name=_('Tags'),
         )
 
 
@@ -178,6 +204,7 @@ class CustomObjectTable(NetBoxTable):
     actions = CustomObjectActionsColumn(
         actions=('edit', 'delete'),
     )
+    tags = CustomObjectTagColumn()
 
     class Meta(NetBoxTable.Meta):
         model = CustomObject
@@ -188,6 +215,7 @@ class CustomObjectTable(NetBoxTable):
             "custom_object_type",
             "created",
             "last_updated",
+            "tags",
         )
         default_columns = (
             "pk",

--- a/netbox_custom_objects/views.py
+++ b/netbox_custom_objects/views.py
@@ -20,6 +20,7 @@ from netbox.forms import (
 from netbox.views import generic
 from netbox.views.generic.mixins import TableMixin
 from utilities.forms import ConfirmationForm
+from utilities.forms.fields import TagFilterField
 from utilities.htmx import htmx_partial
 from utilities.views import ConditionalLoginRequiredMixin, ViewTab, get_viewname, register_model_view
 
@@ -345,6 +346,7 @@ class CustomObjectListView(CustomObjectTableMixin, generic.ObjectListView):
         attrs = {
             "model": model,
             "__module__": "database.filterset_forms",
+            "tag": TagFilterField(model),
         }
 
         for field in self.custom_object_type.fields.all():


### PR DESCRIPTION
### Fixes: #284 

A bit more involved than I initially thought.  The normal tags column has a url_name, but the custom-objects list view URL requires an argument for the COT, so a CustomObjectTagColumn was needed to allow for this.  

Clicking on the tags in the list-view also should take you to the list view filtered for that tag, so that filter had to be added to the dynamically generated form. 

Finally the tags in the COT had an incorrect url_name, so corrected that.

<img width="1242" height="434" alt="Monosnap Cot1s | NetBox 2025-12-09 15-10-55" src="https://github.com/user-attachments/assets/c2dcf094-c6fd-4a2c-9869-367ac6cad306" />
