### PR TITLE
Fixes: #417 - Implement full filtering for object and multiobject fields

### DIFF
--- a/netbox_custom_objects/field_types.py
+++ b/netbox_custom_objects/field_types.py
@@ -491,7 +491,20 @@ class ObjectFieldType(FieldType):
             )
 
     def get_filterform_field(self, field, **kwargs):
-        return None
+        content_type = ContentType.objects.get(pk=field.related_object_type_id)
+        if content_type.app_label == APP_LABEL:
+            from netbox_custom_objects.models import CustomObjectType
+            custom_object_type_id = content_type.model.replace("table", "").replace("model", "")
+            custom_object_type = CustomObjectType.objects.get(pk=custom_object_type_id)
+            model = custom_object_type.get_model()
+        else:
+            model = content_type.model_class()
+        return DynamicModelChoiceField(
+            queryset=model.objects.all(),
+            required=False,
+            label=field,
+            selector=model._meta.app_label != APP_LABEL,
+        )
 
     def render_table_column(self, value):
         return linkify(value)
@@ -799,7 +812,20 @@ class MultiObjectFieldType(FieldType):
             )
 
     def get_filterform_field(self, field, **kwargs):
-        return None
+        content_type = ContentType.objects.get(pk=field.related_object_type_id)
+        if content_type.app_label == APP_LABEL:
+            from netbox_custom_objects.models import CustomObjectType
+            custom_object_type_id = content_type.model.replace("table", "").replace("model", "")
+            custom_object_type = CustomObjectType.objects.get(pk=custom_object_type_id)
+            model = custom_object_type.get_model()
+        else:
+            model = content_type.model_class()
+        return DynamicModelMultipleChoiceField(
+            queryset=model.objects.all(),
+            required=False,
+            label=field,
+            selector=model._meta.app_label != APP_LABEL,
+        )
 
     def get_display_value(self, instance, field_name):
         field = getattr(instance, field_name)

--- a/netbox_custom_objects/filtersets.py
+++ b/netbox_custom_objects/filtersets.py
@@ -74,6 +74,35 @@ def get_filterset_class(model):
         "search": search,
     }
 
