### PR TITLE
Fixes: #382 - Force cache refresh when getting the model for "Related Objects" display

### DIFF
--- a/netbox_custom_objects/template_content.py
+++ b/netbox_custom_objects/template_content.py
@@ -47,7 +47,7 @@ class CustomObjectLink(PluginTemplateExtension):
         linked_custom_objects = []
 
         for field in custom_object_type_fields:
-            model = field.custom_object_type.get_model()
+            model = field.custom_object_type.get_model(no_cache=True)
 
             if field.type == CustomFieldTypeChoices.TYPE_MULTIOBJECT:
                 # Get the M2M field from the model


### PR DESCRIPTION
### Fixes: #382

Forces cache refresh on the `left_page` method of `template_content.py` which renders the "Custom objects linking to this object" table on a related object.

This should fix a persistent crash arising from multi-worker environments, at least in certain workflows. There may be other remaining areas where a similar fix is necessary.