### PR TITLE
342 update init to use migration graph instead of filename

### DIFF
--- a/netbox_custom_objects/__init__.py
+++ b/netbox_custom_objects/__init__.py
@@ -27,7 +27,6 @@ def _migration_finished(sender, **kwargs):
     """Signal handler for post_migrate - clears the migration flag and cache."""
     global _migrations_checked
     _is_migrating.set(False)
-    # Clear the cache after migrations run so we check again
     _migrations_checked = None
 
 

--- a/netbox_custom_objects/__init__.py
+++ b/netbox_custom_objects/__init__.py
@@ -6,7 +6,6 @@ from django.db import connection, transaction
 from django.db.migrations.loader import MigrationLoader
 from django.db.migrations.recorder import MigrationRecorder
 from django.db.models.signals import pre_migrate, post_migrate
-from django.db.utils import DatabaseError, OperationalError, ProgrammingError
 from netbox.plugins import PluginConfig
 
 from .constants import APP_LABEL as APP_LABEL


### PR DESCRIPTION
### Fixes: #342 

Refactored the check for the last migration, now using the migration graph.  Needed to add some caching to make sure init slowdown didn't occur and also recursion checking as migrations can call into get_models, which call into our check routine.