### PR TITLE
Fixes #310 - Linkify primary field

### DIFF
--- a/netbox_custom_objects/field_types.py
+++ b/netbox_custom_objects/field_types.py
@@ -110,6 +110,9 @@ class FieldType:
     def get_table_column_field(self, field, **kwargs):
         raise NotImplementedError
 
+    def render_table_column_linkified(self, record):
+        return linkify(record)
+
     def after_model_generation(self, instance, model, field_name): ...
 
     def create_m2m_table(self, instance, model, field_name): ...

--- a/netbox_custom_objects/views.py
+++ b/netbox_custom_objects/views.py
@@ -127,9 +127,13 @@ class CustomObjectTableMixin(TableMixin):
                         field.name
                     )
                 )
-            # Primary field is linkified to the target Custom Object. Other fields may be rendered via
-            # field-specific "render_foo" methods as supported by django-tables2.
-            if field.primary:
+            # Primary field (if text-based) is linkified to the target Custom Object. Other fields may be
+            # rendered via field-specific "render_foo" methods as supported by django-tables2.
+            linkable_field_types = [
+                CustomFieldTypeChoices.TYPE_TEXT,
+                CustomFieldTypeChoices.TYPE_LONGTEXT,
+            ]
+            if field.primary and field.type in linkable_field_types:
                 attrs[f"render_{field.name}"] = field_type.render_table_column_linkified
             else:
                 # Define a method "render_table_column" method on any FieldType to customize output

--- a/netbox_custom_objects/views.py
+++ b/netbox_custom_objects/views.py
@@ -127,12 +127,17 @@ class CustomObjectTableMixin(TableMixin):
                         field.name
                     )
                 )
-            # Define a method "render_table_column" method on any FieldType to customize output
-            # See https://django-tables2.readthedocs.io/en/latest/pages/custom-data.html#table-render-foo-methods
-            try:
-                attrs[f"render_{field.name}"] = field_type.render_table_column
-            except AttributeError:
-                pass
+            # Primary field is linkified to the target Custom Object. Other fields may be rendered via
+            # field-specific "render_foo" methods as supported by django-tables2.
+            if field.primary:
+                attrs[f"render_{field.name}"] = field_type.render_table_column_linkified
+            else:
+                # Define a method "render_table_column" method on any FieldType to customize output
+                # See https://django-tables2.readthedocs.io/en/latest/pages/custom-data.html#table-render-foo-methods
+                try:
+                    attrs[f"render_{field.name}"] = field_type.render_table_column
+                except AttributeError:
+                    pass
 
         self.table = type(
             f"{data.model._meta.object_name}Table",


### PR DESCRIPTION
### Fixes: #310

Introduces a `render_table_column_linkified` method on the base `FieldType` which during dynamic table generation is attached to the "primary" column and provides a "linkified" value which leads to the target Custom Object.

Upshot is that in a Custom Object list view table, the "primary" field (i.e. "name" below) is automatically made a link, making it easier to create a customized table view with clickable object names.

<img width="626" height="258" alt="Screenshot 2025-12-10 at 9 06 41 AM" src="https://github.com/user-attachments/assets/cbb67d49-51da-4175-9e46-1c2afc9b173a" />

**Note:**
For all non-primary fields, custom column renderers (following the `render_foo` pattern of django-tables2) are still used for overriding the displayed value for multiobject, JSON, etc. Note that if a JSON or other formatted field is made the "primary", formatting will be lost due to the `render_table_column_linkified` behavior taking precedence.
