### PR TITLE
Fixes: #429 - Unregister model from app registry after COT deletion to prevent querying stale database state

### DIFF
--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -739,9 +739,12 @@ class CustomObjectType(NetBoxModel):
 
         # Clear Django's internal relation/field caches so the removed model is no
         # longer discovered during cascade-delete collector traversal.
-        apps.get_models.cache_clear()
         apps.clear_cache()
 
+        # Re-clear the model cache to remove re-cached model from get_model.
+        self.clear_model_cache(self.id)
+
+        # Reconnect the pre_delete handler after all cleanup is done.
         pre_delete.connect(handle_deleted_object)
 
 

--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -720,6 +720,28 @@ class CustomObjectType(NetBoxModel):
         object_type.delete()
         with connection.schema_editor() as schema_editor:
             schema_editor.delete_model(model)
+
+        # Unregister the model and its through-models from Django's app registry so
+        # that subsequent ORM operations (e.g. deleting a related device) do not try
+        # to query the now-dropped table and receive a
+        # "relation 'custom_objects_<id>' does not exist" error.
+        # Use _global_lock to prevent a concurrent get_model() call from racing
+        # against this de-registration and re-adding the model mid-cleanup.
+        with self._global_lock:
+            model_name = model.__name__.lower()
+            if model_name in apps.all_models.get(APP_LABEL, {}):
+                del apps.all_models[APP_LABEL][model_name]
+
+            for through_model in getattr(model, '_through_models', []):
+                through_name = through_model.__name__.lower()
+                if through_name in apps.all_models.get(APP_LABEL, {}):
+                    del apps.all_models[APP_LABEL][through_name]
+
+        # Clear Django's internal relation/field caches so the removed model is no
+        # longer discovered during cascade-delete collector traversal.
+        apps.get_models.cache_clear()
+        apps.clear_cache()
+
         pre_delete.connect(handle_deleted_object)
 
 

--- a/netbox_custom_objects/tests/test_models.py
+++ b/netbox_custom_objects/tests/test_models.py
@@ -174,6 +174,95 @@ class CustomObjectTypeTestCase(CustomObjectsTestCase, TestCase):
             tables = connection.introspection.table_names(cursor)
             self.assertNotIn(table_name, tables)
 
+    def test_delete_unregisters_model_from_app_registry(self):
+        """
+        Regression test for: deleting a Custom Object then its Custom Object Type
+        leaves the dynamically-generated model in Django's app registry.  When a
+        related model (e.g. dcim.Device) is subsequently deleted, Django's ORM
+        Collector discovers the stale model class, tries to query the dropped table
+        and raises "relation '<table>' does not exist".
+        """
+        from django.apps import apps as django_apps
+        from netbox_custom_objects.constants import APP_LABEL
+
+        custom_object_type = self.create_custom_object_type(
+            name="RegTestObject", slug="reg-test-object"
+        )
+        self.create_custom_object_type_field(
+            custom_object_type,
+            name="name",
+            label="Name",
+            type="text",
+            primary=True,
+            required=True,
+        )
+        model = custom_object_type.get_model()
+        model_name = model.__name__.lower()
+
+        # Confirm the model is registered before deletion
+        self.assertIn(model_name, django_apps.all_models.get(APP_LABEL, {}))
+
+        custom_object_type.delete()
+
+        # After deletion the model must be removed from the app registry so that
+        # Django's cascade-delete collector no longer tries to query the dropped table.
+        self.assertNotIn(model_name, django_apps.all_models.get(APP_LABEL, {}))
+
+    def test_stale_registry_entry_causes_relation_error_on_related_object_delete(self):
+        """
+        Demonstrates the failure mode for issue #429.
+
+        Re-registers the stale model class after deletion (simulating the pre-fix
+        state) and confirms that deleting a related NetBox object then raises
+        ProgrammingError('relation "custom_objects_<id>" does not exist').
+
+        The test uses a savepoint so the aborted PostgreSQL transaction does not
+        poison the surrounding test transaction.
+        """
+        from django.apps import apps as django_apps
+        from django.db import ProgrammingError, transaction
+        from dcim.models import Site
+        from netbox_custom_objects.constants import APP_LABEL
+
+        site = Site.objects.create(name='Stale Registry Test Site', slug='stale-registry-test-site')
+
+        cot = self.create_custom_object_type(name='SiteLinked', slug='site-linked')
+        self.create_custom_object_type_field(
+            cot,
+            name='linked_site',
+            label='Linked Site',
+            type='object',
+            related_object_type=self.get_site_object_type(),
+        )
+
+        stale_model = cot.get_model()
+        stale_model_name = stale_model.__name__.lower()
+
+        # Delete the COT; the fix removes the model from apps.all_models.
+        cot.delete()
+        self.assertNotIn(stale_model_name, django_apps.all_models.get(APP_LABEL, {}))
+
+        # Simulate pre-fix state: put the stale model back in the registry and
+        # force Django to rebuild its relation trees from the now-stale registry.
+        django_apps.all_models[APP_LABEL][stale_model_name] = stale_model
+        django_apps.clear_cache()
+
+        try:
+            # Deleting the site now triggers Django's cascade-delete Collector,
+            # which finds the stale FK, queries the dropped table, and fails.
+            sid = transaction.savepoint()
+            try:
+                site.delete()
+                transaction.savepoint_commit(sid)
+                self.fail('Expected ProgrammingError was not raised — the bug is not being reproduced')
+            except ProgrammingError as exc:
+                transaction.savepoint_rollback(sid)
+                self.assertIn('does not exist', str(exc))
+        finally:
+            # Restore clean registry state so subsequent tests are unaffected.
+            django_apps.all_models[APP_LABEL].pop(stale_model_name, None)
+            django_apps.clear_cache()
+
 
 class CustomObjectTypeFieldTestCase(CustomObjectsTestCase, TestCase):
     """Test cases for CustomObjectTypeField model."""


### PR DESCRIPTION
### Fixes: #429

Addresses a condition where deleting a Custom Object (with a FK to a core object) and then deleting its Custom Object Type in quick succession triggers a PostgreSQL error due to the Django `app_registry` being in a stale state. This PR actively unregisters the synthetic model from the registry after COT deletion but prior to signal reconnection.

Also includes two unit tests, one which demonstrates the original behavior (through simulating the pre-fix registry state) and one which verifies clean operation. This demonstration test case is necessary since the error is difficult to reproduce in single-worker, non-cloud deployments.
