### PR TITLE
#336 add test support for NetBox v4.5

### DIFF
--- a/netbox_custom_objects/__init__.py
+++ b/netbox_custom_objects/__init__.py
@@ -20,6 +20,7 @@ class CustomObjectsPluginConfig(PluginConfig):
     author_email = 'support@netboxlabs.com'
     base_url = "custom-objects"
     min_version = "4.4.0"
+    max_version = "4.5.99"
     default_settings = {
         # The maximum number of Custom Object Types that may be created
         'max_custom_object_types': 50,

--- a/netbox_custom_objects/tests/test_api.py
+++ b/netbox_custom_objects/tests/test_api.py
@@ -11,6 +11,20 @@ from users.models import ObjectPermission, Token
 from virtualization.models import Cluster, ClusterType
 
 
+def create_token(user):
+    try:
+        # NetBox >= 4.5
+        from users.choices import TokenVersionChoices
+        token = Token(version=TokenVersionChoices.V1, user=user)
+        token.save()
+        return token.token
+    except ImportError:
+        # NetBox < 4.5
+        token = Token(user=user)
+        token.save()
+        return token.key
+
+
 class CustomObjectTest(CustomObjectsTestCase, APIViewTestCases.APIViewTestCase):
     model = None  # Will be set in setUpTestData
     brief_fields = ['created', 'display', 'id', 'last_updated', 'tags', 'test_field', 'url']
@@ -24,8 +38,8 @@ class CustomObjectTest(CustomObjectsTestCase, APIViewTestCases.APIViewTestCase):
         self.user = create_test_user('testuser')
 
         # Create token for API access
-        self.token = Token.objects.create(user=self.user)
-        self.header = {'HTTP_AUTHORIZATION': f'Token {self.token.key}'}
+        token_key = create_token(self.user)
+        self.header = {'HTTP_AUTHORIZATION': f'Token {token_key}'}
 
         # Ensure we have the model reference
         if self.model is None:


### PR DESCRIPTION
### Fixes: #336 

* Bump max_version from 4.4 to 4.5
* Adapt API tests to specify v1 for test tokens
