### PR TITLE
Fixes #230 - Raise ValidationError if trying to set unique=True on multiobject field

### DIFF
--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -1039,10 +1039,10 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
                 }
             )
 
-        # Uniqueness can not be enforced for boolean fields
-        if self.unique and self.type == CustomFieldTypeChoices.TYPE_BOOLEAN:
+        # Uniqueness can not be enforced for boolean or multiobject fields
+        if self.unique and self.type in [CustomFieldTypeChoices.TYPE_BOOLEAN, CustomFieldTypeChoices.TYPE_MULTIOBJECT]:
             raise ValidationError(
-                {"unique": _("Uniqueness cannot be enforced for boolean fields")}
+                {"unique": _("Uniqueness cannot be enforced for boolean or multiobject fields")}
             )
 
         # Check if uniqueness constraint can be applied when changing from non-unique to unique


### PR DESCRIPTION
## Related to #230

Further to disabling the form field for `unique` on a multiobject field, this PR also enforces this constraint during validation in the model-level `save` method. This prevents non-UI routes from setting that value improperly (as `unique=True` on an M2M field prevents Django from starting up).