### PR TITLE
Fixes: #394 - Reindex cached values when custom object field weights are changed

### DIFF
--- a/netbox_custom_objects/jobs.py
+++ b/netbox_custom_objects/jobs.py
@@ -42,9 +42,10 @@ class ReindexCustomObjectTypeJob(JobRunner):
 
         job = super().enqueue(*args, **kwargs)
 
-        # Persist cot_id in Job.data so it is visible in the UI and queryable for deduplication
+        # Persist cot_id in Job.data so it is visible in the UI and queryable for deduplication.
+        # Merge rather than overwrite in case super().enqueue() populates data itself.
         if job is not None:
-            job.data = {'cot_id': cot_id, 'job_class': cls.__name__}
+            job.data = {**(job.data or {}), 'cot_id': cot_id, 'job_class': cls.__name__}
             job.save(update_fields=['data'])
 
         return job
@@ -52,5 +53,8 @@ class ReindexCustomObjectTypeJob(JobRunner):
     def run(self, *args, **kwargs):
         # Deferred to avoid circular import: models.py imports this module at the top level
         from netbox_custom_objects.models import CustomObjectType
-        cot = CustomObjectType.objects.get(pk=kwargs['cot_id'])
+        cot_id = kwargs.get('cot_id')
+        if not cot_id:
+            raise ValueError('cot_id is required to run ReindexCustomObjectTypeJob')
+        cot = CustomObjectType.objects.get(pk=cot_id)
         get_backend().cache(cot.get_model().objects.all())

--- a/netbox_custom_objects/jobs.py
+++ b/netbox_custom_objects/jobs.py
@@ -1,0 +1,20 @@
+from netbox.jobs import JobRunner
+from netbox.search.backends import get_backend
+
+
+class ReindexCustomObjectTypeJob(JobRunner):
+    """
+    Background job to reindex all CustomObject instances for a given CustomObjectType.
+
+    Triggered when a CustomObjectTypeField's search_weight changes, a new searchable
+    field is added, or a searchable field is deleted.
+    """
+
+    class Meta:
+        name = 'Reindex Custom Object Type'
+
+    def run(self, *args, **kwargs):
+        # Deferred to avoid circular import: models.py imports this module at the top level
+        from netbox_custom_objects.models import CustomObjectType
+        cot = CustomObjectType.objects.get(pk=kwargs['cot_id'])
+        get_backend().cache(cot.get_model().objects.all())

--- a/netbox_custom_objects/jobs.py
+++ b/netbox_custom_objects/jobs.py
@@ -13,6 +13,42 @@ class ReindexCustomObjectTypeJob(JobRunner):
     class Meta:
         name = 'Reindex Custom Object Type'
 
+    @classmethod
+    def enqueue(cls, *args, **kwargs):
+        # All imports deferred to avoid circular import: models.py imports this module at the top level
+        from core.choices import JobStatusChoices
+        from core.models import Job
+        from netbox_custom_objects.models import CustomObjectType
+
+        cot_id = kwargs.get('cot_id')
+
+        # Deduplicate: if a pending or running job for this COT already exists, return it unchanged
+        if not kwargs.get('immediate') and cot_id is not None:
+            existing = Job.objects.filter(
+                status__in=JobStatusChoices.ENQUEUED_STATE_CHOICES,
+                data__cot_id=cot_id,
+                data__job_class=cls.__name__,
+            ).first()
+            if existing:
+                return existing
+
+        # Include the COT name in the job name for observability in the jobs list
+        if 'name' not in kwargs and cot_id is not None:
+            try:
+                cot_name = CustomObjectType.objects.values_list('name', flat=True).get(pk=cot_id)
+                kwargs['name'] = f'{cls.name}: {cot_name}'
+            except CustomObjectType.DoesNotExist:
+                pass
+
+        job = super().enqueue(*args, **kwargs)
+
+        # Persist cot_id in Job.data so it is visible in the UI and queryable for deduplication
+        if job is not None:
+            job.data = {'cot_id': cot_id, 'job_class': cls.__name__}
+            job.save(update_fields=['data'])
+
+        return job
+
     def run(self, *args, **kwargs):
         # Deferred to avoid circular import: models.py imports this module at the top level
         from netbox_custom_objects.models import CustomObjectType

