### PR TITLE
Fixes: #407 - Enforce object permissions on menu navigation

### DIFF
--- a/netbox_custom_objects/navigation.py
+++ b/netbox_custom_objects/navigation.py
@@ -20,6 +20,7 @@ custom_object_type_plugin_menu_item = PluginMenuItem(
         ),
     ),
     auth_required=True,
+    permissions=['netbox_custom_objects.view_customobjecttype'],
 )
 
 
@@ -60,6 +61,7 @@ class CustomObjectTypeMenuItems:
                 link_text=_(title(model._meta.verbose_name_plural)),
                 buttons=(add_button, bulk_import_button),
                 auth_required=True,
+                permissions=[f'netbox_custom_objects.view_{model._meta.model_name}'],
             )
             menu_item.url = reverse_lazy(
                 f"plugins:{APP_LABEL}:customobject_list",


### PR DESCRIPTION
### Fixes: #407 

Adds `permissions` parameters to the `PluginMenuItem`s that define how the custom objects and COTs appear in the nav menu.

For COTs, the permission is `netbox_custom_objects.view_customobjecttype`; for custom objects, the permission name is derived from the synthetic internal table name (i.e. `netbox_custom_objects.view_table1model`). Because permissions are assigned through the UI via human-readable pickers and the "pretty" custom object type name is used (i.e. "Cat"), this does not confront the user with the internal table name for the permission.
