### PR TITLE
Pin selected effective ruff rules to match NetBox core

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -2,6 +2,10 @@ line-length = 120
 target-version = "py310"
 
 [lint]
+# Pin the effective default rule set used with `preview = true` to match Ruff 0.15.1.
+# Ruff 0.15.2 changed the preview defaults, see https://github.com/astral-sh/ruff/releases/tag/0.15.2
+# Keeping this explicit makes ruff deterministic.
+select = ["E4", "E7", "E9", "F"]
 extend-select = ["E1", "E2", "E3", "E501", "W"]
 ignore = ["F403", "F405"]
 preview = true


### PR DESCRIPTION
Pins ruff effective rules to match NetBox core.