--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -44,6 +44,7 @@ from netbox.models.features import (
 from netbox.plugins import get_plugin_config
 from netbox.registry import registry
 from netbox.search import SearchIndex
+from netbox.search.backends import get_backend
 from utilities import filters
 from utilities.datetime import datetime_from_timestamp
 from utilities.object_types import object_type_name
@@ -1527,6 +1528,7 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
         return f"Through_{self.through_table_name}"
 
     def save(self, *args, **kwargs):
+        is_new = self._state.adding
         field_type = FIELD_TYPE_CLASS[self.type]()
         model_field = field_type.get_model_field(self)
         model = self.custom_object_type.get_model()
@@ -1671,6 +1673,20 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
         # Reregister SearchIndex with new set of searchable fields
         self.custom_object_type.register_custom_object_search_index(model)
 
+        # Reindex all objects of this type if search indexing was affected
+        if is_new:
+            needs_reindex = self.search_weight > 0
+        else:
+            needs_reindex = self.search_weight != self.original.search_weight
+        if needs_reindex:
+            _cot_id = self.custom_object_type_id
+
+            def _reindex_on_field_save():
+                cot = CustomObjectType.objects.get(pk=_cot_id)
+                get_backend().cache(cot.get_model().objects.all())
+
+            transaction.on_commit(_reindex_on_field_save)
+
     def delete(self, *args, **kwargs):
         field_type = FIELD_TYPE_CLASS[self.type]()
         model_field = field_type.get_model_field(self)
@@ -1694,6 +1710,16 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
 
         # Reregister SearchIndex with new set of searchable fields
         self.custom_object_type.register_custom_object_search_index(model)
+
+        # Reindex all objects of this type since a searchable field was removed
+        if self.search_weight > 0:
+            _cot_id = self.custom_object_type_id
+
+            def _reindex_on_field_delete():
+                cot = CustomObjectType.objects.get(pk=_cot_id)
+                get_backend().cache(cot.get_model().objects.all())
+
+            transaction.on_commit(_reindex_on_field_delete)
 
 
 class CustomObjectObjectTypeManager(ObjectTypeManager):

--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -44,7 +44,6 @@ from netbox.models.features import (
 from netbox.plugins import get_plugin_config
 from netbox.registry import registry
 from netbox.search import SearchIndex
-from netbox.search.backends import get_backend
 from utilities import filters
 from utilities.datetime import datetime_from_timestamp
 from utilities.object_types import object_type_name
@@ -54,6 +53,7 @@ from utilities.validators import validate_regex
 
 from netbox_custom_objects.constants import APP_LABEL, RESERVED_FIELD_NAMES
 from netbox_custom_objects.field_types import FIELD_TYPE_CLASS
+from netbox_custom_objects.jobs import ReindexCustomObjectTypeJob
 from netbox_custom_objects.utilities import generate_model
 
 
@@ -1679,13 +1679,7 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
         else:
             needs_reindex = self.search_weight != self.original.search_weight
         if needs_reindex:
-            _cot_id = self.custom_object_type_id
-
-            def _reindex_on_field_save():
-                cot = CustomObjectType.objects.get(pk=_cot_id)
-                get_backend().cache(cot.get_model().objects.all())
-
-            transaction.on_commit(_reindex_on_field_save)
+            ReindexCustomObjectTypeJob.enqueue(cot_id=self.custom_object_type_id)
 
     def delete(self, *args, **kwargs):
         field_type = FIELD_TYPE_CLASS[self.type]()
@@ -1713,13 +1707,7 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
 
         # Reindex all objects of this type since a searchable field was removed
         if self.search_weight > 0:
-            _cot_id = self.custom_object_type_id
-
-            def _reindex_on_field_delete():
-                cot = CustomObjectType.objects.get(pk=_cot_id)
-                get_backend().cache(cot.get_model().objects.all())
-
-            transaction.on_commit(_reindex_on_field_delete)
+            ReindexCustomObjectTypeJob.enqueue(cot_id=self.custom_object_type_id)
 
 
 class CustomObjectObjectTypeManager(ObjectTypeManager):

--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -1679,7 +1679,8 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
         else:
             needs_reindex = self.search_weight != self.original.search_weight
         if needs_reindex:
-            ReindexCustomObjectTypeJob.enqueue(cot_id=self.custom_object_type_id)
+            _cot_id = self.custom_object_type_id
+            transaction.on_commit(lambda: ReindexCustomObjectTypeJob.enqueue(cot_id=_cot_id))
 
     def delete(self, *args, **kwargs):
         field_type = FIELD_TYPE_CLASS[self.type]()
@@ -1707,7 +1708,8 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
 
         # Reindex all objects of this type since a searchable field was removed
         if self.search_weight > 0:
-            ReindexCustomObjectTypeJob.enqueue(cot_id=self.custom_object_type_id)
+            _cot_id = self.custom_object_type_id
+            transaction.on_commit(lambda: ReindexCustomObjectTypeJob.enqueue(cot_id=_cot_id))
 
 
 class CustomObjectObjectTypeManager(ObjectTypeManager):

--- a/netbox_custom_objects/tests/test_models.py
+++ b/netbox_custom_objects/tests/test_models.py
@@ -780,19 +780,21 @@ class SearchReindexTestCase(CustomObjectsTestCase, TestCase):
         self.instance = self.model.objects.create(title="Hello World")
 
     def test_job_enqueued_on_field_weight_change(self):
-        """Changing search_weight on a field enqueues a reindex job."""
+        """Changing search_weight on a field enqueues a reindex job after the transaction commits."""
         field = CustomObjectTypeField.objects.get(pk=self.field.pk)
         field.search_weight = 100
         with patch.object(ReindexCustomObjectTypeJob, 'enqueue') as mock_enqueue:
-            field.save()
+            with self.captureOnCommitCallbacks(execute=True):
+                field.save()
         mock_enqueue.assert_called_once_with(cot_id=self.cot.pk)
 
     def test_job_enqueued_on_field_weight_zeroed(self):
-        """Changing search_weight to 0 enqueues a reindex job."""
+        """Changing search_weight to 0 enqueues a reindex job after the transaction commits."""
         field = CustomObjectTypeField.objects.get(pk=self.field.pk)
         field.search_weight = 0
         with patch.object(ReindexCustomObjectTypeJob, 'enqueue') as mock_enqueue:
-            field.save()
+            with self.captureOnCommitCallbacks(execute=True):
+                field.save()
         mock_enqueue.assert_called_once_with(cot_id=self.cot.pk)
 
     def test_job_not_enqueued_when_weight_unchanged(self):
@@ -800,39 +802,43 @@ class SearchReindexTestCase(CustomObjectsTestCase, TestCase):
         field = CustomObjectTypeField.objects.get(pk=self.field.pk)
         field.label = "Modified Title"
         with patch.object(ReindexCustomObjectTypeJob, 'enqueue') as mock_enqueue:
-            field.save()
+            with self.captureOnCommitCallbacks(execute=True):
+                field.save()
         mock_enqueue.assert_not_called()
 
     def test_job_enqueued_on_searchable_field_creation(self):
-        """Adding a new field with search_weight > 0 enqueues a reindex job."""
+        """Adding a new field with search_weight > 0 enqueues a reindex job after the transaction commits."""
         with patch.object(ReindexCustomObjectTypeJob, 'enqueue') as mock_enqueue:
-            new_field = self.create_custom_object_type_field(
-                self.cot,
-                name="subtitle",
-                label="Subtitle",
-                type="text",
-                search_weight=300,
-            )
+            with self.captureOnCommitCallbacks(execute=True):
+                new_field = self.create_custom_object_type_field(
+                    self.cot,
+                    name="subtitle",
+                    label="Subtitle",
+                    type="text",
+                    search_weight=300,
+                )
         self.addCleanup(new_field.delete)
         mock_enqueue.assert_called_once_with(cot_id=self.cot.pk)
 
     def test_job_not_enqueued_on_non_searchable_field_creation(self):
         """Adding a field with search_weight=0 does not enqueue a reindex job."""
         with patch.object(ReindexCustomObjectTypeJob, 'enqueue') as mock_enqueue:
-            non_search_field = self.create_custom_object_type_field(
-                self.cot,
-                name="notes",
-                label="Notes",
-                type="text",
-                search_weight=0,
-            )
+            with self.captureOnCommitCallbacks(execute=True):
+                non_search_field = self.create_custom_object_type_field(
+                    self.cot,
+                    name="notes",
+                    label="Notes",
+                    type="text",
+                    search_weight=0,
+                )
         self.addCleanup(non_search_field.delete)
         mock_enqueue.assert_not_called()
 
     def test_job_enqueued_on_searchable_field_deletion(self):
-        """Deleting a field with search_weight > 0 enqueues a reindex job."""
+        """Deleting a field with search_weight > 0 enqueues a reindex job after the transaction commits."""
         with patch.object(ReindexCustomObjectTypeJob, 'enqueue') as mock_enqueue:
-            self.field.delete()
+            with self.captureOnCommitCallbacks(execute=True):
+                self.field.delete()
         mock_enqueue.assert_called_once_with(cot_id=self.cot.pk)
 
     def test_job_run_updates_cached_values(self):
@@ -849,7 +855,8 @@ class SearchReindexTestCase(CustomObjectsTestCase, TestCase):
         field = CustomObjectTypeField.objects.get(pk=self.field.pk)
         field.search_weight = 100
         with patch.object(ReindexCustomObjectTypeJob, 'enqueue'):
-            field.save()
+            with self.captureOnCommitCallbacks(execute=True):
+                field.save()
 
         # Run the job synchronously via immediate=True
         ReindexCustomObjectTypeJob.enqueue(cot_id=self.cot.pk, immediate=True)

--- a/netbox_custom_objects/tests/test_models.py
+++ b/netbox_custom_objects/tests/test_models.py
@@ -7,8 +7,12 @@ from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
 
+from unittest.mock import patch
+
+from django.contrib.contenttypes.models import ContentType
 from extras.models import CachedValue
 from netbox.search.backends import get_backend
+from netbox_custom_objects.jobs import ReindexCustomObjectTypeJob
 from netbox_custom_objects.models import CustomObjectTypeField
 from core.models import ObjectType
 from .base import CustomObjectsTestCase
@@ -757,7 +761,7 @@ class CustomObjectTestCase(CustomObjectsTestCase, TestCase):
 
 
 class SearchReindexTestCase(CustomObjectsTestCase, TestCase):
-    """Test that search CachedValues are updated when CustomObjectTypeField search weights change."""
+    """Test that ReindexCustomObjectTypeJob is triggered when field search weights change."""
 
     def setUp(self):
         super().setUp()
@@ -774,44 +778,34 @@ class SearchReindexTestCase(CustomObjectsTestCase, TestCase):
         )
         self.model = self.cot.get_model()
         self.instance = self.model.objects.create(title="Hello World")
-        # Prime the search cache for the existing instance
-        get_backend().cache(self.model.objects.all())
 
-    def _cached_values_for_instance(self):
-        from django.contrib.contenttypes.models import ContentType
-        ct = ContentType.objects.get_for_model(self.model)
-        return CachedValue.objects.filter(object_type=ct, object_id=self.instance.pk)
-
-    def test_reindex_on_field_weight_change(self):
-        """Changing search_weight on a field triggers reindex of all objects."""
-        # Verify initial cache has the old weight
-        self.assertEqual(self._cached_values_for_instance().filter(field="title", weight=500).count(), 1)
-
-        # Reload from DB to get _original populated, then change search_weight
+    def test_job_enqueued_on_field_weight_change(self):
+        """Changing search_weight on a field enqueues a reindex job."""
         field = CustomObjectTypeField.objects.get(pk=self.field.pk)
         field.search_weight = 100
-        with self.captureOnCommitCallbacks(execute=True):
+        with patch.object(ReindexCustomObjectTypeJob, 'enqueue') as mock_enqueue:
             field.save()
+        mock_enqueue.assert_called_once_with(cot_id=self.cot.pk)
 
-        # CachedValues should now reflect the new weight
-        self.assertEqual(self._cached_values_for_instance().filter(field="title", weight=100).count(), 1)
-        self.assertEqual(self._cached_values_for_instance().filter(field="title", weight=500).count(), 0)
+    def test_job_enqueued_on_field_weight_zeroed(self):
+        """Changing search_weight to 0 enqueues a reindex job."""
+        field = CustomObjectTypeField.objects.get(pk=self.field.pk)
+        field.search_weight = 0
+        with patch.object(ReindexCustomObjectTypeJob, 'enqueue') as mock_enqueue:
+            field.save()
+        mock_enqueue.assert_called_once_with(cot_id=self.cot.pk)
 
-    def test_no_reindex_when_weight_unchanged(self):
-        """Saving a field without changing search_weight does not alter cached weights."""
-        # Reload from DB to get _original populated, then change only the label
+    def test_job_not_enqueued_when_weight_unchanged(self):
+        """Saving a field without changing search_weight does not enqueue a reindex job."""
         field = CustomObjectTypeField.objects.get(pk=self.field.pk)
         field.label = "Modified Title"
-        with self.captureOnCommitCallbacks(execute=True):
+        with patch.object(ReindexCustomObjectTypeJob, 'enqueue') as mock_enqueue:
             field.save()
+        mock_enqueue.assert_not_called()
 
-        # Weight should be unchanged in the cache
-        self.assertEqual(self._cached_values_for_instance().filter(field="title", weight=500).count(), 1)
-
-    def test_reindex_on_searchable_field_creation(self):
-        """Adding a new field with search_weight > 0 triggers reindex of all objects."""
-        # Add a new searchable field with a default value so existing objects get indexed
-        with self.captureOnCommitCallbacks(execute=True):
+    def test_job_enqueued_on_searchable_field_creation(self):
+        """Adding a new field with search_weight > 0 enqueues a reindex job."""
+        with patch.object(ReindexCustomObjectTypeJob, 'enqueue') as mock_enqueue:
             new_field = self.create_custom_object_type_field(
                 self.cot,
                 name="subtitle",
@@ -819,18 +813,12 @@ class SearchReindexTestCase(CustomObjectsTestCase, TestCase):
                 type="text",
                 search_weight=300,
             )
+        self.addCleanup(new_field.delete)
+        mock_enqueue.assert_called_once_with(cot_id=self.cot.pk)
 
-        # The instance won't have a value for the new field (no default), but
-        # the reindex should have run without error and the existing field remains cached
-        self.assertEqual(self._cached_values_for_instance().filter(field="title", weight=500).count(), 1)
-
-        new_field.delete()
-
-    def test_no_reindex_on_non_searchable_field_creation(self):
-        """Adding a field with search_weight=0 does not trigger a reindex."""
-        initial_count = self._cached_values_for_instance().count()
-
-        with self.captureOnCommitCallbacks(execute=False) as callbacks:
+    def test_job_not_enqueued_on_non_searchable_field_creation(self):
+        """Adding a field with search_weight=0 does not enqueue a reindex job."""
+        with patch.object(ReindexCustomObjectTypeJob, 'enqueue') as mock_enqueue:
             non_search_field = self.create_custom_object_type_field(
                 self.cot,
                 name="notes",
@@ -838,20 +826,39 @@ class SearchReindexTestCase(CustomObjectsTestCase, TestCase):
                 type="text",
                 search_weight=0,
             )
+        self.addCleanup(non_search_field.delete)
+        mock_enqueue.assert_not_called()
 
-        # No on_commit callbacks should have been registered for reindexing
-        self.assertEqual(len(callbacks), 0)
-        self.assertEqual(self._cached_values_for_instance().count(), initial_count)
-
-        non_search_field.delete()
-
-    def test_reindex_on_searchable_field_deletion(self):
-        """Deleting a field with search_weight > 0 triggers reindex of all objects."""
-        # Verify the field is currently indexed
-        self.assertEqual(self._cached_values_for_instance().filter(field="title").count(), 1)
-
-        with self.captureOnCommitCallbacks(execute=True):
+    def test_job_enqueued_on_searchable_field_deletion(self):
+        """Deleting a field with search_weight > 0 enqueues a reindex job."""
+        with patch.object(ReindexCustomObjectTypeJob, 'enqueue') as mock_enqueue:
             self.field.delete()
+        mock_enqueue.assert_called_once_with(cot_id=self.cot.pk)
 
-        # After deletion and reindex, no CachedValues for this field should remain
-        self.assertEqual(self._cached_values_for_instance().filter(field="title").count(), 0)
+    def test_job_run_updates_cached_values(self):
+        """The job's run() method re-caches all objects using the updated SearchIndex."""
+        # Prime the cache with the initial weight
+        get_backend().cache(self.model.objects.all())
+        ct = ContentType.objects.get_for_model(self.model)
+        self.assertEqual(
+            CachedValue.objects.filter(object_type=ct, object_id=self.instance.pk, field="title", weight=500).count(),
+            1,
+        )
+
+        # Save the field with a new weight (suppress automatic enqueue)
+        field = CustomObjectTypeField.objects.get(pk=self.field.pk)
+        field.search_weight = 100
+        with patch.object(ReindexCustomObjectTypeJob, 'enqueue'):
+            field.save()
+
+        # Run the job synchronously via immediate=True
+        ReindexCustomObjectTypeJob.enqueue(cot_id=self.cot.pk, immediate=True)
+
+        self.assertEqual(
+            CachedValue.objects.filter(object_type=ct, object_id=self.instance.pk, field="title", weight=100).count(),
+            1,
+        )
+        self.assertEqual(
+            CachedValue.objects.filter(object_type=ct, object_id=self.instance.pk, field="title", weight=500).count(),
+            0,
+        )

--- a/netbox_custom_objects/tests/test_models.py
+++ b/netbox_custom_objects/tests/test_models.py
@@ -9,7 +9,7 @@ from django.utils import timezone
 
 from extras.models import CachedValue
 from netbox.search.backends import get_backend
-from netbox_custom_objects.models import CustomObjectType, CustomObjectTypeField
+from netbox_custom_objects.models import CustomObjectTypeField
 from core.models import ObjectType
 from .base import CustomObjectsTestCase
 

--- a/netbox_custom_objects/tests/test_models.py
+++ b/netbox_custom_objects/tests/test_models.py
@@ -1,4 +1,5 @@
 from unittest import skip
+from unittest.mock import patch
 from decimal import Decimal
 
 from django.core.exceptions import ValidationError
@@ -7,7 +8,6 @@ from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
 
-from unittest.mock import patch
 
 from django.contrib.contenttypes.models import ContentType
 from extras.models import CachedValue
@@ -862,3 +862,33 @@ class SearchReindexTestCase(CustomObjectsTestCase, TestCase):
             CachedValue.objects.filter(object_type=ct, object_id=self.instance.pk, field="title", weight=500).count(),
             0,
         )
