### PR TITLE
Closes: #296/#366 - Add filter by attributed for custom-object-types

### DIFF
--- a/.github/workflows/lint-tests.yaml
+++ b/.github/workflows/lint-tests.yaml
@@ -34,7 +34,7 @@ jobs:
         run: ruff check
   tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/netbox_custom_objects/field_types.py
+++ b/netbox_custom_objects/field_types.py
@@ -256,8 +256,6 @@ class DecimalFieldType(FieldType):
         return forms.DecimalField(
             label=field,
             required=False,
-            max_digits=12,
-            decimal_places=2,
             min_value=field.validation_minimum,
             max_value=field.validation_maximum,
         )
@@ -363,6 +361,12 @@ class JSONFieldType(FieldType):
         return JSONField(
             required=field.required,
             initial=json.dumps(field.default) if field.default else None,
+        )
+
+    def get_filterform_field(self, field, **kwargs):
+        return forms.CharField(
+            label=field,
+            required=False,
         )
 
 

--- a/netbox_custom_objects/field_types.py
+++ b/netbox_custom_objects/field_types.py
@@ -171,6 +171,12 @@ class TextFieldType(FieldType):
 
 
 class LongTextFieldType(FieldType):
+    def get_filterform_field(self, field, **kwargs):
+        return forms.CharField(
+            label=field,
+            required=False,
+        )
+
     def get_model_field(self, field, **kwargs):
         field_kwargs = self._safe_kwargs(**kwargs)
         field_kwargs.update({"default": field.default, "unique": field.unique})
@@ -241,7 +247,17 @@ class DecimalFieldType(FieldType):
             required=field.required,
             initial=field.default,
             max_digits=12,
-            decimal_places=4,
+            decimal_places=2,
+            min_value=field.validation_minimum,
+            max_value=field.validation_maximum,
+        )
+
+    def get_filterform_field(self, field, **kwargs):
+        return forms.DecimalField(
+            label=field,
+            required=False,
+            max_digits=12,
+            decimal_places=2,
             min_value=field.validation_minimum,
             max_value=field.validation_maximum,
         )
@@ -265,6 +281,18 @@ class BooleanFieldType(FieldType):
             widget=forms.Select(choices=choices),
         )
 
+    def get_filterform_field(self, field, **kwargs):
+        choices = (
+            ('', '---------'),
+            ('true', _("Yes")),
+            ('false', _("No")),
+        )
+        return forms.NullBooleanField(
+            label=field,
+            required=False,
+            widget=forms.Select(choices=choices),
+        )
+
     def get_table_column_field(self, field, **kwargs):
         return BooleanColumn()
 
@@ -280,6 +308,13 @@ class DateFieldType(FieldType):
             required=field.required, initial=field.default, widget=DatePicker()
         )
 
+    def get_filterform_field(self, field, **kwargs):
+        return forms.DateField(
+            label=field,
+            required=False,
+            widget=DatePicker(),
+        )
+
 
 class DateTimeFieldType(FieldType):
     def get_model_field(self, field, **kwargs):
@@ -292,6 +327,13 @@ class DateTimeFieldType(FieldType):
             required=field.required, initial=field.default, widget=DateTimePicker()
         )
 
+    def get_filterform_field(self, field, **kwargs):
+        return forms.DateTimeField(
+            label=field,
+            required=False,
+            widget=DateTimePicker(),
+        )
+
 
 class URLFieldType(FieldType):
     def get_model_field(self, field, **kwargs):
@@ -302,6 +344,12 @@ class URLFieldType(FieldType):
     def get_form_field(self, field, **kwargs):
         return LaxURLField(
             assume_scheme="https", required=field.required, initial=field.default
+        )
+
+    def get_filterform_field(self, field, **kwargs):
+        return forms.CharField(
+            label=field,
+            required=False,
         )
 
 
@@ -319,6 +367,16 @@ class JSONFieldType(FieldType):
 
 
 class SelectFieldType(FieldType):
+    def get_filterform_field(self, field, **kwargs):
+        return DynamicMultipleChoiceField(
+            choices=field.choice_set.choices,
+            label=field,
+            required=False,
+            widget=APISelectMultiple(
+                api_url=f'/api/extras/custom-field-choice-sets/{field.choice_set.pk}/choices/'
+            ),
+        )
+
     def get_model_field(self, field, **kwargs):
         field_kwargs = self._safe_kwargs(**kwargs)
         field_kwargs.update({"default": field.default, "unique": field.unique})
@@ -361,6 +419,17 @@ class SelectFieldType(FieldType):
 
 
 class MultiSelectFieldType(FieldType):
+    def get_filterform_field(self, field, **kwargs):
+        choices = add_blank_choice(field.choice_set.choices)
+        return DynamicMultipleChoiceField(
+            choices=choices,
+            label=field,
+            required=False,
+            widget=APISelectMultiple(
+                api_url=f'/api/extras/custom-field-choice-sets/{field.choice_set.pk}/choices/'
+            ),
+        )
+
     def get_display_value(self, instance, field_name):
         return ", ".join(getattr(instance, field_name) or [])
 
@@ -545,6 +614,11 @@ class ObjectFieldType(FieldType):
             required=False,
             label=field,
             selector=model._meta.app_label != APP_LABEL,
+            query_params=(
+                field.related_object_filter
+                if hasattr(field, "related_object_filter")
+                else None
+            ),
         )
 
     def render_table_column(self, value):
