### PR TITLE
[WIP] Related object tabs — PoC for discussion

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,26 @@ PLUGINS_CONFIG = {
 }
 ```
 
+## Related Object Tabs
+
+When a Custom Object Type has fields referencing other NetBox objects (e.g., a "Firewall Rules" type with a Device field), a **Combined "Custom Objects" tab** automatically appears on the detail pages of those referenced objects, showing all linked custom objects.
+
+You can also enable **dedicated typed tabs** for specific Custom Object Types by adding their slugs to `PLUGINS_CONFIG`:
+
+```python
+PLUGINS_CONFIG = {
+    'netbox_custom_objects': {
+        'typed_tab_slugs': [
+            'firewall-rules',
+            'security-audits',
+        ],
+    },
+}
+```
+
+> [!NOTE]
+> After adding or removing slugs from `typed_tab_slugs`, a NetBox restart is required for the changes to take effect. The combined tab is always active and requires no configuration.
+
 ## Known Limitations
 
 NetBox Custom Objects is now Generally Available which means you can use it in production and migrations to future versions will work. There are many upcoming features including GraphQL support - the best place to see what's on the way is the [issues](https://github.com/netboxlabs/netbox-custom-objects/issues) list on the GitHub repository.

--- a/netbox_custom_objects/__init__.py
+++ b/netbox_custom_objects/__init__.py
@@ -81,6 +81,10 @@ class CustomObjectsPluginConfig(PluginConfig):
     default_settings = {
         # The maximum number of Custom Object Types that may be created
         'max_custom_object_types': 50,
+        # List of COT slugs that get dedicated typed tabs on related object detail pages.
+        # Requires server restart after changes.
+        # Example: ['firewall-rules', 'security-audits']
+        'typed_tab_slugs': [],
     }
     required_settings = []
     template_extensions = "template_content.template_extensions"
@@ -204,7 +208,18 @@ class CustomObjectsPluginConfig(PluginConfig):
                 super().ready()
                 return
 
+            # Register related-object tabs (combined + typed)
+            from .tab_views import register_all_tabs
+            register_all_tabs()
+
         super().ready()
+
+        # These must run AFTER super().ready() which registers journal/changelog views
+        # and triggers URL conf generation via register_models()
+        if not self.should_skip_dynamic_model_creation():
+            from .tab_views import inject_co_urls, deduplicate_registry
+            inject_co_urls()
+            deduplicate_registry()
 
     def get_model(self, model_name, require_ready=True):
         self.apps.check_apps_ready()

--- a/netbox_custom_objects/tab_views.py
+++ b/netbox_custom_objects/tab_views.py
@@ -1,0 +1,533 @@
+"""
+Related-object tab views for netbox-custom-objects.
+
+Two tab types:
+1. Combined "Custom Objects" tab — shows all linked custom objects in a simple table.
+2. Per-COT typed tabs — opt-in via show_tab=True, with type-specific columns, filters, bulk actions.
+
+CRITICAL: During registration, never call get_model() or apps.get_model() for dynamic CO models.
+Read from app_config.get_models() instead, as each get_model() cache miss re-registers
+journal/changelog views and can corrupt cross-reference models.
+See: CESNET/netbox-custom-objects-tab#3
+"""
+
+import logging
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any
+
+from django.apps import apps
+from django.contrib.contenttypes.models import ContentType
+from django.db.models import Q
+from django.db.utils import OperationalError, ProgrammingError
+from django.shortcuts import get_object_or_404, render
+from django.utils.translation import gettext_lazy as _
+from django.views.generic import View
+from extras.choices import CustomFieldTypeChoices, CustomFieldUIVisibleChoices
+from netbox.forms import NetBoxModelFilterSetForm
+from netbox.registry import registry
+from netbox.tables import BaseTable
+from utilities.forms.fields import TagFilterField
+from utilities.paginator import EnhancedPaginator, get_paginate_count
+from utilities.views import ViewTab, register_model_view
+
+import django_tables2 as tables2
+
+from netbox_custom_objects import field_types
+from netbox_custom_objects.constants import APP_LABEL
+from netbox_custom_objects.filtersets import get_filterset_class
+from netbox_custom_objects.models import CustomObjectTypeField
+from netbox_custom_objects.tables import CustomObjectTable
+
+logger = logging.getLogger('netbox_custom_objects')
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_CO_BASE_TEMPLATE = 'netbox_custom_objects/customobject.html'
+
+
+def _get_base_template(instance):
+    """Return the correct base_template for an object's detail page."""
+    if instance._meta.app_label == APP_LABEL:
+        return _CO_BASE_TEMPLATE
+    return f'{instance._meta.app_label}/{instance._meta.model_name}.html'
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+@dataclass
+class LinkedCustomObject:
+    custom_object: Any
+    field: CustomObjectTypeField
+
+
+def _iter_linked_fields(instance):
+    """Yield (field, model, filter_kwargs) for every CO field referencing *instance*."""
+    content_type = ContentType.objects.get_for_model(instance._meta.model)
+    fields = CustomObjectTypeField.objects.filter(
+        related_object_type=content_type,
+        type__in=[CustomFieldTypeChoices.TYPE_OBJECT, CustomFieldTypeChoices.TYPE_MULTIOBJECT],
+    ).select_related('custom_object_type')
+
+    for field in fields:
+        try:
+            model = field.custom_object_type.get_model()
+        except Exception:
+            logger.debug('could not get model for COT %s', field.custom_object_type_id)
+            continue
+
+        if field.type == CustomFieldTypeChoices.TYPE_OBJECT:
+            yield field, model, {f'{field.name}_id': instance.pk}
+        elif field.type == CustomFieldTypeChoices.TYPE_MULTIOBJECT:
+            yield field, model, {field.name: instance.pk}
+
+
+# ===========================================================================
+# Combined tab
+# ===========================================================================
+
+class CustomObjectsTabTable(BaseTable):
+    """Table class for column-preference machinery on the combined tab."""
+
+    type = tables2.Column(verbose_name=_('Type'), orderable=False)
+    object = tables2.Column(verbose_name=_('Object'), orderable=False)
+    value = tables2.Column(verbose_name=_('Value'), orderable=False)
+    field = tables2.Column(verbose_name=_('Field'), orderable=False)
+    tags = tables2.Column(verbose_name=_('Tags'), orderable=False)
+    actions = tables2.Column(verbose_name='', orderable=False)
+
+    exempt_columns = ('actions',)
+
+    class Meta(BaseTable.Meta):
+        fields = ('type', 'object', 'value', 'field', 'tags', 'actions')
+        default_columns = ('type', 'object', 'value', 'field', 'tags', 'actions')
+
+
+_MAX_MULTIOBJECT_DISPLAY = 3
+
+
+def _get_field_value(obj, field):
+    """Return the value stored in *field* on *obj*, for the Value column."""
+    if field.type == CustomFieldTypeChoices.TYPE_OBJECT:
+        return getattr(obj, field.name, None)
+    elif field.type == CustomFieldTypeChoices.TYPE_MULTIOBJECT:
+        qs = getattr(obj, field.name, None)
+        if qs is None:
+            return []
+        return list(qs.all()[:_MAX_MULTIOBJECT_DISPLAY + 1])
+    return None
+
+
+def _count_linked(instance):
+    """Badge callable. Returns None when 0 so hide_if_empty works."""
+    total = 0
+    for _field, model, fk in _iter_linked_fields(instance):
+        try:
+            total += model.objects.filter(**fk).count()
+        except Exception:
+            pass
+    return total or None
+
+
+def _get_linked_objects(instance):
+    """Return list of LinkedCustomObject for all COs referencing *instance*."""
+    results = []
+    for field, model, fk in _iter_linked_fields(instance):
+        try:
+            for obj in model.objects.filter(**fk):
+                results.append(LinkedCustomObject(custom_object=obj, field=field))
+        except Exception:
+            pass
+    return results
+
+
+def _make_combined_tab_view(model_class):
+    """Factory: returns a View subclass for the combined Custom Objects tab."""
+
+    class CombinedTabView(View):
+        tab = ViewTab(
+            label=_('Custom Objects'),
+            badge=_count_linked,
+            weight=2000,
+            hide_if_empty=True,
+        )
+
+        def get(self, request, pk, **kwargs):
+            actual_model = model_class
+            co_slug = kwargs.get('custom_object_type')
+            if co_slug and model_class._meta.app_label == APP_LABEL:
+                from netbox_custom_objects.models import CustomObjectType
+                cot = get_object_or_404(CustomObjectType, slug=co_slug)
+                actual_model = cot.get_model()
+
+            try:
+                instance = get_object_or_404(actual_model.objects.restrict(request.user, 'view'), pk=pk)
+            except AttributeError:
+                instance = get_object_or_404(actual_model, pk=pk)
+
+            linked_all = _get_linked_objects(instance)
+
+            # Quick search filter
+            q = request.GET.get('q', '').strip()
+            if q:
+                q_lower = q.lower()
+                linked_all = [
+                    lo for lo in linked_all
+                    if q_lower in str(lo.custom_object).lower()
+                    or q_lower in str(lo.field.custom_object_type).lower()
+                    or q_lower in str(lo.field).lower()
+                ]
+
+            # Build table object for column-preference machinery
+            tab_table = CustomObjectsTabTable([], empty_text='')
+            visible_cols = None
+            if request.user.is_authenticated and (userconfig := getattr(request.user, 'config', None)):
+                visible_cols = userconfig.get(f'tables.{tab_table.name}.columns')
+            if visible_cols is None:
+                visible_cols = list(CustomObjectsTabTable.Meta.default_columns)
+            tab_table._set_columns(visible_cols)
+            selected_columns = {col for col, _ in tab_table.selected_columns} | set(tab_table.exempt_columns)
+
+            # Pagination
+            paginator = EnhancedPaginator(linked_all, get_paginate_count(request))
+            try:
+                page = paginator.page(int(request.GET.get('page', 1)))
+            except Exception:
+                page = paginator.page(1)
+
+            # Resolve field values for current page only
+            page_rows = [
+                (lo.custom_object, lo.field, _get_field_value(lo.custom_object, lo.field))
+                for lo in page.object_list
+            ]
+
+            return render(request, 'netbox_custom_objects/tabs/combined_tab.html', {
+                'object': instance,
+                'tab': self.tab,
+                'base_template': _get_base_template(instance),
+                'page_obj': page,
+                'paginator': paginator,
+                'page_rows': page_rows,
+                'tab_table': tab_table,
+                'selected_columns': selected_columns,
+                'return_url': request.get_full_path(),
+                'q': q,
+            })
+
+    CombinedTabView.__name__ = f'{model_class.__name__}CombinedTabView'
+    CombinedTabView.__qualname__ = CombinedTabView.__name__
+    return CombinedTabView
+
+
+def _register_combined_tabs(model_classes):
+    """Register combined tab on each model."""
+    for model_class in model_classes:
+        app = model_class._meta.app_label
+        name = model_class._meta.model_name
+        if any(e['name'] == 'custom_objects' for e in registry['views'].get(app, {}).get(name, [])):
+            continue
+        register_model_view(model_class, name='custom_objects', path='custom-objects')(
+            _make_combined_tab_view(model_class)
+        )
+
+
+# ===========================================================================
+# Typed tabs
+# ===========================================================================
+
+def _build_typed_table_class(cot, dynamic_model):
+    """Build a django-tables2 table class for a COT."""
+    model_fields = cot.fields.all()
+    fields = ['id'] + [f.name for f in model_fields if f.ui_visible != CustomFieldUIVisibleChoices.HIDDEN]
+
+    meta = type('Meta', (), {
+        'model': dynamic_model,
+        'fields': fields,
+        'attrs': {'class': 'table table-hover object-list'},
+    })
+
+    attrs = {'Meta': meta, '__module__': 'database.tables'}
+
+    for field in model_fields:
+        if field.ui_visible == CustomFieldUIVisibleChoices.HIDDEN:
+            continue
+        ft = field_types.FIELD_TYPE_CLASS[field.type]()
+        try:
+            attrs[field.name] = ft.get_table_column_field(field)
+        except NotImplementedError:
+            pass
+        linkable = [CustomFieldTypeChoices.TYPE_TEXT, CustomFieldTypeChoices.TYPE_LONGTEXT]
+        if field.primary and field.type in linkable:
+            attrs[f'render_{field.name}'] = ft.render_table_column_linkified
+        else:
+            try:
+                attrs[f'render_{field.name}'] = ft.render_table_column
+            except AttributeError:
+                pass
+
+    return type(f'{dynamic_model._meta.object_name}Table', (CustomObjectTable,), attrs)
+
+
+def _build_filterset_form(cot, dynamic_model):
+    """Build a filterset form class for a COT."""
+    attrs = {
+        'model': dynamic_model,
+        '__module__': 'database.filterset_forms',
+        'tag': TagFilterField(dynamic_model),
+    }
+    for field in cot.fields.all():
+        ft = field_types.FIELD_TYPE_CLASS[field.type]()
+        try:
+            attrs[field.name] = ft.get_filterform_field(field)
+        except NotImplementedError:
+            pass
+    return type(f'{dynamic_model._meta.object_name}FilterForm', (NetBoxModelFilterSetForm,), attrs)
+
+
+def _count_for_type(cot, field_infos):
+    """Badge callable for one COT. Returns None when 0. Uses OR + distinct to avoid double-counting."""
+    cot_pk = cot.pk
+
+    def _badge(instance):
+        from netbox_custom_objects.models import CustomObjectType
+        try:
+            c = CustomObjectType.objects.get(pk=cot_pk)
+            model = c.get_model()
+        except Exception:
+            return None
+        q = Q()
+        for field_name, field_type in field_infos:
+            try:
+                if field_type == CustomFieldTypeChoices.TYPE_OBJECT:
+                    q |= Q(**{f'{field_name}_id': instance.pk})
+                elif field_type == CustomFieldTypeChoices.TYPE_MULTIOBJECT:
+                    q |= Q(**{field_name: instance.pk})
+            except Exception:
+                pass
+        if not q:
+            return None
+        total = model.objects.filter(q).distinct().count()
+        return total or None
+
+    return _badge
+
+
+def _make_typed_tab_view(model_class, cot, field_infos, weight):
+    """Factory: returns a View subclass for a per-COT typed tab."""
+    badge_fn = _count_for_type(cot, field_infos)
+    cot_pk = cot.pk
+    cot_label = str(cot)
+
+    class TypedTabView(View):
+        tab = ViewTab(label=cot_label, badge=badge_fn, weight=weight, hide_if_empty=True)
+
+        def get(self, request, pk, **kwargs):
+            try:
+                instance = get_object_or_404(model_class.objects.restrict(request.user, 'view'), pk=pk)
+            except AttributeError:
+                instance = get_object_or_404(model_class, pk=pk)
+
+            from netbox_custom_objects.models import CustomObjectType as COTModel
+            error_ctx = {
+                'object': instance, 'tab': self.tab,
+                'base_template': _get_base_template(instance),
+                'table': None, 'preferences': {'pagination.placement': 'bottom'},
+            }
+            try:
+                c = COTModel.objects.get(pk=cot_pk)
+                dynamic_model = c.get_model()
+            except Exception:
+                return render(request, 'netbox_custom_objects/tabs/typed_tab.html', error_ctx)
+
+            q = Q()
+            for fn, ft in field_infos:
+                if ft == CustomFieldTypeChoices.TYPE_OBJECT:
+                    q |= Q(**{f'{fn}_id': instance.pk})
+                elif ft == CustomFieldTypeChoices.TYPE_MULTIOBJECT:
+                    q |= Q(**{fn: instance.pk})
+
+            base_qs = dynamic_model.objects.filter(q).distinct()
+            filterset = get_filterset_class(dynamic_model)(request.GET, queryset=base_qs)
+            filter_form = _build_filterset_form(c, dynamic_model)(request.GET)
+
+            table = _build_typed_table_class(c, dynamic_model)(filterset.qs)
+            table.columns.show('pk')
+            table.htmx_url = request.path
+            table.embedded = False
+            table.configure(request)
+
+            if request.user.is_authenticated and (uc := getattr(request.user, 'config', None)):
+                prefs = {'pagination.placement': uc.get('pagination.placement', 'bottom')}
+            else:
+                prefs = {'pagination.placement': 'bottom'}
+
+            ctx = {
+                'object': instance, 'tab': self.tab,
+                'base_template': _get_base_template(instance),
+                'table': table, 'filter_form': filter_form,
+                'return_url': request.get_full_path(),
+                'custom_object_type': c, 'model': dynamic_model,
+                'preferences': prefs,
+            }
+            if request.htmx and not request.htmx.boosted:
+                return render(request, 'htmx/table.html', ctx)
+            return render(request, 'netbox_custom_objects/tabs/typed_tab.html', ctx)
+
+    TypedTabView.__name__ = f'{model_class.__name__}_{cot.slug}_TypedTabView'
+    TypedTabView.__qualname__ = TypedTabView.__name__
+    return TypedTabView
+
+
+def _register_typed_tabs(model_classes, weight=2100):
+    """Register per-type tabs for COTs listed in typed_tab_slugs plugin config."""
+    from netbox.plugins import get_plugin_config
+    typed_slugs = get_plugin_config('netbox_custom_objects', 'typed_tab_slugs') or []
+    if not typed_slugs:
+        return
+
+    try:
+        all_fields = CustomObjectTypeField.objects.filter(
+            type__in=[CustomFieldTypeChoices.TYPE_OBJECT, CustomFieldTypeChoices.TYPE_MULTIOBJECT],
+            custom_object_type__slug__in=typed_slugs,
+        ).select_related('custom_object_type')
+
+        ct_cot_fields = defaultdict(list)
+        ct_cot_map = {}
+        for f in all_fields:
+            if f.related_object_type_id is None:
+                continue
+            key = (f.related_object_type_id, f.custom_object_type_id)
+            ct_cot_fields[key].append((f.name, f.type))
+            ct_cot_map[key] = f.custom_object_type
+
+        model_ct_map = {}
+        for mc in model_classes:
+            ct = ContentType.objects.get_for_model(mc)
+            model_ct_map[ct.pk] = mc
+    except (OperationalError, ProgrammingError):
+        logger.warning('database unavailable — typed tabs not registered')
+        return
+
+    for (ct_id, cot_pk), field_infos in ct_cot_fields.items():
+        if ct_id not in model_ct_map:
+            continue
+        mc = model_ct_map[ct_id]
+        cot = ct_cot_map[(ct_id, cot_pk)]
+        slug = cot.slug
+        existing = registry['views'].get(mc._meta.app_label, {}).get(mc._meta.model_name, [])
+        if any(e['name'] == f'custom_objects_{slug}' for e in existing):
+            continue
+        register_model_view(mc, name=f'custom_objects_{slug}', path=f'custom-objects-{slug}')(
+            _make_typed_tab_view(mc, cot, field_infos, weight)
+        )
+        logger.info('registered typed tab "%s" for %s.%s', slug, mc._meta.app_label, mc._meta.model_name)
+
+
+# ===========================================================================
+# Orchestrator
+# ===========================================================================
+
+def inject_co_urls():
+    """Inject URL patterns for tab views on CO dynamic model detail pages."""
+    try:
+        import netbox_custom_objects.urls as co_urls
+        from django.urls import path as url_path
+    except ImportError:
+        return
+
+    co_views = {}
+    for model_name, entries in registry['views'].get(APP_LABEL, {}).items():
+        if not model_name.startswith('table'):
+            continue
+        for e in entries:
+            if e['name'].startswith('custom_objects') and e['name'] not in co_views:
+                co_views[e['name']] = (e['path'], e['view'])
+
+    existing = {p.name for p in co_urls.urlpatterns if hasattr(p, 'name') and p.name}
+    for action, (path_str, view_cls) in co_views.items():
+        url_name = f'customobject_{action}'
+        if url_name in existing:
+            continue
+        co_urls.urlpatterns.append(
+            url_path(f'<str:custom_object_type>/<int:pk>/{path_str}/', view_cls.as_view(), name=url_name)
+        )
+
+
+def deduplicate_registry():
+    """Remove duplicate view registrations. Call AFTER super().ready()."""
+    for _app, model_map in registry['views'].items():
+        for model_name, entries in model_map.items():
+            seen = set()
+            deduped = []
+            for e in entries:
+                if e['name'] not in seen:
+                    seen.add(e['name'])
+                    deduped.append(e)
+            if len(deduped) < len(entries):
+                model_map[model_name] = deduped
+
+
+def _discover_referenced_models():
+    """
+    Discover models referenced by CO fields.
+    Uses app_config.get_models() for CO models — NEVER get_model().
+    """
+    from netbox_custom_objects.models import CustomObject
+    try:
+        app_config = apps.get_app_config(APP_LABEL)
+    except LookupError:
+        return []
+
+    co_models = [m for m in app_config.get_models() if issubclass(m, CustomObject) and m is not CustomObject]
+
+    try:
+        ref_fields = CustomObjectTypeField.objects.filter(
+            type__in=[CustomFieldTypeChoices.TYPE_OBJECT, CustomFieldTypeChoices.TYPE_MULTIOBJECT],
+        ).select_related('related_object_type')
+    except (OperationalError, ProgrammingError):
+        return []
+
+    seen = set()
+    result = []
+    for f in ref_fields:
+        if f.related_object_type_id is None:
+            continue
+        ct = f.related_object_type
+        key = (ct.app_label, ct.model)
+        if key in seen:
+            continue
+        seen.add(key)
+        if ct.app_label == APP_LABEL:
+            match = next((m for m in co_models if m._meta.model_name == ct.model), None)
+            if match:
+                result.append(match)
+        else:
+            try:
+                result.append(apps.get_model(ct.app_label, ct.model))
+            except LookupError:
+                pass
+
+    # Include CO models that might receive CO-to-CO tabs
+    for m in co_models:
+        if m not in result:
+            result.append(m)
+
+    return result
+
+
+def register_all_tabs():
+    """
+    Main entry point — called from ready().
+    Registers combined + typed tabs. Must run BEFORE URL conf is loaded.
+    """
+    models = _discover_referenced_models()
+    if not models:
+        return
+
+    logger.info('register_all_tabs: %d models discovered', len(models))
+    _register_combined_tabs(models)
+    _register_typed_tabs(models)

--- a/netbox_custom_objects/tab_views.py
+++ b/netbox_custom_objects/tab_views.py
@@ -133,12 +133,15 @@ def _count_linked(instance):
     return total or None
 
 
-def _get_linked_objects(instance):
-    """Return list of LinkedCustomObject for all COs referencing *instance*."""
+def _get_linked_objects(instance, user):
+    """Return list of LinkedCustomObject for all COs referencing *instance*, filtered by *user* permissions."""
     results = []
     for field, model, fk in _iter_linked_fields(instance):
+        qs = model.objects
+        if hasattr(qs, 'restrict'):
+            qs = qs.restrict(user, 'view')
         try:
-            for obj in model.objects.filter(**fk).prefetch_related('tags'):
+            for obj in qs.filter(**fk).prefetch_related('tags'):
                 results.append(LinkedCustomObject(custom_object=obj, field=field))
         except (OperationalError, ProgrammingError):
             pass
@@ -169,7 +172,7 @@ def _make_combined_tab_view(model_class):
                 qs = qs.restrict(request.user, 'view')
             instance = get_object_or_404(qs, pk=pk)
 
-            linked_all = _get_linked_objects(instance)
+            linked_all = _get_linked_objects(instance, request.user)
 
             # Quick search filter
             q = request.GET.get('q', '').strip()
@@ -328,7 +331,10 @@ def _make_typed_tab_view(model_class, cot, field_infos, weight):
                 return render(request, 'netbox_custom_objects/tabs/typed_tab.html', error_ctx)
 
             q = _build_link_q(field_infos, instance.pk)
-            base_qs = dynamic_model.objects.filter(q).distinct()
+            base_qs = dynamic_model.objects
+            if hasattr(base_qs, 'restrict'):
+                base_qs = base_qs.restrict(request.user, 'view')
+            base_qs = base_qs.filter(q).distinct()
             filterset = get_filterset_class(dynamic_model)(request.GET, queryset=base_qs)
             filter_form = build_filterset_form_class(dynamic_model)(request.GET)
 

--- a/netbox_custom_objects/tab_views.py
+++ b/netbox_custom_objects/tab_views.py
@@ -303,14 +303,20 @@ def _count_for_type(cot, field_infos):
     return _badge
 
 
-def _make_typed_tab_view(model_class, cot, field_infos, weight):
+def _make_typed_tab_view(model_class, cot, field_infos, weight, permission=None):
     """Factory: returns a View subclass for a per-COT typed tab."""
     badge_fn = _count_for_type(cot, field_infos)
     cot_pk = cot.pk
     cot_label = str(cot)
 
     class TypedTabView(View):
-        tab = ViewTab(label=cot_label, badge=badge_fn, weight=weight, hide_if_empty=True)
+        tab = ViewTab(
+            label=cot_label,
+            badge=badge_fn,
+            weight=weight,
+            permission=permission,
+            hide_if_empty=True,
+        )
 
         def get(self, request, pk, **kwargs):
             qs = model_class.objects
@@ -405,8 +411,14 @@ def _register_typed_tabs(model_classes, weight=2100):
         existing = registry['views'].get(mc._meta.app_label, {}).get(mc._meta.model_name, [])
         if any(e['name'] == f'custom_objects_{slug}' for e in existing):
             continue
+        co_model = model_ct_map.get(cot.object_type_id)
+        permission = (
+            f'{co_model._meta.app_label}.view_{co_model._meta.model_name}'
+            if co_model is not None
+            else None
+        )
         register_model_view(mc, name=f'custom_objects_{slug}', path=f'custom-objects-{slug}')(
-            _make_typed_tab_view(mc, cot, field_infos, weight)
+            _make_typed_tab_view(mc, cot, field_infos, weight, permission=permission)
         )
         logger.info('registered typed tab "%s" for %s.%s', slug, mc._meta.app_label, mc._meta.model_name)
 

--- a/netbox_custom_objects/tab_views.py
+++ b/netbox_custom_objects/tab_views.py
@@ -3,7 +3,8 @@ Related-object tab views for netbox-custom-objects.
 
 Two tab types:
 1. Combined "Custom Objects" tab — shows all linked custom objects in a simple table.
-2. Per-COT typed tabs — opt-in via show_tab=True, with type-specific columns, filters, bulk actions.
+2. Per-COT typed tabs — opt-in via the ``typed_tab_slugs`` list in ``PLUGINS_CONFIG``,
+   with type-specific columns, filters, and bulk actions.
 
 CRITICAL: During registration, never call get_model() or apps.get_model() for dynamic CO models.
 Read from app_config.get_models() instead, as each get_model() cache miss re-registers
@@ -24,10 +25,8 @@ from django.shortcuts import get_object_or_404, render
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import View
 from extras.choices import CustomFieldTypeChoices, CustomFieldUIVisibleChoices
-from netbox.forms import NetBoxModelFilterSetForm
 from netbox.registry import registry
 from netbox.tables import BaseTable
-from utilities.forms.fields import TagFilterField
 from utilities.paginator import EnhancedPaginator, get_paginate_count
 from utilities.views import ViewTab, register_model_view
 
@@ -35,6 +34,7 @@ import django_tables2 as tables2
 
 from netbox_custom_objects import field_types
 from netbox_custom_objects.constants import APP_LABEL
+from netbox_custom_objects.dynamic_forms import build_filterset_form_class
 from netbox_custom_objects.filtersets import get_filterset_class
 from netbox_custom_objects.models import CustomObjectTypeField
 from netbox_custom_objects.tables import CustomObjectTable
@@ -128,7 +128,7 @@ def _count_linked(instance):
     for _field, model, fk in _iter_linked_fields(instance):
         try:
             total += model.objects.filter(**fk).count()
-        except Exception:
+        except (OperationalError, ProgrammingError):
             pass
     return total or None
 
@@ -138,9 +138,9 @@ def _get_linked_objects(instance):
     results = []
     for field, model, fk in _iter_linked_fields(instance):
         try:
-            for obj in model.objects.filter(**fk):
+            for obj in model.objects.filter(**fk).prefetch_related('tags'):
                 results.append(LinkedCustomObject(custom_object=obj, field=field))
-        except Exception:
+        except (OperationalError, ProgrammingError):
             pass
     return results
 
@@ -164,10 +164,10 @@ def _make_combined_tab_view(model_class):
                 cot = get_object_or_404(CustomObjectType, slug=co_slug)
                 actual_model = cot.get_model()
 
-            try:
-                instance = get_object_or_404(actual_model.objects.restrict(request.user, 'view'), pk=pk)
-            except AttributeError:
-                instance = get_object_or_404(actual_model, pk=pk)
+            qs = actual_model.objects
+            if hasattr(qs, 'restrict'):
+                qs = qs.restrict(request.user, 'view')
+            instance = get_object_or_404(qs, pk=pk)
 
             linked_all = _get_linked_objects(instance)
 
@@ -272,42 +272,26 @@ def _build_typed_table_class(cot, dynamic_model):
     return type(f'{dynamic_model._meta.object_name}Table', (CustomObjectTable,), attrs)
 
 
-def _build_filterset_form(cot, dynamic_model):
-    """Build a filterset form class for a COT."""
-    attrs = {
-        'model': dynamic_model,
-        '__module__': 'database.filterset_forms',
-        'tag': TagFilterField(dynamic_model),
-    }
-    for field in cot.fields.all():
-        ft = field_types.FIELD_TYPE_CLASS[field.type]()
-        try:
-            attrs[field.name] = ft.get_filterform_field(field)
-        except NotImplementedError:
-            pass
-    return type(f'{dynamic_model._meta.object_name}FilterForm', (NetBoxModelFilterSetForm,), attrs)
+def _build_link_q(field_infos, instance_pk):
+    """Build the OR'd Q filter selecting CO rows that link to *instance_pk* via any of *field_infos*."""
+    q = Q()
+    for field_name, field_type in field_infos:
+        if field_type == CustomFieldTypeChoices.TYPE_OBJECT:
+            q |= Q(**{f'{field_name}_id': instance_pk})
+        elif field_type == CustomFieldTypeChoices.TYPE_MULTIOBJECT:
+            q |= Q(**{field_name: instance_pk})
+    return q
 
 
 def _count_for_type(cot, field_infos):
     """Badge callable for one COT. Returns None when 0. Uses OR + distinct to avoid double-counting."""
-    cot_pk = cot.pk
 
     def _badge(instance):
-        from netbox_custom_objects.models import CustomObjectType
         try:
-            c = CustomObjectType.objects.get(pk=cot_pk)
-            model = c.get_model()
+            model = cot.get_model()
         except Exception:
             return None
-        q = Q()
-        for field_name, field_type in field_infos:
-            try:
-                if field_type == CustomFieldTypeChoices.TYPE_OBJECT:
-                    q |= Q(**{f'{field_name}_id': instance.pk})
-                elif field_type == CustomFieldTypeChoices.TYPE_MULTIOBJECT:
-                    q |= Q(**{field_name: instance.pk})
-            except Exception:
-                pass
+        q = _build_link_q(field_infos, instance.pk)
         if not q:
             return None
         total = model.objects.filter(q).distinct().count()
@@ -326,10 +310,10 @@ def _make_typed_tab_view(model_class, cot, field_infos, weight):
         tab = ViewTab(label=cot_label, badge=badge_fn, weight=weight, hide_if_empty=True)
 
         def get(self, request, pk, **kwargs):
-            try:
-                instance = get_object_or_404(model_class.objects.restrict(request.user, 'view'), pk=pk)
-            except AttributeError:
-                instance = get_object_or_404(model_class, pk=pk)
+            qs = model_class.objects
+            if hasattr(qs, 'restrict'):
+                qs = qs.restrict(request.user, 'view')
+            instance = get_object_or_404(qs, pk=pk)
 
             from netbox_custom_objects.models import CustomObjectType as COTModel
             error_ctx = {
@@ -343,16 +327,10 @@ def _make_typed_tab_view(model_class, cot, field_infos, weight):
             except Exception:
                 return render(request, 'netbox_custom_objects/tabs/typed_tab.html', error_ctx)
 
-            q = Q()
-            for fn, ft in field_infos:
-                if ft == CustomFieldTypeChoices.TYPE_OBJECT:
-                    q |= Q(**{f'{fn}_id': instance.pk})
-                elif ft == CustomFieldTypeChoices.TYPE_MULTIOBJECT:
-                    q |= Q(**{fn: instance.pk})
-
+            q = _build_link_q(field_infos, instance.pk)
             base_qs = dynamic_model.objects.filter(q).distinct()
             filterset = get_filterset_class(dynamic_model)(request.GET, queryset=base_qs)
-            filter_form = _build_filterset_form(c, dynamic_model)(request.GET)
+            filter_form = build_filterset_form_class(dynamic_model)(request.GET)
 
             table = _build_typed_table_class(c, dynamic_model)(filterset.qs)
             table.columns.show('pk')

--- a/netbox_custom_objects/templates/netbox_custom_objects/customobject.html
+++ b/netbox_custom_objects/templates/netbox_custom_objects/customobject.html
@@ -73,12 +73,7 @@
     <li class="nav-item">
       <a class="nav-link{% if not tab %} active{% endif %}" href="{{ object.get_absolute_url }}">{{ object.custom_object_type.get_verbose_name }}</a>
     </li>
-    <li class="nav-item">
-      <a class="nav-link{% if tab == 'journal' %} active{% endif %}" href="{% url 'plugins:netbox_custom_objects:customobject_journal' object.custom_object_type.slug object.pk %}">{% trans "Journal" %}</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link{% if tab == 'changelog' %} active{% endif %}" href="{% url 'plugins:netbox_custom_objects:customobject_changelog' object.custom_object_type.slug object.pk %}">{% trans "Changelog" %}</a>
-    </li>
+    {% model_view_tabs object %}
   </ul>
 {% endblock tabs %}
 

--- a/netbox_custom_objects/templates/netbox_custom_objects/tabs/combined_tab.html
+++ b/netbox_custom_objects/templates/netbox_custom_objects/tabs/combined_tab.html
@@ -1,0 +1,142 @@
+{% extends base_template %}
+{% load i18n perms helpers %}
+{% block content %}
+    {# Controls row — Quick search + Configure Table #}
+    <div class="row mb-3" id="results">
+        <div class="col-auto d-print-none">
+            <form method="get" class="input-group input-group-flat me-2 quicksearch">
+                <input type="search" name="q" value="{{ q }}" class="form-control"
+                       placeholder="{% trans 'Quick search' %}">
+                <span class="input-group-text py-1">
+                    {% if q %}
+                        <a href="?" class="text-secondary"><i class="mdi mdi-close-circle"></i></a>
+                    {% endif %}
+                </span>
+            </form>
+        </div>
+        <div class="col-auto ms-auto d-print-none">
+            <div class="table-configure btn-group">
+                <button type="button" data-bs-toggle="modal" title="{% trans 'Configure Table' %}"
+                        data-bs-target="#CustomObjectsTabTable_config" class="btn">
+                    <i class="mdi mdi-cog"></i> {% trans "Configure Table" %}
+                </button>
+            </div>
+        </div>
+    </div>
+    {# Table in card #}
+    <div class="card">
+        {% if page_rows %}
+            <div class="table-responsive">
+                <table class="table table-hover object-list mb-0">
+                    <thead>
+                        <tr>
+                            {% if 'type' in selected_columns %}
+                                <th>{% trans "Type" %}</th>
+                            {% endif %}
+                            {% if 'object' in selected_columns %}
+                                <th>{% trans "Object" %}</th>
+                            {% endif %}
+                            {% if 'value' in selected_columns %}
+                                <th>{% trans "Value" %}</th>
+                            {% endif %}
+                            {% if 'field' in selected_columns %}
+                                <th>{% trans "Field" %}</th>
+                            {% endif %}
+                            {% if 'tags' in selected_columns %}
+                                <th>{% trans "Tags" %}</th>
+                            {% endif %}
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for obj, field, value in page_rows %}
+                            <tr>
+                                {% if 'type' in selected_columns %}
+                                    <td>
+                                        {% if request.user|can_view:field.custom_object_type %}
+                                            <a href="{{ field.custom_object_type.get_absolute_url }}">{{ field.custom_object_type }}</a>
+                                        {% else %}
+                                            {{ field.custom_object_type }}
+                                        {% endif %}
+                                    </td>
+                                {% endif %}
+                                {% if 'object' in selected_columns %}
+                                    <td>
+                                        <a href="{{ obj.get_absolute_url }}">{{ obj }}</a>
+                                    </td>
+                                {% endif %}
+                                {% if 'value' in selected_columns %}
+                                    <td>
+                                        {% if field.type == 'object' %}
+                                            {% if value %}
+                                                <a href="{{ value.get_absolute_url }}">{{ value }}</a>
+                                            {% else %}
+                                                &mdash;
+                                            {% endif %}
+                                        {% elif field.type == 'multiobject' %}
+                                            {% if value %}
+                                                {% for related_obj in value|slice:":3" %}
+                                                    <a href="{{ related_obj.get_absolute_url }}">{{ related_obj }}</a>
+                                                    {% if not forloop.last %},{% endif %}
+                                                {% endfor %}
+                                                {% if value|length > 3 %}&hellip;{% endif %}
+                                            {% else %}
+                                                &mdash;
+                                            {% endif %}
+                                        {% else %}
+                                            &mdash;
+                                        {% endif %}
+                                    </td>
+                                {% endif %}
+                                {% if 'field' in selected_columns %}<td>{{ field }}</td>{% endif %}
+                                {% if 'tags' in selected_columns %}
+                                    <td>
+                                        {% for t in obj.tags.all %}
+                                            {% tag t %}
+                                        {% empty %}
+                                            &mdash;
+                                        {% endfor %}
+                                    </td>
+                                {% endif %}
+                                <td class="text-end text-nowrap noprint">
+                                    <span class="btn-group dropdown">
+                                        {% if request.user|can_change:obj %}
+                                            <a class="btn btn-sm btn-warning"
+                                               href="{% url 'plugins:netbox_custom_objects:customobject_edit' pk=obj.pk custom_object_type=obj.custom_object_type.slug %}?return_url={{ return_url|urlencode }}"
+                                               aria-label="Edit">
+                                                <i class="mdi mdi-pencil"></i>
+                                            </a>
+                                            <a class="btn btn-sm btn-warning dropdown-toggle" type="button"
+                                               data-bs-toggle="dropdown" style="padding-left: 2px">
+                                                <span class="visually-hidden">Toggle Dropdown</span>
+                                            </a>
+                                            <ul class="dropdown-menu">
+                                                {% if request.user|can_delete:obj %}
+                                                    <li>
+                                                        <a class="dropdown-item"
+                                                           href="{% url 'plugins:netbox_custom_objects:customobject_delete' pk=obj.pk custom_object_type=obj.custom_object_type.slug %}?return_url={{ return_url|urlencode }}">
+                                                            <i class="mdi mdi-trash-can-outline"></i> {% trans "Delete" %}
+                                                        </a>
+                                                    </li>
+                                                {% endif %}
+                                            </ul>
+                                        {% endif %}
+                                    </span>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+            {% include 'inc/paginator.html' with paginator=paginator page=page_obj placement='bottom' %}
+        {% else %}
+            <div class="card-body text-muted">
+                {% trans "No custom objects are linked to this object." %}
+            </div>
+        {% endif %}
+    </div>
+{% endblock content %}
+{% block modals %}
+    {{ block.super }}
+    {% table_config_form tab_table %}
+{% endblock modals %}

--- a/netbox_custom_objects/templates/netbox_custom_objects/tabs/typed_tab.html
+++ b/netbox_custom_objects/templates/netbox_custom_objects/tabs/typed_tab.html
@@ -1,0 +1,72 @@
+{% extends base_template %}
+{% load helpers %}
+{% load render_table from django_tables2 %}
+{% load i18n %}
+{% block content %}
+    {% if table %}
+        {# Results / Filters sub-tabs (standard NetBox list view pattern) #}
+        <ul class="nav nav-tabs" role="tablist">
+            <li class="nav-item" role="presentation">
+                <a class="nav-link active" id="object-list-tab" data-bs-toggle="tab"
+                   data-bs-target="#object-list" type="button" role="tab"
+                   aria-controls="object-list" aria-selected="true">
+                    {% trans "Results" %}
+                    <span class="badge text-bg-secondary total-object-count">{{ table.page.paginator.count }}</span>
+                </a>
+            </li>
+            {% if filter_form %}
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link" id="filters-form-tab" data-bs-toggle="tab"
+                            data-bs-target="#filters-form" type="button" role="tab"
+                            aria-controls="filters-form" aria-selected="false">
+                        {% trans "Filters" %}
+                        {% badge filter_form.changed_data|length bg_color="primary" %}
+                    </button>
+                </li>
+            {% endif %}
+        </ul>
+        {# Results tab pane #}
+        <div class="tab-pane show active mt-3" id="object-list" role="tabpanel" aria-labelledby="object-list-tab">
+            {% if filter_form %}
+                {% applied_filters model filter_form request.GET %}
+            {% endif %}
+            {% include 'inc/table_controls_htmx.html' with table_modal=table.name|add:"_config" %}
+            <form method="post">
+                {% csrf_token %}
+                <input type="hidden" name="return_url" value="{{ return_url }}">
+                <div class="card">
+                    <div class="htmx-container table-responsive" id="object_list">
+                        {% include 'htmx/table.html' %}
+                    </div>
+                </div>
+                <div class="d-print-none mt-2">
+                    <button type="submit" name="_edit"
+                            formaction="{% url 'plugins:netbox_custom_objects:customobject_bulk_edit' custom_object_type=custom_object_type.slug %}?return_url={{ return_url|urlencode:'' }}"
+                            class="btn btn-yellow">
+                        <i class="mdi mdi-pencil" aria-hidden="true"></i> Edit Selected
+                    </button>
+                    <button type="submit" name="_delete"
+                            formaction="{% url 'plugins:netbox_custom_objects:customobject_bulk_delete' custom_object_type=custom_object_type.slug %}?return_url={{ return_url|urlencode:'' }}"
+                            class="btn btn-red">
+                        <i class="mdi mdi-trash-can-outline" aria-hidden="true"></i> Delete Selected
+                    </button>
+                </div>
+            </form>
+        </div>
+        {# Filters tab pane #}
+        {% if filter_form %}
+            <div class="tab-pane show mt-3" id="filters-form" role="tabpanel" aria-labelledby="filters-form-tab">
+                {% include 'inc/filter_list.html' %}
+            </div>
+        {% endif %}
+    {% else %}
+        <div class="card">
+            <div class="card-body text-muted">{% trans "No custom objects are linked to this object." %}</div>
+        </div>
+    {% endif %}
+{% endblock content %}
+{% block modals %}
+    {% if table %}
+        {% table_config_form table %}
+    {% endif %}
+{% endblock modals %}

--- a/netbox_custom_objects/views.py
+++ b/netbox_custom_objects/views.py
@@ -831,7 +831,7 @@ class CustomObjectJournalView(ConditionalLoginRequiredMixin, View):
         )
 
         journal_table = JournalEntryTable(
-            data=journal_entries, orderable=False, user=request.user
+            data=journal_entries, orderable=False
         )
         journal_table.configure(request)
         journal_table.columns.hide("assigned_object_type")
@@ -861,7 +861,7 @@ class CustomObjectJournalView(ConditionalLoginRequiredMixin, View):
                 "form": form,
                 "table": journal_table,
                 "base_template": self.base_template,
-                "tab": "journal",
+                "tab": self.tab,
                 "form_action": reverse(
                     "plugins:netbox_custom_objects:custom_journalentry_add"
                 ),
@@ -903,7 +903,7 @@ class CustomObjectChangeLogView(ConditionalLoginRequiredMixin, View):
         )
 
         objectchanges_table = ObjectChangeTable(
-            data=objectchanges, orderable=False, user=request.user
+            data=objectchanges, orderable=False
         )
         objectchanges_table.configure(request)
 
@@ -918,6 +918,6 @@ class CustomObjectChangeLogView(ConditionalLoginRequiredMixin, View):
                 "object": obj,
                 "table": objectchanges_table,
                 "base_template": self.base_template,
-                "tab": "changelog",
+                "tab": self.tab,
             },
         )


### PR DESCRIPTION
## Summary

> **This is a Proof of Concept / Work in Progress — not ready for merge.** The design and configuration approach need discussion before finalizing.

Integrates the standalone [netbox-custom-objects-tab](https://github.com/CESNET/netbox-custom-objects-tab) plugin into core netbox-custom-objects (ref: [CESNET/netbox-custom-objects-tab#8](https://github.com/CESNET/netbox-custom-objects-tab/issues/8)).

Closes #26

### What's implemented

- **Combined "Custom Objects" tab** — automatically appears on detail pages of any NetBox object referenced by a Custom Object Type. Shows all linked custom objects with actions, tags, column config, and quick search. Always active, no configuration needed.
- **Per-COT typed tabs** — opt-in dedicated tabs for specific Custom Object Types, with type-specific columns, per-field filters, and bulk actions. Configured via `typed_tab_slugs` in `PLUGINS_CONFIG`.
- **CO-to-CO support** — custom objects referencing other custom objects also get tabs.
- Plugin wiring (`__init__.py`), templates, and README documentation.

### Open questions for discussion

- [ ] **Configuration approach**: Currently typed tabs are enabled via `typed_tab_slugs` list in `PLUGINS_CONFIG`. Is this the right UX, or should this be a per-COT toggle in the admin UI?
- [ ] **Badge/count behavior**: Badges use `OR + distinct` queries to avoid double-counting — are there performance concerns at scale?
- [ ] **Template/styling**: Do the tab templates align with NetBox core conventions, or do they need adjustment?

### Commits

1. `1cac046` — Add related object tab views and templates
2. `ab29d56` — Wire tab registration into plugin and fix pre-existing view bugs
3. `69c46a7` — Document related object tabs in README

### Images
<img width="791" height="633" alt="obrazek" src="https://github.com/user-attachments/assets/5147a5ee-0d89-438b-920d-38faea47d79d" />
<img width="1551" height="502" alt="obrazek" src="https://github.com/user-attachments/assets/3856d414-772a-44cc-8e61-70531780d379" />
<img width="754" height="622" alt="obrazek" src="https://github.com/user-attachments/assets/cd6bd7e0-c21d-450b-90d9-609aa92d5350" />
<img width="1558" height="479" alt="obrazek" src="https://github.com/user-attachments/assets/f62fdd5f-d2f8-47e0-9268-9f4c86bb7a65" />
<img width="1551" height="458" alt="obrazek" src="https://github.com/user-attachments/assets/807c9c82-e9d6-4906-ac7c-5e61bf74636e" />