+
+    def test_job_name_includes_cot_name(self):
+        """Enqueued job name includes the COT name for observability."""
+        from core.models import Job
+        job = ReindexCustomObjectTypeJob.enqueue(cot_id=self.cot.pk, immediate=True)
+        self.assertEqual(job.name, f'Reindex Custom Object Type: {self.cot.name}')
+
+    def test_job_data_contains_cot_id(self):
+        """Job.data is populated with cot_id and job_class for UI visibility and deduplication."""
+        from core.models import Job
+        job = ReindexCustomObjectTypeJob.enqueue(cot_id=self.cot.pk, immediate=True)
+        self.assertEqual(job.data['cot_id'], self.cot.pk)
+        self.assertEqual(job.data['job_class'], 'ReindexCustomObjectTypeJob')
+
+    def test_duplicate_job_not_enqueued(self):
+        """A second enqueue for the same COT returns the existing pending job without creating a new one."""
+        from core.choices import JobStatusChoices
+        from core.models import Job
+
+        with patch('django_rq.get_queue'):
+            first_job = ReindexCustomObjectTypeJob.enqueue(cot_id=self.cot.pk)
+        # Simulate the first job still pending
+        first_job.status = JobStatusChoices.STATUS_PENDING
+        first_job.save(update_fields=['status'])
+
+        with patch('django_rq.get_queue'):
+            second_job = ReindexCustomObjectTypeJob.enqueue(cot_id=self.cot.pk)
+
+        self.assertEqual(first_job.pk, second_job.pk)
+        self.assertEqual(Job.objects.filter(data__cot_id=self.cot.pk).count(), 1)