@@ -922,6 +996,11 @@ class MultiObjectFieldType(FieldType):
             required=False,
             label=field,
             selector=model._meta.app_label != APP_LABEL,
+            query_params=(
+                field.related_object_filter
+                if hasattr(field, "related_object_filter")
+                else None
+            ),
         )
 
     def get_display_value(self, instance, field_name):

--- a/netbox_custom_objects/field_types.py
+++ b/netbox_custom_objects/field_types.py
@@ -247,7 +247,7 @@ class DecimalFieldType(FieldType):
             required=field.required,
             initial=field.default,
             max_digits=12,
-            decimal_places=2,
+            decimal_places=4,
             min_value=field.validation_minimum,
             max_value=field.validation_maximum,
         )
@@ -420,7 +420,7 @@ class SelectFieldType(FieldType):
 
 class MultiSelectFieldType(FieldType):
     def get_filterform_field(self, field, **kwargs):
-        choices = add_blank_choice(field.choice_set.choices)
+        choices = field.choice_set.choices
         return DynamicMultipleChoiceField(
             choices=choices,
             label=field,

--- a/netbox_custom_objects/filtersets.py
+++ b/netbox_custom_objects/filtersets.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation
 from typing import Any, Dict, Optional, Type
 
-from django.db.models import JSONField, QuerySet, Q
+from django.db.models import QuerySet, Q
 from django.utils.dateparse import parse_date, parse_datetime
 
 from extras.choices import CustomFieldTypeChoices
@@ -147,23 +147,14 @@ def get_filterset_class(model):
     """
     Create and return a filterset class for the given custom object model.
     """
-    # Get standard fields from the model
-    fields = [field.name for field in model._meta.fields]
-
+    # fields=[] disables auto-generation; all filters are added explicitly below
+    # via build_filter_for_field so there are no shadowed duplicates.
     meta = type(
         "Meta",
         (),
         {
             "model": model,
-            "fields": fields,
-            "filter_overrides": {
-                JSONField: {
-                    "filter_class": django_filters.CharFilter,
-                    "extra": lambda f: {
-                        "lookup_expr": "icontains",
-                    },
-                },
-            },
+            "fields": [],
         },
     )
 

--- a/netbox_custom_objects/filtersets.py
+++ b/netbox_custom_objects/filtersets.py
@@ -91,6 +91,11 @@ FIELD_TYPE_FILTERS = {
         extra_kwargs={"choices": lambda f: f.choices}
     ),
     CustomFieldTypeChoices.TYPE_OBJECT: FilterSpec(django_filters.ModelChoiceFilter),
+    # CustomManyToManyField inherits ManyToManyField, so Django's ORM translates
+    # `field__in=values` to a JOIN through the through table at the SQL level.
+    # The custom descriptor/manager only affects instance-level access (e.g.
+    # `instance.field.all()`), not queryset filtering, so ModelMultipleChoiceFilter
+    # is correct here without needing explicit through-table queries.
     CustomFieldTypeChoices.TYPE_MULTIOBJECT: FilterSpec(django_filters.ModelMultipleChoiceFilter),
 }
 
@@ -132,7 +137,7 @@ def build_filter_for_field(field) -> Optional[django_filters.Filter]:
 
     return spec.build(
         field_name=field.name,
-        label=field.label,
+        label=field.label or field.name,
         queryset=queryset,
         **extra_kwargs,
     )

--- a/netbox_custom_objects/filtersets.py
+++ b/netbox_custom_objects/filtersets.py
@@ -1,7 +1,9 @@
 import django_filters
+from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation
-from django.contrib.postgres.fields import ArrayField
-from django.db.models import JSONField, Q
+from typing import Any, Dict, Optional, Type
+
+from django.db.models import JSONField, QuerySet, Q
 from django.utils.dateparse import parse_date, parse_datetime
 
 from extras.choices import CustomFieldTypeChoices
@@ -10,9 +12,87 @@ from netbox.filtersets import NetBoxModelFilterSet
 from .models import CustomObjectType
 
 __all__ = (
+    "ArrayContainsFilter",
     "CustomObjectTypeFilterSet",
     "get_filterset_class",
 )
