### PR TITLE
#338 remove global exception handler on _all_migrations_applied

### DIFF
--- a/netbox_custom_objects/__init__.py
+++ b/netbox_custom_objects/__init__.py
@@ -55,12 +55,12 @@ class CustomObjectsPluginConfig(PluginConfig):
                 "migrate",
                 APP_LABEL,
                 check=True,
-                dry_run=True,
                 interactive=False,
                 verbosity=0,
             )
             return True
-        except (CommandError, Exception):
+        except CommandError:
+            # CommandError is raised when there are unapplied migrations
             return False
 
     def ready(self):

--- a/netbox_custom_objects/__init__.py
+++ b/netbox_custom_objects/__init__.py
@@ -52,7 +52,7 @@ class CustomObjectsPluginConfig(PluginConfig):
         Determine if dynamic model creation should be skipped.
 
         Returns True if dynamic models should not be created/loaded due to:
-        - Currently running migrations 
+        - Currently running migrations
         - Running tests
         - Required migration not yet applied
 

--- a/netbox_custom_objects/__init__.py
+++ b/netbox_custom_objects/__init__.py
@@ -76,10 +76,10 @@ class CustomObjectsPluginConfig(PluginConfig):
                 "ignore", category=UserWarning, message=".*database.*"
             )
 
-            # Skip database calls if running during migration or if table doesn't exist
-            # or if not all migrations have been applied yet
+            # Skip database calls if running during migration or tests, or if not all migrations have been applied yet
             if (
                 self._is_running_migration()
+                or self._is_running_test()
                 or not self._all_migrations_applied()
             ):
                 super().ready()
@@ -148,10 +148,11 @@ class CustomObjectsPluginConfig(PluginConfig):
                 "ignore", category=UserWarning, message=".*database.*"
             )
 
-            # Skip custom object type model loading if running during migration
+            # Skip custom object type model loading if running during migration or tests,
             # or if not all migrations have been applied yet
             if (
                 self._is_running_migration()
+                or self._is_running_test()
                 or not self._all_migrations_applied()
             ):
                 return


### PR DESCRIPTION
### Fixes: #338 

Reworked the init logic.  The call_command to migration check has side-effects when running migrations and migration checks so had to be removed.

* combined the separate check functions into one routine
* instead of checking sys.argv for migration added migration signal handlers
* removed exception handlers around the transaction-atomics as the `_should_skip_dynamic_model_creation` will have already checked if in tests and bypassed this, so all exceptions should be raised.
* however, unfortunately need a check to make sure the last migration was run '0003_ensure_fk_constraints' any updates to the main model (that would cause a field does not exist error) when using custom object type would need the migration name replaced here in the future. 

Tested running:
* Tests
* migrations from empty DB
* migrations from in-tact DB
* create COT from restart
* restart and use COT
* Running migrations from run_command (see script below):
