### PR TITLE
Clear model cache for custom object types pointing to current COT when saving any field on target

### DIFF
--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -1714,6 +1714,10 @@ def clear_cache_on_field_save(sender, instance, **kwargs):
     """
     if instance.custom_object_type_id:
         CustomObjectType.clear_model_cache(instance.custom_object_type_id)
+    for pointing_field in CustomObjectTypeField.objects.filter(
+        related_object_type=instance.custom_object_type.object_type
+    ):
+        CustomObjectType.clear_model_cache(pointing_field.custom_object_type_id)
 
 
 @receiver(pre_delete, sender=CustomObjectTypeField)


### PR DESCRIPTION
### Fixes: #348

When saving a Custom Object Type Field, we clear the model cache for the current COTF's CustomObjectType. However, other COTs which have object or multiobject fields pointing to the current COTF's COT have the old COT object cached.

With this fix, when saving a COTF, we also clear the model cache for any COT which has fields pointing to the currently-being-saved COTF's COT, ensuring that all COTs are aware of the most current version of the COT being modified.