+
+
+class ArrayContainsFilter(django_filters.MultipleChoiceFilter):
+    """
+    Filter for ArrayField (TYPE_MULTISELECT): checks if the array contains any
+    of the selected values using OR semantics with PostgreSQL array containment.
+
+    Standard MultipleChoiceFilter uses ``exact`` lookup, which compares the
+    entire array rather than checking membership. This class uses
+    ``__contains=[v]`` instead, matching Django's array containment operator.
+    """
+
+    def filter(self, qs, value):
+        if not value:
+            return qs
+        q = Q()
+        for v in value:
+            q |= Q(**{f"{self.field_name}__contains": [v]})
+        return qs.filter(q).distinct()
+
+
+@dataclass
+class FilterSpec:
+    """
+    Declarative specification describing how a custom field type
+    should be translated into a django-filter Filter instance.
+    """
+    filter_class: Type[django_filters.Filter]
+    lookup_expr: Optional[str] = None
+    extra_kwargs: Optional[Dict[str, Any]] = None
+
+    def build(
+        self, field_name: str, label: str, queryset: Optional[QuerySet] = None, **kwargs
+        ) -> django_filters.Filter:
+        """
+        Instantiate and return a django-filter Filter.
+        Allows overriding defaults via **kwargs.
+        """
+        filter_kwargs = {
+            "field_name": field_name,
+            "label": label,
+        }
+
+        if self.lookup_expr:
+            filter_kwargs["lookup_expr"] = self.lookup_expr
+
+        if queryset is not None:
+            filter_kwargs["queryset"] = queryset
+
+        # Callers (build_filter_for_field) resolve extra_kwargs callables and pass
+        # the results here as **kwargs; merge them directly.
+        filter_kwargs.update(kwargs)
+
+        return self.filter_class(**filter_kwargs)
+
+
+FIELD_TYPE_FILTERS = {
+    CustomFieldTypeChoices.TYPE_TEXT: FilterSpec(django_filters.CharFilter, lookup_expr="icontains"),
+    CustomFieldTypeChoices.TYPE_LONGTEXT: FilterSpec(django_filters.CharFilter, lookup_expr="icontains"),
+    CustomFieldTypeChoices.TYPE_INTEGER: FilterSpec(django_filters.NumberFilter, lookup_expr="exact"),
+    CustomFieldTypeChoices.TYPE_DECIMAL: FilterSpec(django_filters.NumberFilter, lookup_expr="exact"),
+    CustomFieldTypeChoices.TYPE_BOOLEAN: FilterSpec(django_filters.BooleanFilter),
+    CustomFieldTypeChoices.TYPE_DATE: FilterSpec(django_filters.DateFilter, lookup_expr="exact"),
+    CustomFieldTypeChoices.TYPE_DATETIME: FilterSpec(django_filters.DateTimeFilter, lookup_expr="exact"),
+    CustomFieldTypeChoices.TYPE_URL: FilterSpec(django_filters.CharFilter, lookup_expr="icontains"),
+    CustomFieldTypeChoices.TYPE_JSON: FilterSpec(django_filters.CharFilter, lookup_expr="icontains"),
+    CustomFieldTypeChoices.TYPE_SELECT: FilterSpec(
+        django_filters.MultipleChoiceFilter,
+        extra_kwargs={"choices": lambda f: f.choices}
+    ),
+    CustomFieldTypeChoices.TYPE_MULTISELECT: FilterSpec(
+        ArrayContainsFilter,
+        extra_kwargs={"choices": lambda f: f.choices}
+    ),
+    CustomFieldTypeChoices.TYPE_OBJECT: FilterSpec(django_filters.ModelChoiceFilter),
+    CustomFieldTypeChoices.TYPE_MULTIOBJECT: FilterSpec(django_filters.ModelMultipleChoiceFilter),
+}
 
 
 class CustomObjectTypeFilterSet(NetBoxModelFilterSet):
@@ -25,10 +105,44 @@ class CustomObjectTypeFilterSet(NetBoxModelFilterSet):
         )
 
 
+def build_filter_for_field(field) -> Optional[django_filters.Filter]:
+    if not (spec := FIELD_TYPE_FILTERS.get(field.type)):
+        return None
+
+    queryset = None
+    if field.type in (
+        CustomFieldTypeChoices.TYPE_OBJECT,
+        CustomFieldTypeChoices.TYPE_MULTIOBJECT,
+    ):
+        related_object_type = getattr(field, "related_object_type", None)
+        if not related_object_type:
+            # Defensive guard: if data integrity is compromised and the related object type
+            # is missing, skip building a filter for this field rather than raising.
+            return None
+        model_class = related_object_type.model_class()
+        if model_class is None:
+            # ContentType exists but the model is no longer installed (e.g. stale content type).
+            return None
+        queryset = model_class.objects.all()
+
+    extra_kwargs = {}
+    if spec.extra_kwargs:
+        for key, value in spec.extra_kwargs.items():
+            extra_kwargs[key] = value(field) if callable(value) else value
+
+    return spec.build(
+        field_name=field.name,
+        label=field.label,
+        queryset=queryset,
+        **extra_kwargs,
+    )
+
+
 def get_filterset_class(model):
     """
     Create and return a filterset class for the given custom object model.
     """