+    # Add filters for M2M (multiobject) fields, which are not in model._meta.fields.
+    # By the time get_filterset_class() is called (at request time), after_model_generation()
+    # will have already resolved m2m_field.remote_field.model and .through to actual model
+    # classes. Calling this during app startup (before model generation) would fail.
+    for m2m_field in model._meta.many_to_many:
+        field_name = m2m_field.name
+        through_model = m2m_field.remote_field.through
+        related_model = m2m_field.remote_field.model
+
+        def make_m2m_filter(through, fname):
+            def filter_m2m(self, queryset, name, value):
+                if not value:
+                    return queryset
+                ids = [v.pk for v in value]
+                source_ids = through.objects.filter(
+                    target_id__in=ids
+                ).values_list("source_id", flat=True)
+                return queryset.filter(pk__in=source_ids)
+            filter_m2m.__name__ = f"filter_{fname}"
+            return filter_m2m
+
+        method_name = f"filter_{field_name}"
+        attrs[method_name] = make_m2m_filter(through_model, field_name)
+        attrs[field_name] = django_filters.ModelMultipleChoiceFilter(
+            queryset=related_model.objects.all(),
+            method=method_name,
+            label=field_name,
+        )
+
     return type(
         f"{model._meta.object_name}FilterSet",
         (NetBoxModelFilterSet,),

--- a/netbox_custom_objects/tests/test_filtersets.py
+++ b/netbox_custom_objects/tests/test_filtersets.py
@@ -1,0 +1,399 @@
+from django.test import TestCase
+
+from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site
+
+from netbox_custom_objects.field_types import MultiObjectFieldType, ObjectFieldType
+from netbox_custom_objects.filtersets import get_filterset_class
+from netbox_custom_objects.models import CustomObjectTypeField
+from utilities.forms.fields import (
+    DynamicModelChoiceField,
+    DynamicModelMultipleChoiceField,
+)
+
+from .base import CustomObjectsTestCase
+
+
+def _make_device_fixtures(suffix):
+    """Create minimal DCIM fixtures needed to instantiate a Device."""
+    site = Site.objects.create(name=f"Site {suffix}", slug=f"site-{suffix}")
+    mfr = Manufacturer.objects.create(name=f"Mfr {suffix}", slug=f"mfr-{suffix}")
+    dt = DeviceType.objects.create(
+        manufacturer=mfr, model=f"DT {suffix}", slug=f"dt-{suffix}"
+    )
+    role = DeviceRole.objects.create(
+        name=f"Role {suffix}", slug=f"role-{suffix}", color="ff0000"
+    )
+    return site, dt, role
+
+
+# ---------------------------------------------------------------------------
+# ObjectFieldType.get_filterform_field — form field shape
+# ---------------------------------------------------------------------------
+
+
+class ObjectFieldFilterFormFieldTestCase(CustomObjectsTestCase, TestCase):
+    """get_filterform_field() for an object field returns a DynamicModelChoiceField."""
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.cot = cls.create_custom_object_type(name="ObjFFTest", slug="obj-ff-test")
+        cls.create_custom_object_type_field(
+            cls.cot, name="name", label="Name", type="text", primary=True, required=True
+        )
+        cls.field = cls.create_custom_object_type_field(
+            cls.cot,
+            name="device",
+            label="Device",
+            type="object",
+            related_object_type=cls.get_device_object_type(),
+        )
+
+    def test_returns_dynamic_model_choice_field(self):
+        form_field = ObjectFieldType().get_filterform_field(self.field)
+        self.assertIsInstance(form_field, DynamicModelChoiceField)
+
+    def test_form_field_not_required(self):
+        form_field = ObjectFieldType().get_filterform_field(self.field)
+        self.assertFalse(form_field.required)
+
+    def test_form_field_queryset_uses_related_model(self):
+        form_field = ObjectFieldType().get_filterform_field(self.field)
+        self.assertEqual(form_field.queryset.model, Device)
+
+
+# ---------------------------------------------------------------------------
+# ObjectFieldType — filterset queryset filtering (DCIM target)
+# ---------------------------------------------------------------------------
+
+
+class ObjectFieldFiltersetTestCase(CustomObjectsTestCase, TestCase):
+    """Filtering by ?<field>=<pk> works for object fields pointing at DCIM models."""
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.cot = cls.create_custom_object_type(name="ObjFSTest", slug="obj-fs-test")
+        cls.create_custom_object_type_field(
+            cls.cot, name="name", label="Name", type="text", primary=True, required=True
+        )
+        cls.create_custom_object_type_field(
+            cls.cot,
+            name="device",
+            label="Device",
+            type="object",
+            related_object_type=cls.get_device_object_type(),
+        )
+
+        site, dt, role = _make_device_fixtures("ofst")
+        cls.device1 = Device.objects.create(
+            name="Device OFS 1", site=site, device_type=dt, role=role
+        )
+        cls.device2 = Device.objects.create(
+            name="Device OFS 2", site=site, device_type=dt, role=role
+        )
+
+        model = cls.cot.get_model()
+        cls.obj_d1 = model.objects.create(name="Obj D1", device=cls.device1)
+        cls.obj_d2 = model.objects.create(name="Obj D2", device=cls.device2)
+        cls.obj_none = model.objects.create(name="Obj None")
+
+    def _filterset(self, params):
+        model = self.cot.get_model()
+        return get_filterset_class(model)(params, model.objects.all())
+
+    def test_filter_returns_matching_object(self):
+        pks = list(self._filterset({"device": self.device1.pk}).qs.values_list("pk", flat=True))
+        self.assertIn(self.obj_d1.pk, pks)
+        self.assertNotIn(self.obj_d2.pk, pks)
+        self.assertNotIn(self.obj_none.pk, pks)
+
+    def test_filter_different_value(self):
+        pks = list(self._filterset({"device": self.device2.pk}).qs.values_list("pk", flat=True))
+        self.assertIn(self.obj_d2.pk, pks)
+        self.assertNotIn(self.obj_d1.pk, pks)
+
+    def test_no_filter_returns_all(self):
+        self.assertEqual(self._filterset({}).qs.count(), 3)
+
+
+# ---------------------------------------------------------------------------
+# MultiObjectFieldType.get_filterform_field — form field shape
+# ---------------------------------------------------------------------------
+
+
+class MultiObjectFieldFilterFormFieldTestCase(CustomObjectsTestCase, TestCase):
+    """get_filterform_field() for a multiobject field returns a DynamicModelMultipleChoiceField."""
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.cot = cls.create_custom_object_type(name="MoFFTest", slug="mo-ff-test")
+        cls.create_custom_object_type_field(
+            cls.cot, name="name", label="Name", type="text", primary=True, required=True
+        )
+        cls.field = cls.create_custom_object_type_field(
+            cls.cot,
+            name="sites",
+            label="Sites",
+            type="multiobject",
+            related_object_type=cls.get_site_object_type(),
+        )
+
+    def test_returns_dynamic_model_multiple_choice_field(self):
+        form_field = MultiObjectFieldType().get_filterform_field(self.field)
+        self.assertIsInstance(form_field, DynamicModelMultipleChoiceField)
+
+    def test_form_field_not_required(self):
+        form_field = MultiObjectFieldType().get_filterform_field(self.field)
+        self.assertFalse(form_field.required)
+
+    def test_form_field_queryset_uses_related_model(self):
+        form_field = MultiObjectFieldType().get_filterform_field(self.field)
+        self.assertEqual(form_field.queryset.model, Site)
+
+
+# ---------------------------------------------------------------------------
+# MultiObjectFieldType — filterset queryset filtering (DCIM target)
+# ---------------------------------------------------------------------------
+
+
+class MultiObjectFieldFiltersetTestCase(CustomObjectsTestCase, TestCase):
+    """Filtering by ?<field>=<pk> works for multiobject fields pointing at DCIM models."""
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.cot = cls.create_custom_object_type(name="MoFSTest", slug="mo-fs-test")
+        cls.create_custom_object_type_field(
+            cls.cot, name="name", label="Name", type="text", primary=True, required=True
+        )
+        cls.create_custom_object_type_field(
+            cls.cot,
+            name="sites",
+            label="Sites",
+            type="multiobject",
+            related_object_type=cls.get_site_object_type(),
+        )
+
+        cls.site1 = Site.objects.create(name="Site MOFS 1", slug="site-mofs-1")
+        cls.site2 = Site.objects.create(name="Site MOFS 2", slug="site-mofs-2")
+
+        model = cls.cot.get_model()
+        cls.obj_s1 = model.objects.create(name="Obj S1")
+        cls.obj_s1.sites.add(cls.site1)
+        cls.obj_s2 = model.objects.create(name="Obj S2")
+        cls.obj_s2.sites.add(cls.site2)
+        cls.obj_both = model.objects.create(name="Obj Both")
+        cls.obj_both.sites.add(cls.site1, cls.site2)
+        cls.obj_none = model.objects.create(name="Obj None")
+
+    def _filterset(self, params):
+        model = self.cot.get_model()
+        return get_filterset_class(model)(params, model.objects.all())
+
+    def test_filter_single_site_returns_linked_objects(self):
+        pks = list(self._filterset({"sites": [self.site1.pk]}).qs.values_list("pk", flat=True))
+        self.assertIn(self.obj_s1.pk, pks)
+        self.assertIn(self.obj_both.pk, pks)
+        self.assertNotIn(self.obj_s2.pk, pks)
+        self.assertNotIn(self.obj_none.pk, pks)
+
+    def test_filter_multiple_sites_returns_union(self):
+        # OR semantics: any object linked to site1 or site2
+        pks = list(
+            self._filterset({"sites": [self.site1.pk, self.site2.pk]}).qs.values_list("pk", flat=True)
+        )
+        self.assertIn(self.obj_s1.pk, pks)
+        self.assertIn(self.obj_s2.pk, pks)
+        self.assertIn(self.obj_both.pk, pks)
+        self.assertNotIn(self.obj_none.pk, pks)
+
+    def test_filter_multiple_sites_no_duplicates(self):
+        # obj_both is linked to both sites but should appear only once
+        qs = self._filterset({"sites": [self.site1.pk, self.site2.pk]}).qs
+        obj_both_count = qs.filter(pk=self.obj_both.pk).count()
+        self.assertEqual(obj_both_count, 1)
+
+    def test_filter_other_site(self):
+        pks = list(self._filterset({"sites": [self.site2.pk]}).qs.values_list("pk", flat=True))
+        self.assertIn(self.obj_s2.pk, pks)
+        self.assertIn(self.obj_both.pk, pks)
+        self.assertNotIn(self.obj_s1.pk, pks)
+
+    def test_no_filter_returns_all(self):
+        self.assertEqual(self._filterset({}).qs.count(), 4)
+
+
+# ---------------------------------------------------------------------------
+# Object field with a custom object type as target
+# ---------------------------------------------------------------------------
+
+
+class CustomObjectTargetObjectFieldTestCase(CustomObjectsTestCase, TestCase):
+    """Object field pointing at another custom object type: form field and filtering."""
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        # Target COT
+        cls.target_cot = cls.create_custom_object_type(
+            name="TargetObj", slug="target-obj"
+        )
+        cls.create_custom_object_type_field(
+            cls.target_cot, name="name", label="Name", type="text", primary=True, required=True
+        )
+
+        # Source COT with object field → target COT
+        cls.source_cot = cls.create_custom_object_type(
+            name="SourceObj", slug="source-obj"
+        )
+        cls.create_custom_object_type_field(
+            cls.source_cot, name="name", label="Name", type="text", primary=True, required=True
+        )
+        cls.create_custom_object_type_field(
+            cls.source_cot,
+            name="related",
+            label="Related",
+            type="object",
+            related_object_type=cls.target_cot.object_type,
+        )
+
+        target_model = cls.target_cot.get_model()
+        cls.target1 = target_model.objects.create(name="Target 1")
+        cls.target2 = target_model.objects.create(name="Target 2")
+
+        source_model = cls.source_cot.get_model()
+        cls.source_t1 = source_model.objects.create(name="Source T1", related=cls.target1)
+        cls.source_t2 = source_model.objects.create(name="Source T2", related=cls.target2)
+        cls.source_none = source_model.objects.create(name="Source None")
+
+    def _field(self):
+        return CustomObjectTypeField.objects.get(
+            custom_object_type=self.source_cot, name="related"
+        )
+
+    def test_filterform_field_returns_dynamic_model_choice_field(self):
+        form_field = ObjectFieldType().get_filterform_field(self._field())
+        self.assertIsInstance(form_field, DynamicModelChoiceField)
+
+    def test_filterform_field_queryset_points_at_target_model(self):
+        form_field = ObjectFieldType().get_filterform_field(self._field())
+        target_model = self.target_cot.get_model()
+        self.assertEqual(
+            form_field.queryset.model._meta.db_table,
+            target_model._meta.db_table,
+        )
+
+    def test_filter_by_custom_object_target(self):
+        source_model = self.source_cot.get_model()
+        fs = get_filterset_class(source_model)(
+            {"related": self.target1.pk}, source_model.objects.all()
+        )
+        pks = list(fs.qs.values_list("pk", flat=True))
+        self.assertIn(self.source_t1.pk, pks)
+        self.assertNotIn(self.source_t2.pk, pks)
+        self.assertNotIn(self.source_none.pk, pks)
+
+    def test_filter_other_target(self):
+        source_model = self.source_cot.get_model()
+        fs = get_filterset_class(source_model)(
+            {"related": self.target2.pk}, source_model.objects.all()
+        )
+        pks = list(fs.qs.values_list("pk", flat=True))
+        self.assertIn(self.source_t2.pk, pks)
+        self.assertNotIn(self.source_t1.pk, pks)
+
+
+# ---------------------------------------------------------------------------
+# Multiobject field with a custom object type as target
+# ---------------------------------------------------------------------------
+
+
+class CustomObjectTargetMultiObjectFieldTestCase(CustomObjectsTestCase, TestCase):
+    """Multiobject field pointing at another custom object type: form field and filtering."""
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        # Target COT
+        cls.target_cot = cls.create_custom_object_type(
+            name="TargetMObj", slug="target-mobj"
+        )
+        cls.create_custom_object_type_field(
+            cls.target_cot, name="name", label="Name", type="text", primary=True, required=True
+        )
+
+        # Source COT with multiobject field → target COT
+        cls.source_cot = cls.create_custom_object_type(
+            name="SourceMObj", slug="source-mobj"
+        )
+        cls.create_custom_object_type_field(
+            cls.source_cot, name="name", label="Name", type="text", primary=True, required=True
+        )
+        cls.create_custom_object_type_field(
+            cls.source_cot,
+            name="related_items",
+            label="Related Items",
+            type="multiobject",
+            related_object_type=cls.target_cot.object_type,
+        )
+
+        target_model = cls.target_cot.get_model()
+        cls.target1 = target_model.objects.create(name="Target M1")
+        cls.target2 = target_model.objects.create(name="Target M2")
+
+        source_model = cls.source_cot.get_model()
+        cls.source_t1 = source_model.objects.create(name="Source MT1")
+        cls.source_t1.related_items.add(cls.target1)
+        cls.source_t2 = source_model.objects.create(name="Source MT2")
+        cls.source_t2.related_items.add(cls.target2)
+        cls.source_both = source_model.objects.create(name="Source MBoth")
+        cls.source_both.related_items.add(cls.target1, cls.target2)
+        cls.source_none = source_model.objects.create(name="Source MNone")
+
+    def _field(self):
+        return CustomObjectTypeField.objects.get(
+            custom_object_type=self.source_cot, name="related_items"
+        )
+
+    def test_filterform_field_returns_dynamic_model_multiple_choice_field(self):
+        form_field = MultiObjectFieldType().get_filterform_field(self._field())
+        self.assertIsInstance(form_field, DynamicModelMultipleChoiceField)
+
+    def test_filterform_field_queryset_points_at_target_model(self):
+        form_field = MultiObjectFieldType().get_filterform_field(self._field())
+        target_model = self.target_cot.get_model()
+        self.assertEqual(
+            form_field.queryset.model._meta.db_table,
+            target_model._meta.db_table,
+        )
+
+    def test_filter_single_target(self):
+        source_model = self.source_cot.get_model()
+        fs = get_filterset_class(source_model)(
+            {"related_items": [self.target1.pk]}, source_model.objects.all()
+        )
+        pks = list(fs.qs.values_list("pk", flat=True))
+        self.assertIn(self.source_t1.pk, pks)
+        self.assertIn(self.source_both.pk, pks)
+        self.assertNotIn(self.source_t2.pk, pks)
+        self.assertNotIn(self.source_none.pk, pks)
+
+    def test_filter_multiple_targets_returns_union(self):
+        source_model = self.source_cot.get_model()
+        fs = get_filterset_class(source_model)(
+            {"related_items": [self.target1.pk, self.target2.pk]}, source_model.objects.all()
+        )
+        pks = list(fs.qs.values_list("pk", flat=True))
+        self.assertIn(self.source_t1.pk, pks)
+        self.assertIn(self.source_t2.pk, pks)
+        self.assertIn(self.source_both.pk, pks)
+        self.assertNotIn(self.source_none.pk, pks)
+
+    def test_filter_multiple_targets_no_duplicates(self):
+        source_model = self.source_cot.get_model()
+        qs = get_filterset_class(source_model)(
+            {"related_items": [self.target1.pk, self.target2.pk]}, source_model.objects.all()
+        ).qs
+        self.assertEqual(qs.filter(pk=self.source_both.pk).count(), 1)


### PR DESCRIPTION
### Fixes: #417 

This PR fully implements the `get_filterform_field` methods for `ObjectFieldType` and `MultiObjectFieldType`, as well as adding proper handling for M2M (multiobject) filtering in `filtersets.py`.

  This means:
  - `?device=27` (object) — already worked at the DB level; now also shows a UI field in the filter form
  - `?sites=22` (multiobject) — now works via the through-table filter method, and also shows a multi-select UI field

Also adds a `test_filtersets.py` file to test filter functionality against a variety of field types and target objects.
