### PR TITLE
Improve initialization code check when running migrations

### DIFF
--- a/netbox_custom_objects/__init__.py
+++ b/netbox_custom_objects/__init__.py
@@ -75,8 +75,6 @@ class CustomObjectsPluginConfig(PluginConfig):
         Returns True if all migrations are applied, False otherwise.
         """
         try:
-            # --check: exit non-zero (raise error) if unapplied migrations exist
-            # --dry-run: don't actually apply anything
             call_command(
                 "migrate",
                 APP_LABEL,
@@ -87,8 +85,6 @@ class CustomObjectsPluginConfig(PluginConfig):
             )
             return True
         except (CommandError, Exception):
-            # CommandError is raised when --check fails (unapplied migrations exist)
-            # Catch other exceptions during migration check
             return False
 
     def ready(self):

--- a/netbox_custom_objects/__init__.py
+++ b/netbox_custom_objects/__init__.py
@@ -44,31 +44,6 @@ class CustomObjectsPluginConfig(PluginConfig):
         return "test" in sys.argv
 
     @staticmethod
-    def _check_custom_object_type_table_exists():
-        """
-        Check if the CustomObjectType table exists in the database.
-        Returns True if the table exists, False otherwise.
-        """
-        from django.db import connection
-        from .models import CustomObjectType
-
-        try:
-            # Use raw SQL to check table existence without generating ORM errors
-            with connection.cursor() as cursor:
-                table_name = CustomObjectType._meta.db_table
-                cursor.execute("""
-                    SELECT EXISTS (
-                        SELECT FROM information_schema.tables
-                        WHERE table_name = %s
-                    )
-                """, [table_name])
-                table_exists = cursor.fetchone()[0]
-                return table_exists
-        except (OperationalError, ProgrammingError, DatabaseError):
-            # Catch database-specific errors (permission issues, etc.)
-            return False
-
-    @staticmethod
     def _all_migrations_applied():
         """
         Check if all migrations for this app are applied.
@@ -104,7 +79,6 @@ class CustomObjectsPluginConfig(PluginConfig):
             # or if not all migrations have been applied yet
             if (
                 self._is_running_migration()
-                or not self._check_custom_object_type_table_exists()
                 or not self._all_migrations_applied()
             ):
                 super().ready()
@@ -177,7 +151,6 @@ class CustomObjectsPluginConfig(PluginConfig):
             # or if not all migrations have been applied yet
             if (
                 self._is_running_migration()
-                or not self._check_custom_object_type_table_exists()
                 or not self._all_migrations_applied()
             ):
                 return


### PR DESCRIPTION
### Fixes: #326 

Improves the check in init for if running in a migration, now checks that all migrations for custom objects have been run.  This also makes the `_check_custom_object_type_table_exists` routine superfluous so can be removed.