--- a/netbox_custom_objects/tests/test_models.py
+++ b/netbox_custom_objects/tests/test_models.py
@@ -865,13 +865,11 @@ class SearchReindexTestCase(CustomObjectsTestCase, TestCase):
 
     def test_job_name_includes_cot_name(self):
         """Enqueued job name includes the COT name for observability."""
-        from core.models import Job
         job = ReindexCustomObjectTypeJob.enqueue(cot_id=self.cot.pk, immediate=True)
         self.assertEqual(job.name, f'Reindex Custom Object Type: {self.cot.name}')
 
     def test_job_data_contains_cot_id(self):
         """Job.data is populated with cot_id and job_class for UI visibility and deduplication."""
-        from core.models import Job
         job = ReindexCustomObjectTypeJob.enqueue(cot_id=self.cot.pk, immediate=True)
         self.assertEqual(job.data['cot_id'], self.cot.pk)
         self.assertEqual(job.data['job_class'], 'ReindexCustomObjectTypeJob')

--- a/netbox_custom_objects/tests/test_models.py
+++ b/netbox_custom_objects/tests/test_models.py
@@ -7,7 +7,9 @@ from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
 
-from netbox_custom_objects.models import CustomObjectTypeField
+from extras.models import CachedValue
+from netbox.search.backends import get_backend
+from netbox_custom_objects.models import CustomObjectType, CustomObjectTypeField
 from core.models import ObjectType
 from .base import CustomObjectsTestCase
 