+    # Get standard fields from the model
     fields = [field.name for field in model._meta.fields]
 
     meta = type(
@@ -37,16 +151,8 @@ def get_filterset_class(model):
         {
             "model": model,
             "fields": fields,
-            # TODO: overrides should come from FieldType
-            # These are placeholders; should use different logic
             "filter_overrides": {
                 JSONField: {
-                    "filter_class": django_filters.CharFilter,
-                    "extra": lambda f: {
-                        "lookup_expr": "icontains",
-                    },
-                },
-                ArrayField: {
                     "filter_class": django_filters.CharFilter,
                     "extra": lambda f: {
                         "lookup_expr": "icontains",
@@ -96,38 +202,15 @@ def get_filterset_class(model):
 
     attrs = {
         "Meta": meta,
-        "__module__": "database.filtersets",
+        "__module__": "netbox_custom_objects.filtersets",
         "search": search,
     }
 
-    # Add filters for M2M (multiobject) fields, which are not in model._meta.fields.
-    # By the time get_filterset_class() is called (at request time), after_model_generation()
-    # will have already resolved m2m_field.remote_field.model and .through to actual model
-    # classes. Calling this during app startup (before model generation) would fail.
-    for m2m_field in model._meta.many_to_many:
-        field_name = m2m_field.name
-        through_model = m2m_field.remote_field.through
-        related_model = m2m_field.remote_field.model
-
-        def make_m2m_filter(through, fname):
-            def filter_m2m(self, queryset, name, value):
-                if not value:
-                    return queryset
-                ids = [v.pk for v in value]
-                source_ids = through.objects.filter(
-                    target_id__in=ids
-                ).values_list("source_id", flat=True)
-                return queryset.filter(pk__in=source_ids)
-            filter_m2m.__name__ = f"filter_{fname}"
-            return filter_m2m
-
-        method_name = f"filter_{field_name}"
-        attrs[method_name] = make_m2m_filter(through_model, field_name)
-        attrs[field_name] = django_filters.ModelMultipleChoiceFilter(
-            queryset=related_model.objects.all(),
-            method=method_name,
-            label=field_name,
-        )
+    # For each custom field, add a corresponding filter
+    for field in model.custom_object_type.fields.all():
+        filter_instance = build_filter_for_field(field)
+        if filter_instance:
+            attrs[field.name] = filter_instance
 
     return type(
         f"{model._meta.object_name}FilterSet",

--- a/netbox_custom_objects/tests/test_api.py
+++ b/netbox_custom_objects/tests/test_api.py
@@ -4,7 +4,7 @@ Tests for API code paths.
 from django.test import TestCase
 from django.urls import reverse
 
-from utilities.testing import APIViewTestCases, create_test_user
+from utilities.testing import create_test_user
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -30,9 +30,87 @@ def create_token(user):
         return token.key
 
 
-class CustomObjectTest(CustomObjectsTestCase, APIViewTestCases.APIViewTestCase):
+class CustomObjectAPITestCaseMixin:
+    """
+    Base test class for custom object API endpoints.
+
+    Subclasses must provide:
+      - setUp() — sets self.user, self.header, self.client
+      - _get_detail_url(instance)
+      - _get_list_url()
+      - _get_queryset()
+      - _add_permission(action, name=None)
+      - create_data — list of dicts (at least one element)
+      - bulk_update_data — dict of fields to PATCH
+    """
+
+    @property
+    def update_data(self):
+        return getattr(self, '_update_data', self.bulk_update_data)
+
+    def assertHttpStatus(self, response, expected_status):
+        self.assertEqual(
+            response.status_code,
+            expected_status,
+            f'Expected HTTP {expected_status}; received {response.status_code}: '
+            f'{getattr(response, "data", response.content)}',
+        )
+
+    def test_get_object_without_permission(self):
+        """GET a single object without permission returns 403."""
+        instance = self._get_queryset().first()
+        response = self.client.get(self._get_detail_url(instance), **self.header)
+        self.assertHttpStatus(response, 403)
+
+    def test_get_object(self):
+        """GET a single object with permission returns 200 and the correct record."""
+        self._add_permission('view', 'Get object perm')
+        instance = self._get_queryset().first()
+        response = self.client.get(self._get_detail_url(instance), **self.header)
+        self.assertHttpStatus(response, 200)
+        self.assertEqual(response.data['id'], instance.pk)
+
+    def test_list_objects_without_permission(self):
+        """GET the list endpoint without permission returns 403."""
+        response = self.client.get(self._get_list_url(), **self.header)
+        self.assertHttpStatus(response, 403)
+
+    def test_create_object_without_permission(self):
+        """POST to the list endpoint without permission returns 403."""
+        response = self.client.post(
+            self._get_list_url(), self.create_data[0], format='json', **self.header
+        )
+        self.assertHttpStatus(response, 403)
+
+    def test_update_object_without_permission(self):
+        """PATCH a single object without permission returns 403."""
+        instance = self._get_queryset().first()
+        response = self.client.patch(
+            self._get_detail_url(instance), self.update_data, format='json', **self.header
+        )
+        self.assertHttpStatus(response, 403)
+
+    def test_update_object(self):
+        """PATCH a single object returns 200 and persists the changes."""
+        self._add_permission('change', 'Update object perm')
+        instance = self._get_queryset().first()
+        response = self.client.patch(
+            self._get_detail_url(instance), self.update_data, format='json', **self.header
+        )
+        self.assertHttpStatus(response, 200)
+        instance.refresh_from_db()
+        for field, value in self.update_data.items():
+            self.assertEqual(getattr(instance, field), value)
+
+    def test_delete_object_without_permission(self):
+        """DELETE a single object without permission returns 403."""
+        instance = self._get_queryset().first()
+        response = self.client.delete(self._get_detail_url(instance), **self.header)
+        self.assertHttpStatus(response, 403)
+
+
+class CustomObjectTest(CustomObjectsTestCase, CustomObjectAPITestCaseMixin, TestCase):
     model = None  # Will be set in setUpTestData
-    brief_fields = ['created', 'display', 'id', 'last_updated', 'tags', 'test_field', 'url']
     bulk_update_data = {
         'test_field': 'Updated test field',
     }
@@ -41,6 +119,10 @@ class CustomObjectTest(CustomObjectsTestCase, APIViewTestCases.APIViewTestCase):
         """Set up test data."""
         # Create a user
         self.user = create_test_user('testuser')
+
+        # Use DRF's APIClient so that format='json' is honoured on all HTTP methods
+        # (Django's plain Client defaults PATCH/PUT to application/octet-stream).
+        self.client = APIClient()
 
         # Create token for API access
         token_key = create_token(self.user)
@@ -326,13 +408,6 @@ class CustomObjectTest(CustomObjectsTestCase, APIViewTestCases.APIViewTestCase):
             set(instance.devices.values_list('id', flat=True)),
             set(data['devices']),
         )
-
-    # TODO: GraphQL
-    def test_graphql_list_objects(self):
-        ...
-
-    def test_graphql_get_object(self):
-        ...
 
 
 class LinkedObjectsAPITest(CustomObjectsTestCase, TestCase):

--- a/netbox_custom_objects/tests/test_api.py
+++ b/netbox_custom_objects/tests/test_api.py
@@ -100,6 +100,8 @@ class CustomObjectAPITestCaseMixin:
         self.assertHttpStatus(response, 200)
         instance.refresh_from_db()
         for field, value in self.update_data.items():
+            # Note: getattr comparison only works for scalar fields. FK/M2M fields
+            # require separate assertions (e.g. comparing PKs or querysets).
             self.assertEqual(getattr(instance, field), value)
 
     def test_delete_object_without_permission(self):

--- a/netbox_custom_objects/tests/test_filtersets.py
+++ b/netbox_custom_objects/tests/test_filtersets.py
@@ -3,15 +3,17 @@ Tests for filtersets used by the plugin's UI and API views.
 """
 import datetime
 from decimal import Decimal
+from unittest.mock import MagicMock
 
 from django.test import TestCase
 from django.utils import timezone
 
 from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site
+from extras.choices import CustomFieldTypeChoices
 from extras.models import CustomFieldChoiceSet
 
 from netbox_custom_objects.field_types import MultiObjectFieldType, ObjectFieldType
-from netbox_custom_objects.filtersets import ArrayContainsFilter, get_filterset_class
+from netbox_custom_objects.filtersets import ArrayContainsFilter, build_filter_for_field, get_filterset_class
 from netbox_custom_objects.models import CustomObjectTypeField
 from utilities.forms.fields import (
     DynamicModelChoiceField,
@@ -405,6 +407,47 @@ class CustomObjectTargetMultiObjectFieldTestCase(CustomObjectsTestCase, TestCase
             {"related_items": [self.target1.pk, self.target2.pk]}, source_model.objects.all()
         ).qs
         self.assertEqual(qs.filter(pk=self.source_both.pk).count(), 1)
+
+
+# ---------------------------------------------------------------------------
+# build_filter_for_field defensive guards
+# ---------------------------------------------------------------------------
+
+
+class BuildFilterForFieldGuardsTestCase(TestCase):
+    """build_filter_for_field returns None rather than raising when a field's
+    related_object_type is missing or its ContentType is stale."""
+
+    def _field(self, field_type, related_object_type):
+        field = MagicMock()
+        field.type = field_type
+        field.related_object_type = related_object_type
+        return field
+
+    def test_object_field_missing_related_object_type_returns_none(self):
+        self.assertIsNone(
+            build_filter_for_field(self._field(CustomFieldTypeChoices.TYPE_OBJECT, None))
+        )
+
+    def test_multiobject_field_missing_related_object_type_returns_none(self):
+        self.assertIsNone(
+            build_filter_for_field(self._field(CustomFieldTypeChoices.TYPE_MULTIOBJECT, None))
+        )
+
+    def test_object_field_stale_content_type_returns_none(self):
+        # ContentType row exists but the app/model is no longer installed
+        related_ot = MagicMock()
+        related_ot.model_class.return_value = None
+        self.assertIsNone(
+            build_filter_for_field(self._field(CustomFieldTypeChoices.TYPE_OBJECT, related_ot))
+        )
+
+    def test_multiobject_field_stale_content_type_returns_none(self):
+        related_ot = MagicMock()
+        related_ot.model_class.return_value = None
+        self.assertIsNone(
+            build_filter_for_field(self._field(CustomFieldTypeChoices.TYPE_MULTIOBJECT, related_ot))
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/netbox_custom_objects/tests/test_filtersets.py
+++ b/netbox_custom_objects/tests/test_filtersets.py
@@ -5,12 +5,13 @@ import datetime
 from decimal import Decimal
 
 from django.test import TestCase
+from django.utils import timezone
 
 from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site
 from extras.models import CustomFieldChoiceSet
 
 from netbox_custom_objects.field_types import MultiObjectFieldType, ObjectFieldType
-from netbox_custom_objects.filtersets import get_filterset_class
+from netbox_custom_objects.filtersets import ArrayContainsFilter, get_filterset_class
 from netbox_custom_objects.models import CustomObjectTypeField
 from utilities.forms.fields import (
     DynamicModelChoiceField,
@@ -646,3 +647,347 @@ class MultiSelectPrimaryFieldSearchTestCase(CustomObjectsTestCase, TestCase):
         pks = list(self._search("blue").values_list("pk", flat=True))
         self.assertIn(self.obj_multi.pk, pks)
         self.assertNotIn(self.obj_red.pk, pks)
+
+
+# ---------------------------------------------------------------------------
+# Scalar field type filterset tests (build_filter_for_field / FIELD_TYPE_FILTERS)
+# ---------------------------------------------------------------------------
+
+
+class ScalarFieldFiltersetTestCase(CustomObjectsTestCase):
+    """
+    Base for filterset tests covering scalar custom field types.
+
+    Subclasses must:
+      - set ``match_params`` (class attr): filter params that should return obj_match
+      - set ``obj_match`` / ``obj_no_match`` in ``setUpTestData``
+      - set ``total_count`` (class attr, default 2) when the fixture has more rows
+    """
+    match_params: dict = {}
+    total_count: int = 2
+
+    def _filterset(self, params):
+        model = self.cot.get_model()
+        return get_filterset_class(model)(params, model.objects.all())
+
+    def test_filter_returns_match_not_other(self):
+        pks = list(self._filterset(self.match_params).qs.values_list('pk', flat=True))
+        self.assertIn(self.obj_match.pk, pks)
+        self.assertNotIn(self.obj_no_match.pk, pks)
+
+    def test_no_filter_returns_all(self):
+        self.assertEqual(self._filterset({}).qs.count(), self.total_count)
+
+
+class TextFieldFiltersetTestCase(ScalarFieldFiltersetTestCase, TestCase):
+    """CharFilter with icontains is generated for TYPE_TEXT fields."""
+
+    match_params = {'note': 'foo'}
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.cot = cls.create_custom_object_type(name='TextFS', slug='text-fs')
+        cls.create_custom_object_type_field(
+            cls.cot, name='name', label='Name', type='text', primary=True, required=True
+        )
+        cls.create_custom_object_type_field(cls.cot, name='note', label='Note', type='text')
+
+        model = cls.cot.get_model()
+        cls.obj_match = model.objects.create(name='alpha', note='foo bar')
+        cls.obj_no_match = model.objects.create(name='beta', note='baz qux')
+
+    def test_icontains_case_insensitive(self):
+        pks = list(self._filterset({'note': 'FOO'}).qs.values_list('pk', flat=True))
+        self.assertIn(self.obj_match.pk, pks)
+        self.assertNotIn(self.obj_no_match.pk, pks)
+
+
+class LongTextFieldFiltersetTestCase(ScalarFieldFiltersetTestCase, TestCase):
+    """CharFilter with icontains is generated for TYPE_LONGTEXT fields."""
+
+    match_params = {'body': 'match'}
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.cot = cls.create_custom_object_type(name='LongTextFS', slug='longtext-fs')
+        cls.create_custom_object_type_field(
+            cls.cot, name='name', label='Name', type='text', primary=True, required=True
+        )
+        cls.create_custom_object_type_field(cls.cot, name='body', label='Body', type='longtext')
+
+        model = cls.cot.get_model()
+        cls.obj_match = model.objects.create(name='alpha', body='match content')
+        cls.obj_no_match = model.objects.create(name='beta', body='other content')
+
+    def test_icontains_case_insensitive(self):
+        pks = list(self._filterset({'body': 'MATCH'}).qs.values_list('pk', flat=True))
+        self.assertIn(self.obj_match.pk, pks)
+        self.assertNotIn(self.obj_no_match.pk, pks)
+
+
+class IntegerFieldFiltersetTestCase(ScalarFieldFiltersetTestCase, TestCase):
+    """NumberFilter with exact lookup is generated for TYPE_INTEGER fields."""
+
+    match_params = {'count': 10}
+    total_count = 3
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.cot = cls.create_custom_object_type(name='IntFS', slug='int-fs')
+        cls.create_custom_object_type_field(
+            cls.cot, name='name', label='Name', type='text', primary=True, required=True
+        )
+        cls.create_custom_object_type_field(cls.cot, name='count', label='Count', type='integer')
+
+        model = cls.cot.get_model()
+        cls.obj_match = model.objects.create(name='ten', count=10)
+        cls.obj_no_match = model.objects.create(name='twenty', count=20)
+        cls.obj_null = model.objects.create(name='none')
+
+    def test_null_excluded_by_exact_filter(self):
+        pks = list(self._filterset(self.match_params).qs.values_list('pk', flat=True))
+        self.assertNotIn(self.obj_null.pk, pks)
+
+
+class DecimalFieldFiltersetTestCase(ScalarFieldFiltersetTestCase, TestCase):
+    """NumberFilter with exact lookup is generated for TYPE_DECIMAL fields."""
+
+    match_params = {'price': '1.5'}
+    total_count = 3
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.cot = cls.create_custom_object_type(name='DecFS', slug='dec-fs')
+        cls.create_custom_object_type_field(
+            cls.cot, name='name', label='Name', type='text', primary=True, required=True
+        )
+        cls.create_custom_object_type_field(cls.cot, name='price', label='Price', type='decimal')
+
+        model = cls.cot.get_model()
+        cls.obj_match = model.objects.create(name='cheap', price=Decimal('1.5'))
+        cls.obj_no_match = model.objects.create(name='expensive', price=Decimal('9.9'))
+        cls.obj_null = model.objects.create(name='free')
+
+    def test_null_excluded_by_exact_filter(self):
+        pks = list(self._filterset(self.match_params).qs.values_list('pk', flat=True))
+        self.assertNotIn(self.obj_null.pk, pks)
+
+
+class BooleanFieldFiltersetTestCase(ScalarFieldFiltersetTestCase, TestCase):
+    """BooleanFilter is generated for TYPE_BOOLEAN fields."""
+
+    match_params = {'active': True}
+    total_count = 3
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.cot = cls.create_custom_object_type(name='BoolFS', slug='bool-fs')
+        cls.create_custom_object_type_field(
+            cls.cot, name='name', label='Name', type='text', primary=True, required=True
+        )
+        cls.create_custom_object_type_field(
+            cls.cot, name='active', label='Active', type='boolean'
+        )
+
+        model = cls.cot.get_model()
+        cls.obj_true = model.objects.create(name='on', active=True)
+        cls.obj_false = model.objects.create(name='off', active=False)
+        cls.obj_null = model.objects.create(name='unknown')
+        cls.obj_match = cls.obj_true
+        cls.obj_no_match = cls.obj_false
+
+    def test_filter_false(self):
+        pks = list(self._filterset({'active': False}).qs.values_list('pk', flat=True))
+        self.assertIn(self.obj_false.pk, pks)
+        self.assertNotIn(self.obj_true.pk, pks)
+
+
+class DateFieldFiltersetTestCase(ScalarFieldFiltersetTestCase, TestCase):
+    """DateFilter with exact lookup is generated for TYPE_DATE fields."""
+
+    match_params = {'start': '2025-01-15'}
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.cot = cls.create_custom_object_type(name='DateFS', slug='date-fs')
+        cls.create_custom_object_type_field(
+            cls.cot, name='name', label='Name', type='text', primary=True, required=True
+        )
+        cls.create_custom_object_type_field(cls.cot, name='start', label='Start', type='date')
+
+        model = cls.cot.get_model()
+        cls.obj_match = model.objects.create(name='jan', start=datetime.date(2025, 1, 15))
+        cls.obj_no_match = model.objects.create(name='feb', start=datetime.date(2025, 2, 20))
+
+
+class DateTimeFieldFiltersetTestCase(ScalarFieldFiltersetTestCase, TestCase):
+    """DateTimeFilter with exact lookup is generated for TYPE_DATETIME fields."""
+
+    match_params = {'ts': '2025-06-01 09:00:00'}
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.cot = cls.create_custom_object_type(name='DtFS', slug='dt-fs')
+        cls.create_custom_object_type_field(
+            cls.cot, name='name', label='Name', type='text', primary=True, required=True
+        )
+        cls.create_custom_object_type_field(cls.cot, name='ts', label='Timestamp', type='datetime')
+
+        model = cls.cot.get_model()
+        cls.obj_match = model.objects.create(
+            name='am', ts=timezone.make_aware(datetime.datetime(2025, 6, 1, 9, 0, 0))
+        )
+        cls.obj_no_match = model.objects.create(
+            name='pm', ts=timezone.make_aware(datetime.datetime(2025, 6, 1, 18, 0, 0))
+        )
+
+
+class URLFieldFiltersetTestCase(ScalarFieldFiltersetTestCase, TestCase):
+    """CharFilter with icontains is generated for TYPE_URL fields."""
+
+    match_params = {'link': 'github'}
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.cot = cls.create_custom_object_type(name='URLFS', slug='url-fs')
+        cls.create_custom_object_type_field(
+            cls.cot, name='name', label='Name', type='text', primary=True, required=True
+        )
+        cls.create_custom_object_type_field(cls.cot, name='link', label='Link', type='url')
+
+        model = cls.cot.get_model()
+        cls.obj_match = model.objects.create(name='gh', link='https://github.com/example')
+        cls.obj_no_match = model.objects.create(name='gl', link='https://gitlab.com/example')
+
+
+class JSONFieldFiltersetTestCase(ScalarFieldFiltersetTestCase, TestCase):
+    """CharFilter with icontains is generated for TYPE_JSON fields."""
+
+    match_params = {'meta': 'prod'}
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.cot = cls.create_custom_object_type(name='JSONFS', slug='json-fs')
+        cls.create_custom_object_type_field(
+            cls.cot, name='name', label='Name', type='text', primary=True, required=True
+        )
+        cls.create_custom_object_type_field(cls.cot, name='meta', label='Meta', type='json')
+
+        model = cls.cot.get_model()
+        cls.obj_match = model.objects.create(name='a', meta={'env': 'prod'})
+        cls.obj_no_match = model.objects.create(name='b', meta={'env': 'staging'})
+
+
+class SelectFieldFiltersetTestCase(ScalarFieldFiltersetTestCase, TestCase):
+    """MultipleChoiceFilter with OR semantics is generated for TYPE_SELECT fields."""
+
+    match_params = {'status': ['active']}
+    total_count = 3
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.choice_set = CustomFieldChoiceSet.objects.create(
+            name='StatusChoicesFS',
+            extra_choices=[['active', 'Active'], ['inactive', 'Inactive'], ['retired', 'Retired']],
+        )
+        cls.cot = cls.create_custom_object_type(name='SelectFS', slug='select-fs')
+        cls.create_custom_object_type_field(
+            cls.cot, name='name', label='Name', type='text', primary=True, required=True
+        )
+        cls.create_custom_object_type_field(
+            cls.cot, name='status', label='Status', type='select', choice_set=cls.choice_set
+        )
+
+        model = cls.cot.get_model()
+        cls.obj_active = model.objects.create(name='a', status='active')
+        cls.obj_inactive = model.objects.create(name='b', status='inactive')
+        cls.obj_no_status = model.objects.create(name='c')
+        cls.obj_match = cls.obj_active
+        cls.obj_no_match = cls.obj_inactive
+
+    def test_different_choice(self):
+        pks = list(self._filterset({'status': ['inactive']}).qs.values_list('pk', flat=True))
+        self.assertIn(self.obj_inactive.pk, pks)
+        self.assertNotIn(self.obj_active.pk, pks)
+
+    def test_null_excluded(self):
+        pks = list(self._filterset(self.match_params).qs.values_list('pk', flat=True))
+        self.assertNotIn(self.obj_no_status.pk, pks)
+
+    def test_multi_value_or_semantics(self):
+        pks = list(self._filterset({'status': ['active', 'inactive']}).qs.values_list('pk', flat=True))
+        self.assertIn(self.obj_active.pk, pks)
+        self.assertIn(self.obj_inactive.pk, pks)
+        self.assertNotIn(self.obj_no_status.pk, pks)
+
+
+class MultiSelectFieldFiltersetTestCase(ScalarFieldFiltersetTestCase, TestCase):
+    """ArrayContainsFilter is generated for TYPE_MULTISELECT: containment semantics, not exact match."""
+
+    match_params = {'colors': ['red']}
+    total_count = 4
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.choice_set = CustomFieldChoiceSet.objects.create(
+            name='ColorChoicesFS',
+            extra_choices=[['red', 'Red'], ['green', 'Green'], ['blue', 'Blue']],
+        )
+        cls.cot = cls.create_custom_object_type(name='MultiSelFS', slug='multisel-fs')
+        cls.create_custom_object_type_field(
+            cls.cot, name='name', label='Name', type='text', primary=True, required=True
+        )
+        cls.create_custom_object_type_field(
+            cls.cot, name='colors', label='Colors', type='multiselect', choice_set=cls.choice_set
+        )
+
+        model = cls.cot.get_model()
+        cls.obj_red = model.objects.create(name='r', colors=['red'])
+        cls.obj_multi = model.objects.create(name='rm', colors=['red', 'blue'])
+        cls.obj_green = model.objects.create(name='g', colors=['green'])
+        cls.obj_none = model.objects.create(name='n')
+        cls.obj_match = cls.obj_red
+        cls.obj_no_match = cls.obj_green
+
+    def test_filter_returns_match_not_other(self):
+        # Extends the base test: obj_multi (["red","blue"]) must also match on "red"
+        pks = list(self._filterset(self.match_params).qs.values_list('pk', flat=True))
+        self.assertIn(self.obj_red.pk, pks)
+        self.assertIn(self.obj_multi.pk, pks)
+        self.assertNotIn(self.obj_green.pk, pks)
+        self.assertNotIn(self.obj_none.pk, pks)
+
+    def test_filter_partial_array_match(self):
+        # obj_multi has ["red", "blue"]; filtering by "blue" should still match it
+        pks = list(self._filterset({'colors': ['blue']}).qs.values_list('pk', flat=True))
+        self.assertIn(self.obj_multi.pk, pks)
+        self.assertNotIn(self.obj_red.pk, pks)
+        self.assertNotIn(self.obj_green.pk, pks)
+
+    def test_filter_multiple_values_returns_union(self):
+        pks = list(self._filterset({'colors': ['red', 'green']}).qs.values_list('pk', flat=True))
+        self.assertIn(self.obj_red.pk, pks)
+        self.assertIn(self.obj_multi.pk, pks)
+        self.assertIn(self.obj_green.pk, pks)
+        self.assertNotIn(self.obj_none.pk, pks)
+
+    def test_no_duplicates_when_object_matches_multiple_filter_values(self):
+        # obj_multi has both "red" and "blue"; must appear only once in results
+        qs = self._filterset({'colors': ['red', 'blue']}).qs
+        self.assertEqual(qs.filter(pk=self.obj_multi.pk).count(), 1)
+
+    def test_uses_array_contains_filter_class(self):
+        model = self.cot.get_model()
+        fs_class = get_filterset_class(model)
+        self.assertIsInstance(fs_class.base_filters.get('colors'), ArrayContainsFilter)


### PR DESCRIPTION
### Fixes: #296 #366

From @ifoughal original PR: #365 - added tests and cleanup.

This pull request adds dynamic filtering capabilities for custom object type fields, allowing users to filter custom objects based on their field values via the API and UI.

  Changes:
  - Introduced a FilterSpec dataclass and field type-to-filter mapping system in filtersets.py
  - Added ArrayContainsFilter for multiselect fields, fixing filtering on PostgreSQL ArrayField
  - Implemented get_filterform_field for Decimal, Object, and MultiObject field types
  - Fixed incorrect module name from "database.filtersets" to "netbox_custom_objects.filtersets"
  - Added test coverage for all custom field types

<img width="664" height="638" alt="Monosnap Cot1 | NetBox 2026-04-16 16-15-13" src="https://github.com/user-attachments/assets/db1c425d-f21a-4ae2-825a-9407e6550e0f" />
<img width="1355" height="998" alt="Monosnap Cot1s | NetBox 2026-04-16 16-15-29" src="https://github.com/user-attachments/assets/1129d1b7-4d07-4db1-b988-05e8c6e48c73" />


Also needed to add new CustomObjectAPITestCaseMixin as previously was using NetBox APIViewTestCases.APIViewTestCase which plugins shouldn't do - this was causing errors from NetBox recent test changes.