### PR TITLE
Fixes: #372 - Explicitly check whether queryset is None to avoid unnecessary evaluation

### DIFF
--- a/netbox_custom_objects/views.py
+++ b/netbox_custom_objects/views.py
@@ -342,7 +342,7 @@ class CustomObjectListView(CustomObjectTableMixin, generic.ObjectListView):
         self.filterset_form = self.get_filterset_form()
 
     def get_queryset(self, request):
-        if self.queryset:
+        if self.queryset is not None:
             return self.queryset
         custom_object_type = self.kwargs.get("custom_object_type", None)
         self.custom_object_type = get_object_or_404(


### PR DESCRIPTION
### Fixes: #372 

`if self.queryset:` triggers an evaluation of the entire unfiltered queryset. Changing to an explicit comparison against `None` will greatly improve performance on list views of large datasets.