### PR TITLE
Fixes: #291 - Add description tooltips on custom object fields in object detail views

### DIFF
--- a/netbox_custom_objects/templates/netbox_custom_objects/customobject.html
+++ b/netbox_custom_objects/templates/netbox_custom_objects/customobject.html
@@ -112,7 +112,16 @@
               {% with is_visible_in_ui=object|get_field_is_ui_visible:field %}
                 {% if field.is_single_value and is_visible_in_ui %}
                   <tr>
-                    <th scope="row">{{ field }}</th>
+                    <th scope="row">{{ field }}
+                      {% if field.description %}
+                        <i
+                          class="mdi mdi-information text-primary"
+                          data-bs-toggle="tooltip"
+                          data-bs-placement="right"
+                          title="{{ field.description|escape }}"
+                        ></i>
+                      {% endif %}
+                    </th>
                     <td>
                       {% with customfield=field value=object|get_field_value:field %}
                         {% include "builtins/customfield_value.html" %}


### PR DESCRIPTION
### Fixes: #291

If the `description` field on a Custom Object Type Field is populated, it is included via an "i" icon and hover tooltip on the Custom Object detail page, in the same manner as Custom Fields in core objects.

<img width="622" height="420" alt="Screenshot 2026-01-22 at 9 27 10 PM" src="https://github.com/user-attachments/assets/9a9da335-487f-430f-b412-dcf96df50fe1" />
