### PR TITLE
Fixes: #230 - Disable the "unique" option on multi-object fields

### DIFF
--- a/netbox_custom_objects/forms.py
+++ b/netbox_custom_objects/forms.py
@@ -182,6 +182,10 @@ class CustomObjectTypeFieldForm(CustomFieldForm):
             if "related_object_type" in self.fields:
                 self.fields["related_object_type"].disabled = True
 
+        # Multi-object fields may not be set unique
+        if self.initial["type"] == CustomFieldTypeChoices.TYPE_MULTIOBJECT:
+            self.fields["unique"].disabled = True
+
     def clean_primary(self):
         primary_fields = self.cleaned_data["custom_object_type"].fields.filter(
             primary=True


### PR DESCRIPTION
### Fixes: #230

Because M2M fields cannot be set "unique" in Django (and we suppress the error condition that arises if a Custom Object Type Field is set accordingly), we disable the option if the field type is multi-object.