@@ -752,3 +754,104 @@ class CustomObjectTestCase(CustomObjectsTestCase, TestCase):
 
         # Verify it's gone
         self.assertEqual(self.model.objects.count(), 0)
+
+
+class SearchReindexTestCase(CustomObjectsTestCase, TestCase):
+    """Test that search CachedValues are updated when CustomObjectTypeField search weights change."""
+
+    def setUp(self):
+        super().setUp()
+        self.cot = self.create_custom_object_type(
+            name="ReindexTest",
+            slug="reindex-test",
+        )
+        self.field = self.create_custom_object_type_field(
+            self.cot,
+            name="title",
+            label="Title",
+            type="text",
+            search_weight=500,
+        )
+        self.model = self.cot.get_model()
+        self.instance = self.model.objects.create(title="Hello World")
+        # Prime the search cache for the existing instance
+        get_backend().cache(self.model.objects.all())
+
+    def _cached_values_for_instance(self):
+        from django.contrib.contenttypes.models import ContentType
+        ct = ContentType.objects.get_for_model(self.model)
+        return CachedValue.objects.filter(object_type=ct, object_id=self.instance.pk)
+
+    def test_reindex_on_field_weight_change(self):
+        """Changing search_weight on a field triggers reindex of all objects."""
+        # Verify initial cache has the old weight
+        self.assertEqual(self._cached_values_for_instance().filter(field="title", weight=500).count(), 1)
+
+        # Reload from DB to get _original populated, then change search_weight
+        field = CustomObjectTypeField.objects.get(pk=self.field.pk)
+        field.search_weight = 100
+        with self.captureOnCommitCallbacks(execute=True):
+            field.save()
+
+        # CachedValues should now reflect the new weight
+        self.assertEqual(self._cached_values_for_instance().filter(field="title", weight=100).count(), 1)
+        self.assertEqual(self._cached_values_for_instance().filter(field="title", weight=500).count(), 0)
+
+    def test_no_reindex_when_weight_unchanged(self):
+        """Saving a field without changing search_weight does not alter cached weights."""
+        # Reload from DB to get _original populated, then change only the label
+        field = CustomObjectTypeField.objects.get(pk=self.field.pk)
+        field.label = "Modified Title"
+        with self.captureOnCommitCallbacks(execute=True):
+            field.save()
+
+        # Weight should be unchanged in the cache
+        self.assertEqual(self._cached_values_for_instance().filter(field="title", weight=500).count(), 1)
+
+    def test_reindex_on_searchable_field_creation(self):
+        """Adding a new field with search_weight > 0 triggers reindex of all objects."""
+        # Add a new searchable field with a default value so existing objects get indexed
+        with self.captureOnCommitCallbacks(execute=True):
+            new_field = self.create_custom_object_type_field(
+                self.cot,
+                name="subtitle",
+                label="Subtitle",
+                type="text",
+                search_weight=300,
+            )
+
+        # The instance won't have a value for the new field (no default), but
+        # the reindex should have run without error and the existing field remains cached
+        self.assertEqual(self._cached_values_for_instance().filter(field="title", weight=500).count(), 1)
+
+        new_field.delete()
+
+    def test_no_reindex_on_non_searchable_field_creation(self):
+        """Adding a field with search_weight=0 does not trigger a reindex."""
+        initial_count = self._cached_values_for_instance().count()
+
+        with self.captureOnCommitCallbacks(execute=False) as callbacks:
+            non_search_field = self.create_custom_object_type_field(
+                self.cot,
+                name="notes",
+                label="Notes",
+                type="text",
+                search_weight=0,
+            )
+
+        # No on_commit callbacks should have been registered for reindexing
+        self.assertEqual(len(callbacks), 0)
+        self.assertEqual(self._cached_values_for_instance().count(), initial_count)
+
+        non_search_field.delete()
+
+    def test_reindex_on_searchable_field_deletion(self):
+        """Deleting a field with search_weight > 0 triggers reindex of all objects."""
+        # Verify the field is currently indexed
+        self.assertEqual(self._cached_values_for_instance().filter(field="title").count(), 1)
+
+        with self.captureOnCommitCallbacks(execute=True):
+            self.field.delete()
+
+        # After deletion and reindex, no CachedValues for this field should remain
+        self.assertEqual(self._cached_values_for_instance().filter(field="title").count(), 0)


### PR DESCRIPTION
### Fixes: #394 

When custom object fields are updated (changing their search weights), custom objects of that type will now have their cached search values reindexed accordingly.

The reindex process is handled as a background RQ job to avoid blocking on large data sets.