### PR TITLE
Closes: #395 - Expand unit tests

### DIFF
--- a/netbox_custom_objects/tests/base.py
+++ b/netbox_custom_objects/tests/base.py
@@ -7,6 +7,22 @@ from utilities.testing import create_test_user
 from netbox_custom_objects.models import CustomObjectType, CustomObjectTypeField
 
 
+class TransactionCleanupMixin:
+    """Mixin for TransactionTestCase subclasses that create CustomObjectType instances.
+
+    Deletes all COTs in tearDown so their backing tables are dropped before the
+    database flush that TransactionTestCase performs between tests.
+    """
+
+    def tearDown(self):
+        for cot in CustomObjectType.objects.all():
+            try:
+                cot.delete()
+            except Exception as exc:
+                print(f"WARNING: tearDown could not delete COT {cot.pk}: {exc}")
+        super().tearDown()
+
+
 class CustomObjectsTestCase:
     """
     Base test case for custom objects tests.

--- a/netbox_custom_objects/tests/test_api.py
+++ b/netbox_custom_objects/tests/test_api.py
@@ -302,8 +302,9 @@ class CustomObjectTest(CustomObjectsTestCase, APIViewTestCases.APIViewTestCase):
 
         devices = Device.objects.all()
 
+        # custom_object_type3 (ComplexObject) uses 'name' as its primary text field
         data = {
-            'test_field': 'Test 004',
+            'name': 'Test Nested 001',
             'device': devices[0].id,
             'devices': [devices[1].id, devices[2].id],
         }
@@ -317,11 +318,12 @@ class CustomObjectTest(CustomObjectsTestCase, APIViewTestCases.APIViewTestCase):
         self.assertHttpStatus(response, status.HTTP_201_CREATED)
         self.assertEqual(self._get_queryset().count(), initial_count + 1)
         instance = self._get_queryset().get(pk=response.data['id'])
-        self.assertInstanceEqual(
-            instance,
-            self.create_data[0],
-            exclude=self.validation_excluded_fields,
-            api=True
+        # Assert all fields sent in data, including the nested FK and M2M object fields
+        self.assertEqual(instance.name, data['name'])
+        self.assertEqual(instance.device_id, data['device'])
+        self.assertSetEqual(
+            set(instance.devices.values_list('id', flat=True)),
+            set(data['devices']),
         )
 
     # TODO: GraphQL

--- a/netbox_custom_objects/tests/test_api.py
+++ b/netbox_custom_objects/tests/test_api.py
@@ -1,3 +1,6 @@
+"""
+Tests for API code paths.
+"""
 from django.test import TestCase
 from django.urls import reverse
 
@@ -173,22 +176,111 @@ class CustomObjectTest(CustomObjectsTestCase, APIViewTestCases.APIViewTestCase):
         viewname = 'plugins-api:netbox_custom_objects-api:customobject-list'
         return reverse(viewname, kwargs={'custom_object_type': self.custom_object_type1.slug})
 
+    def _add_permission(self, action, name=None):
+        """Grant the test user a permission for the current model."""
+        perm = ObjectPermission(
+            name=name or f'Test {action} permission',
+            actions=[action],
+        )
+        perm.save()
+        perm.users.add(self.user)
+        perm.object_types.add(ObjectType.objects.get_for_model(self.model))
+        return perm
+
     def test_list_objects(self):
-        # TODO: Needs filtering by pk to work
-        ...
+        """GET the list URL returns only objects for the requested COT."""
+        self._add_permission('view', 'List view perm')
+
+        response = self.client.get(self._get_list_url(), **self.header)
+
+        self.assertHttpStatus(response, 200)
+        # The three objects created in setUpTestData must be present.
+        self.assertGreaterEqual(response.data['count'], 3)
 
     def test_bulk_create_objects(self):
-        ...
+        """Create multiple objects with required fields via individual POST requests.
+
+        CustomObjectViewSet uses a standard DRF ModelViewSet which does not expose a
+        bulk-create endpoint, so we exercise per-object creation to verify required
+        field enforcement and response shape.
+        """
+        self._add_permission('add', 'Bulk create perm')
+
+        initial_count = self._get_queryset().count()
+        for data in self.create_data:
+            response = self.client.post(
+                self._get_list_url(), data, format='json', **self.header
+            )
+            self.assertHttpStatus(response, 201)
+
+        self.assertEqual(self._get_queryset().count(), initial_count + len(self.create_data))
 
     def test_bulk_delete_objects(self):
-        ...
+        """Delete multiple objects via individual DELETE requests.
+
+        CustomObjectViewSet uses a standard DRF ModelViewSet which does not expose a
+        bulk-delete endpoint, so we exercise per-object deletion.
+        """
+        self._add_permission('delete', 'Bulk delete perm')
+
+        initial_count = self._get_queryset().count()
+        self.assertGreaterEqual(initial_count, 2, "Need at least 2 objects to test bulk delete.")
+        instances = list(self._get_queryset()[:2])
+
+        for instance in instances:
+            response = self.client.delete(self._get_detail_url(instance), **self.header)
+            self.assertHttpStatus(response, 204)
+
+        self.assertEqual(self._get_queryset().count(), initial_count - 2)
+        for instance in instances:
+            self.assertFalse(
+                self._get_queryset().filter(pk=instance.pk).exists(),
+                f"Object {instance.pk} should have been deleted.",
+            )
 
     def test_bulk_update_objects(self):
-        ...
+        """Partial-update (PATCH) multiple objects — required fields are not enforced.
+
+        CustomObjectViewSet uses a standard DRF ModelViewSet which does not expose a
+        bulk-update endpoint, so we exercise per-object PATCH to verify that required
+        fields need not be re-supplied on each update.
+        """
+        self._add_permission('change', 'Bulk update perm')
+
+        instances = list(self._get_queryset()[:2])
+        updates = {
+            instances[0].pk: 'Updated 001',
+            instances[1].pk: 'Updated 002',
+        }
+
+        for instance in instances:
+            response = self.client.patch(
+                self._get_detail_url(instance),
+                {'test_field': updates[instance.pk]},
+                format='json',
+                **self.header,
+            )
+            self.assertHttpStatus(response, 200)
+
+        instances[0].refresh_from_db()
+        instances[1].refresh_from_db()
+        self.assertEqual(instances[0].test_field, 'Updated 001')
+        self.assertEqual(instances[1].test_field, 'Updated 002')
 
     def test_delete_object(self):
-        # TODO: ObjectChange causes failure
-        ...
+        """DELETE a single object returns 204 and removes the record."""
+        self._add_permission('delete', 'Delete perm')
+
+        instance = self._get_queryset().first()
+        url = self._get_detail_url(instance)
+
+        response = self.client.delete(url, **self.header)
+
+        self.assertHttpStatus(response, 204)
+        self.assertFalse(
+            self._get_queryset().filter(pk=instance.pk).exists(),
+            "Deleted object should no longer exist in the database.",
+        )
 
     def test_create_with_nested_serializers(self):
         """
@@ -559,3 +651,121 @@ class CustomObjectTypeFieldObjectResolutionTest(CustomObjectsTestCase, TestCase)
         """An unknown app_label must still return 400."""
         response = self._post_field('invalid-app', self._internal_model_name())
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+
+class SerializerFieldCoverageTest(CustomObjectsTestCase, TestCase):
+    """
+    Verify that the dynamic serializer produced by get_serializer_class() exposes
+    the expected fields in API responses.
+    """
+
+    def setUp(self):
+        self.user = create_test_user('serluser')
+        token_key = create_token(self.user)
+        self.header = {'HTTP_AUTHORIZATION': f'Token {token_key}'}
+
+        self.cot = CustomObjectsTestCase.create_custom_object_type(
+            name='SerializerTest', slug='serializer-test'
+        )
+        # Primary text field
+        CustomObjectsTestCase.create_custom_object_type_field(
+            self.cot,
+            name='label',
+            label='Label',
+            type='text',
+            primary=True,
+            required=True,
+        )
+        # Integer field
+        CustomObjectsTestCase.create_custom_object_type_field(
+            self.cot,
+            name='count',
+            label='Count',
+            type='integer',
+        )
+        # Object field (device)
+        device_ct = CustomObjectsTestCase.get_device_object_type()
+        CustomObjectsTestCase.create_custom_object_type_field(
+            self.cot,
+            name='device',
+            label='Device',
+            type='object',
+            related_object_type=device_ct,
+        )
+
+        self.model = self.cot.get_model()
+
+        obj_perm = ObjectPermission(name='Serializer view perm', actions=['view'])
+        obj_perm.save()
+        obj_perm.users.add(self.user)
+        obj_perm.object_types.add(ObjectType.objects.get_for_model(self.model))
+
+    def tearDown(self):
+        CustomObjectType.clear_model_cache()
+        super().tearDown()
+
+    def _list_url(self):
+        return reverse(
+            'plugins-api:netbox_custom_objects-api:customobject-list',
+            kwargs={'custom_object_type': self.cot.slug},
+        )
+
+    def _detail_url(self, instance):
+        return reverse(
+            'plugins-api:netbox_custom_objects-api:customobject-detail',
+            kwargs={'pk': instance.pk, 'custom_object_type': self.cot.slug},
+        )
+
+    def test_detail_response_contains_netbox_standard_fields(self):
+        """Detail response must include the standard NetBox envelope fields."""
+        instance = self.model.objects.create(label='Test Instance', count=5)
+        response = self.client.get(self._detail_url(instance), **self.header)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for field in ('id', 'url', 'display', 'created', 'last_updated', 'tags'):
+            self.assertIn(field, response.data, f"Standard field '{field}' missing from response")
+
+    def test_detail_response_contains_custom_fields(self):
+        """Detail response includes fields defined on the COT."""
+        instance = self.model.objects.create(label='My Label', count=42)
+        response = self.client.get(self._detail_url(instance), **self.header)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('label', response.data)
+        self.assertEqual(response.data['label'], 'My Label')
+        self.assertIn('count', response.data)
+        self.assertEqual(response.data['count'], 42)
+
+    def test_detail_response_contains_object_field(self):
+        """Object fields (FK) are serialised as nested representations."""
+        instance = self.model.objects.create(label='Device Holder')
+        response = self.client.get(self._detail_url(instance), **self.header)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('device', response.data)
+        # When no device is set the field must be present but null
+        self.assertIsNone(response.data['device'])
+
+    def test_list_response_shape(self):
+        """List response wraps results in count/next/previous/results envelope."""
+        self.model.objects.create(label='A')
+        self.model.objects.create(label='B')
+        response = self.client.get(self._list_url(), **self.header)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for key in ('count', 'next', 'previous', 'results'):
+            self.assertIn(key, response.data, f"Envelope key '{key}' missing from list response")
+        self.assertGreaterEqual(response.data['count'], 2)
+
+    def test_url_field_is_absolute(self):
+        """The 'url' field in the response must be an absolute HTTP URL."""
+        instance = self.model.objects.create(label='URL Test')
+        response = self.client.get(self._detail_url(instance), **self.header)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        url_value = response.data.get('url', '')
+        self.assertRegex(
+            url_value,
+            r'^https?://',
+            f"'url' field should be an absolute HTTP(S) URL, got: {url_value!r}",
+        )

--- a/netbox_custom_objects/tests/test_deletion.py
+++ b/netbox_custom_objects/tests/test_deletion.py
@@ -1,0 +1,224 @@
+"""
+Tests for deletion scenarios with cascading effects.
+
+Uses TransactionTestCase so that DDL statements (CREATE/DROP TABLE) issued during
+setup and teardown are not wrapped in Django's per-test rollback transaction.  That
+lets us verify table-level changes and FK CASCADE behaviour that cannot be observed
+inside a rolled-back savepoint.
+"""
+from django.apps import apps as django_apps
+from django.db import connection
+from django.test import TransactionTestCase
+
+from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site
+from netbox_custom_objects.constants import APP_LABEL
+from netbox_custom_objects.models import CustomObjectType, CustomObjectTypeField
+
+from .base import CustomObjectsTestCase
+
+
+class DeletionTestCase(CustomObjectsTestCase, TransactionTestCase):
+    """Test deletion scenarios with cascading effects."""
+
+    def setUp(self):
+        """Purge stale dynamic models left in the app registry by earlier TestCase
+        classes whose setUpTestData transaction was rolled back (dropping the backing
+        tables).  Leaving them registered causes Django's cascade-delete collector to
+        query non-existent tables when a related core object is deleted.
+        """
+        super().setUp()
+        stale = [
+            name
+            for name, model in list(django_apps.all_models.get(APP_LABEL, {}).items())
+            if getattr(model, '_generated_table_model', False)
+        ]
+        for name in stale:
+            django_apps.all_models[APP_LABEL].pop(name, None)
+        if stale:
+            django_apps.clear_cache()
+
+    def tearDown(self):
+        """Remove any COTs that were not deleted as part of the test so that
+        their backing tables are dropped before the database flush."""
+        for cot in CustomObjectType.objects.all():
+            try:
+                cot.delete()
+            except Exception as exc:
+                # Log but do not re-raise: tearDown must not mask the original
+                # test failure.  A best-effort cleanup is still better than none.
+                print(f"WARNING: tearDown could not delete COT {cot.pk}: {exc}")
+        super().tearDown()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _table_exists(self, table_name):
+        with connection.cursor() as cursor:
+            return table_name in connection.introspection.table_names(cursor)
+
+    def _field_exists_on_model(self, model, field_name):
+        return field_name in {f.name for f in model._meta.get_fields()}
+
+    # ------------------------------------------------------------------
+    # Tests
+    # ------------------------------------------------------------------
+
+    def test_delete_cot_with_instances(self):
+        """#140 – Deleting a COT must drop the backing table (and therefore all instances)."""
+        cot = self.create_simple_custom_object_type(name='deltest', slug='del-test')
+        model = cot.get_model()
+        table_name = cot.get_database_table_name()
+
+        model_name = model.__name__.lower()
+        model.objects.create(name='Instance 1')
+        model.objects.create(name='Instance 2')
+        self.assertEqual(model.objects.count(), 2)
+        self.assertTrue(self._table_exists(table_name))
+        self.assertIn(model_name, django_apps.all_models.get(APP_LABEL, {}))
+
+        cot.delete()
+
+        self.assertFalse(
+            self._table_exists(table_name),
+            f"Table '{table_name}' should have been dropped when the COT was deleted.",
+        )
+        self.assertNotIn(
+            model_name,
+            django_apps.all_models.get(APP_LABEL, {}),
+            "Deleted COT's model must be removed from the app registry.",
+        )
+
+    def test_delete_co_referenced_by_another_co(self):
+        """#283 – Deleting a CO that is the target of an object field should CASCADE."""
+        cot_a = self.create_simple_custom_object_type(name='typea', slug='type-a')
+        cot_b = self.create_simple_custom_object_type(name='typeb', slug='type-b')
+
+        # cot_b.ref_a → cot_a (FK CASCADE via _ensure_field_fk_constraint)
+        self.create_custom_object_type_field(
+            cot_b,
+            name='ref_a',
+            label='Reference A',
+            type='object',
+            related_object_type=cot_a.object_type,
+        )
+
+        model_a = cot_a.get_model()
+        model_b = cot_b.get_model()
+
+        obj_a = model_a.objects.create(name='Object A')
+        obj_b = model_b.objects.create(name='Object B', ref_a=obj_a)
+        self.assertEqual(obj_b.ref_a_id, obj_a.pk)
+
+        # Deleting obj_a should cascade and remove obj_b
+        obj_a.delete()
+
+        self.assertFalse(
+            model_b.objects.filter(pk=obj_b.pk).exists(),
+            "Custom Object B should have been deleted by FK CASCADE when Object A was deleted.",
+        )
+
+    def test_delete_cot_referenced_by_another_cot(self):
+        """#183 – Deleting a COT must also clean up object fields in other COTs that reference it."""
+        cot_target = self.create_simple_custom_object_type(name='target', slug='target-type')
+        cot_source = self.create_simple_custom_object_type(name='source', slug='source-type')
+
+        ref_field = self.create_custom_object_type_field(
+            cot_source,
+            name='ref_target',
+            label='Reference Target',
+            type='object',
+            related_object_type=cot_target.object_type,
+        )
+        ref_field_id = ref_field.id
+
+        # Deleting the target COT must remove the field that references it
+        cot_target.delete()
+
+        self.assertFalse(
+            CustomObjectTypeField.objects.filter(pk=ref_field_id).exists(),
+            "Field referencing the deleted COT should have been removed.",
+        )
+        # The source COT itself must survive
+        self.assertTrue(CustomObjectType.objects.filter(pk=cot_source.pk).exists())
+
+    def test_delete_cotf_with_data(self):
+        """#367 – Deleting a field whose instances already contain data should succeed."""
+        cot = self.create_simple_custom_object_type(name='fielddeltest', slug='field-del-test')
+
+        extra_field = self.create_custom_object_type_field(
+            cot,
+            name='extra',
+            label='Extra',
+            type='text',
+        )
+        model = cot.get_model()
+
+        model.objects.create(name='Item 1', extra='value1')
+        model.objects.create(name='Item 2', extra='value2')
+
+        # Deletion should not raise even though rows contain data in 'extra'
+        extra_field.delete()
+
+        # Regenerate the model and confirm the column is gone
+        cot.clear_model_cache(cot.id)
+        fresh_model = cot.get_model()
+
+        self.assertFalse(
+            self._field_exists_on_model(fresh_model, 'extra'),
+            "Field 'extra' should no longer appear on the model after deletion.",
+        )
+        # Existing rows must still be accessible
+        self.assertEqual(fresh_model.objects.count(), 2)
+
+    def test_delete_referenced_core_object(self):
+        """Deleting a core NetBox object must CASCADE to COs that reference it via an object field.
+
+        The cascade is enforced at the database level via the ON DELETE CASCADE FK constraint
+        added by _ensure_field_fk_constraint().  We use a raw-SQL DELETE to bypass Django's
+        Python-level cascade collector, which can fail when stale dynamic models from other
+        test classes remain in the app registry but their backing tables have been dropped.
+        This approach also proves the database constraint is actually in effect.
+        """
+        site = Site.objects.create(name='Del Test Site', slug='del-test-site')
+        manufacturer = Manufacturer.objects.create(name='Del Test Mfr', slug='del-test-mfr')
+        device_type = DeviceType.objects.create(
+            manufacturer=manufacturer, model='Del Test Type', slug='del-test-type'
+        )
+        role = DeviceRole.objects.create(
+            name='Del Test Role', slug='del-test-role', color='aaaaaa'
+        )
+        device = Device.objects.create(
+            name='Del Test Device', site=site, device_type=device_type, role=role
+        )
+
+        cot = self.create_simple_custom_object_type(name='devref', slug='dev-ref')
+        self.create_custom_object_type_field(
+            cot,
+            name='device',
+            label='Device',
+            type='object',
+            related_object_type=self.get_device_object_type(),
+        )
+        model = cot.get_model()
+
+        co = model.objects.create(name='CO with Device', device=device)
+        self.assertEqual(co.device_id, device.pk)
+
+        # Delete the device via raw SQL to exercise the database-level FK CASCADE
+        # constraint directly, bypassing Django's Python cascade collector (which can
+        # be confused by stale dynamic models left in the app registry by other tests).
+        device_pk = device.pk
+        with connection.cursor() as cursor:
+            cursor.execute('DELETE FROM dcim_device WHERE id = %s', [device_pk])
+
+        # Verify the device row is actually gone.
+        self.assertFalse(
+            Device.objects.filter(pk=device_pk).exists(),
+            "Device should have been deleted by the raw SQL DELETE.",
+        )
+        # The custom object must have been removed by the DB-level FK CASCADE.
+        self.assertFalse(
+            model.objects.filter(pk=co.pk).exists(),
+            "Custom Object should have been deleted by the DB-level FK CASCADE when Device was deleted.",
+        )

--- a/netbox_custom_objects/tests/test_deletion.py
+++ b/netbox_custom_objects/tests/test_deletion.py
@@ -14,10 +14,10 @@ from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site
 from netbox_custom_objects.constants import APP_LABEL
 from netbox_custom_objects.models import CustomObjectType, CustomObjectTypeField
 
-from .base import CustomObjectsTestCase
+from .base import CustomObjectsTestCase, TransactionCleanupMixin
 
 
-class DeletionTestCase(CustomObjectsTestCase, TransactionTestCase):
+class DeletionTestCase(TransactionCleanupMixin, CustomObjectsTestCase, TransactionTestCase):
     """Test deletion scenarios with cascading effects."""
 
     def setUp(self):
@@ -36,18 +36,6 @@ class DeletionTestCase(CustomObjectsTestCase, TransactionTestCase):
             django_apps.all_models[APP_LABEL].pop(name, None)
         if stale:
             django_apps.clear_cache()
-
-    def tearDown(self):
-        """Remove any COTs that were not deleted as part of the test so that
-        their backing tables are dropped before the database flush."""
-        for cot in CustomObjectType.objects.all():
-            try:
-                cot.delete()
-            except Exception as exc:
-                # Log but do not re-raise: tearDown must not mask the original
-                # test failure.  A best-effort cleanup is still better than none.
-                print(f"WARNING: tearDown could not delete COT {cot.pk}: {exc}")
-        super().tearDown()
 
     # ------------------------------------------------------------------
     # Helpers

--- a/netbox_custom_objects/tests/test_field_types.py
+++ b/netbox_custom_objects/tests/test_field_types.py
@@ -73,14 +73,13 @@ class TextFieldTypeTestCase(FieldTypeTestCase):
 
     def test_text_field_model_generation(self):
         """Test text field model generation."""
-        field = self.create_custom_object_type_field(
+        self.create_custom_object_type_field(
             self.custom_object_type,
             name="description",
             label="Description",
             type="text",
             required=True
         )
-        field  # To silence ruff error
 
         model = self.custom_object_type.get_model()
         instance = model.objects.create(name="Test", description="Test description")
@@ -105,13 +104,12 @@ class LongTextFieldTypeTestCase(FieldTypeTestCase):
 
     def test_long_text_field_model_generation(self):
         """Test long text field model generation."""
-        field = self.create_custom_object_type_field(
+        self.create_custom_object_type_field(
             self.custom_object_type,
             name="content",
             label="Content",
             type="longtext"
         )
-        field  # To silence ruff error
 
         model = self.custom_object_type.get_model()
         long_content = "This is a very long text content that should be stored in a TextField."
@@ -168,14 +166,13 @@ class IntegerFieldTypeTestCase(FieldTypeTestCase):
 
     def test_integer_field_model_generation(self):
         """Test integer field model generation."""
-        field = self.create_custom_object_type_field(
+        self.create_custom_object_type_field(
             self.custom_object_type,
             name="count",
             label="Count",
             type="integer",
             default=10
         )
-        field  # To silence ruff error
 
         model = self.custom_object_type.get_model()
         instance = model.objects.create(name="Test", count=25)
@@ -231,14 +228,13 @@ class DecimalFieldTypeTestCase(FieldTypeTestCase):
 
     def test_decimal_field_model_generation(self):
         """Test decimal field model generation."""
-        field = self.create_custom_object_type_field(
+        self.create_custom_object_type_field(
             self.custom_object_type,
             name="price",
             label="Price",
             type="decimal",
             default=10.50
         )
-        field  # To silence ruff error
 
         model = self.custom_object_type.get_model()
         instance = model.objects.create(name="Test", price=Decimal("25.75"))
@@ -283,14 +279,13 @@ class BooleanFieldTypeTestCase(FieldTypeTestCase):
 
     def test_boolean_field_model_generation(self):
         """Test boolean field model generation."""
-        field = self.create_custom_object_type_field(
+        self.create_custom_object_type_field(
             self.custom_object_type,
             name="active",
             label="Active",
             type="boolean",
             default=True
         )
-        field  # To silence ruff error
 
         model = self.custom_object_type.get_model()
         instance = model.objects.create(name="Test", active=False)
@@ -335,13 +330,12 @@ class DateFieldTypeTestCase(FieldTypeTestCase):
 
     def test_date_field_model_generation(self):
         """Test date field model generation."""
-        field = self.create_custom_object_type_field(
+        self.create_custom_object_type_field(
             self.custom_object_type,
             name="created_date",
             label="Created Date",
             type="date"
         )
-        field  # To silence ruff error
 
         model = self.custom_object_type.get_model()
         test_date = date(2023, 1, 1)
@@ -387,13 +381,12 @@ class DateTimeFieldTypeTestCase(FieldTypeTestCase):
 
     def test_datetime_field_model_generation(self):
         """Test datetime field model generation."""
-        field = self.create_custom_object_type_field(
+        self.create_custom_object_type_field(
             self.custom_object_type,
             name="created_datetime",
             label="Created DateTime",
             type="datetime"
         )
-        field  # To silence ruff error
 
         model = self.custom_object_type.get_model()
         test_datetime = datetime(2023, 1, 1, 12, 0, 0)
@@ -438,13 +431,12 @@ class URLFieldTypeTestCase(FieldTypeTestCase):
 
     def test_url_field_model_generation(self):
         """Test URL field model generation."""
-        field = self.create_custom_object_type_field(
+        self.create_custom_object_type_field(
             self.custom_object_type,
             name="website",
             label="Website",
             type="url"
         )
-        field  # To silence ruff error
 
         model = self.custom_object_type.get_model()
         instance = model.objects.create(name="Test", website="https://example.com")
@@ -470,13 +462,12 @@ class JSONFieldTypeTestCase(FieldTypeTestCase):
 
     def test_json_field_model_generation(self):
         """Test JSON field model generation."""
-        field = self.create_custom_object_type_field(
+        self.create_custom_object_type_field(
             self.custom_object_type,
             name="metadata",
             label="Metadata",
             type="json"
         )
-        field  # To silence ruff error
 
         model = self.custom_object_type.get_model()
         test_data = {"key": "value", "number": 42, "list": [1, 2, 3]}
@@ -527,7 +518,7 @@ class SelectFieldTypeTestCase(FieldTypeTestCase):
 
     def test_select_field_model_generation(self):
         """Test select field model generation."""
-        field = self.create_custom_object_type_field(
+        self.create_custom_object_type_field(
             self.custom_object_type,
             name="status",
             label="Status",
@@ -535,7 +526,6 @@ class SelectFieldTypeTestCase(FieldTypeTestCase):
             choice_set=self.choice_set,
             default="choice1"
         )
-        field  # To silence ruff error
 
         model = self.custom_object_type.get_model()
         instance = model.objects.create(name="Test", status="choice2")
@@ -585,14 +575,13 @@ class MultiSelectFieldTypeTestCase(FieldTypeTestCase):
 
     def test_multiselect_field_model_generation(self):
         """Test multiselect field model generation."""
-        field = self.create_custom_object_type_field(
+        self.create_custom_object_type_field(
             self.custom_object_type,
             name="tags",
             label="Tags",
             type="multiselect",
             choice_set=self.choice_set
         )
-        field  # To silence ruff error
 
         model = self.custom_object_type.get_model()
         instance = model.objects.create(name="Test", tags=["choice1", "choice3"])
@@ -623,40 +612,35 @@ class ObjectFieldTypeTestCase(FieldTypeTestCase):
 
     def test_object_field_model_generation(self):
         """Test object field model generation."""
-        field = self.create_custom_object_type_field(
+        self.create_custom_object_type_field(
             self.custom_object_type,
             name="device",
             label="Device",
             type="object",
             related_object_type=self.device_object_type
         )
-        field  # To silence ruff error
+
+        from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site
 
         model = self.custom_object_type.get_model()
 
-        # Create a test device (if available)
-        try:
-            from dcim.models import Device, Site, DeviceRole, DeviceType, Manufacturer
-            site = Site.objects.create(name="Test Site", slug="test-site")
-            manufacturer = Manufacturer.objects.create(name="Test Manufacturer", slug="test-manufacturer")
-            device_type = DeviceType.objects.create(
-                manufacturer=manufacturer,
-                model="Test Model",
-                slug="test-model"
-            )
-            device_role = DeviceRole.objects.create(name="Test Role", slug="test-role")
-            device = Device.objects.create(
-                name="Test Device",
-                site=site,
-                device_type=device_type,
-                role=device_role
-            )
+        site = Site.objects.create(name="Test Site", slug="test-site")
+        manufacturer = Manufacturer.objects.create(name="Test Manufacturer", slug="test-manufacturer")
+        device_type = DeviceType.objects.create(
+            manufacturer=manufacturer,
+            model="Test Model",
+            slug="test-model"
+        )
+        device_role = DeviceRole.objects.create(name="Test Role", slug="test-role")
+        device = Device.objects.create(
+            name="Test Device",
+            site=site,
+            device_type=device_type,
+            role=device_role
+        )
 
-            instance = model.objects.create(name="Test", device=device)
-            self.assertEqual(instance.device, device)
-        except ImportError:
-            # Skip if DCIM models are not available
-            pass
+        instance = model.objects.create(name="Test", device=device)
+        self.assertEqual(instance.device, device)
 
 
 class MultiObjectFieldTypeTestCase(FieldTypeTestCase):
@@ -682,50 +666,45 @@ class MultiObjectFieldTypeTestCase(FieldTypeTestCase):
 
     def test_multiobject_field_model_generation(self):
         """Test multiobject field model generation."""
-        field = self.create_custom_object_type_field(
+        self.create_custom_object_type_field(
             self.custom_object_type,
             name="devices",
             label="Devices",
             type="multiobject",
             related_object_type=self.device_object_type
         )
-        field  # To silence ruff error
+
+        from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site
 
         model = self.custom_object_type.get_model()
 
-        # Create test devices (if available)
-        try:
-            from dcim.models import Device, Site, DeviceRole, DeviceType, Manufacturer
-            site = Site.objects.create(name="Test Site", slug="test-site")
-            manufacturer = Manufacturer.objects.create(name="Test Manufacturer", slug="test-manufacturer")
-            device_type = DeviceType.objects.create(
-                manufacturer=manufacturer,
-                model="Test Model",
-                slug="test-model"
-            )
-            device_role = DeviceRole.objects.create(name="Test Role", slug="test-role")
-            device1 = Device.objects.create(
-                name="Test Device 1",
-                site=site,
-                device_type=device_type,
-                role=device_role
-            )
-            device2 = Device.objects.create(
-                name="Test Device 2",
-                site=site,
-                device_type=device_type,
-                role=device_role
-            )
+        site = Site.objects.create(name="Test Site", slug="test-site")
+        manufacturer = Manufacturer.objects.create(name="Test Manufacturer", slug="test-manufacturer")
+        device_type = DeviceType.objects.create(
+            manufacturer=manufacturer,
+            model="Test Model",
+            slug="test-model"
+        )
+        device_role = DeviceRole.objects.create(name="Test Role", slug="test-role")
+        device1 = Device.objects.create(
+            name="Test Device 1",
+            site=site,
+            device_type=device_type,
+            role=device_role
+        )
+        device2 = Device.objects.create(
+            name="Test Device 2",
+            site=site,
+            device_type=device_type,
+            role=device_role
+        )
 
-            instance = model.objects.create(name="Test")
-            instance.devices.add(device1, device2)
+        instance = model.objects.create(name="Test")
+        instance.devices.add(device1, device2)
 
-            self.assertEqual(instance.devices.count(), 2)
-            self.assertIn(device1, instance.devices.all())
-            self.assertIn(device2, instance.devices.all())
-        except ImportError:
-            # Skip if DCIM models are not available
-            pass
+        self.assertEqual(instance.devices.count(), 2)
+        self.assertIn(device1, instance.devices.all())
+        self.assertIn(device2, instance.devices.all())
 
 
 class SelfReferentialFieldTestCase(FieldTypeTestCase):
@@ -738,14 +717,13 @@ class SelfReferentialFieldTestCase(FieldTypeTestCase):
 
     def test_self_referential_object_field(self):
         """#263 – A COT may have an FK object field pointing to itself."""
-        field = self.create_custom_object_type_field(
+        self.create_custom_object_type_field(
             self.custom_object_type,
             name="parent",
             label="Parent",
             type="object",
             related_object_type=self.custom_object_type.object_type,
         )
-        field  # To silence ruff error
 
         model = self.custom_object_type.get_model()
 
@@ -756,14 +734,13 @@ class SelfReferentialFieldTestCase(FieldTypeTestCase):
 
     def test_self_referential_multiobject_field(self):
         """#263 – A COT may have a M2M multiobject field pointing to itself."""
-        field = self.create_custom_object_type_field(
+        self.create_custom_object_type_field(
             self.custom_object_type,
             name="children",
             label="Children",
             type="multiobject",
             related_object_type=self.custom_object_type.object_type,
         )
-        field  # To silence ruff error
 
         model = self.custom_object_type.get_model()
 
@@ -795,14 +772,13 @@ class CrossReferentialFieldTestCase(FieldTypeTestCase):
         )
 
         # Add object field referencing second type
-        field = self.create_custom_object_type_field(
+        self.create_custom_object_type_field(
             self.custom_object_type,
             name="related_object",
             label="Related Object",
             type="object",
             related_object_type=second_type.object_type
         )
-        field  # To silence ruff error
 
         model1 = self.custom_object_type.get_model()
         model2 = second_type.get_model()
@@ -827,14 +803,13 @@ class CrossReferentialFieldTestCase(FieldTypeTestCase):
         )
 
         # Add multiobject field referencing second type
-        field = self.create_custom_object_type_field(
+        self.create_custom_object_type_field(
             self.custom_object_type,
             name="related_objects",
             label="Related Objects",
             type="multiobject",
             related_object_type=second_type.object_type
         )
-        field  # To silence ruff error
 
         model1 = self.custom_object_type.get_model()
         model2 = second_type.get_model()

--- a/netbox_custom_objects/tests/test_field_types.py
+++ b/netbox_custom_objects/tests/test_field_types.py
@@ -1,9 +1,13 @@
+"""
+Tests for all the different field types supported by Custom Object Type Fields.
+"""
 from unittest import skip
 from datetime import date, datetime
 from decimal import Decimal
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 
+from netbox_custom_objects.models import CustomObjectTypeField
 from .base import CustomObjectsTestCase
 
 
@@ -725,54 +729,48 @@ class MultiObjectFieldTypeTestCase(FieldTypeTestCase):
 
 
 class SelfReferentialFieldTestCase(FieldTypeTestCase):
-    """Test cases for self-referential object fields."""
+    """Test cases for self-referential object fields.
 
-    @skip("Causes infinite recursion error")
+    The recursion guard in CustomObjectTypeField._check_recursion() explicitly
+    permits self-referential fields (#263), so these tests should pass without
+    any skip decorator.
+    """
+
     def test_self_referential_object_field(self):
-        """Test creating a self-referential object field."""
-        # Add a self-referential object field
+        """#263 – A COT may have an FK object field pointing to itself."""
         field = self.create_custom_object_type_field(
             self.custom_object_type,
             name="parent",
             label="Parent",
             type="object",
-            related_object_type=self.custom_object_type.object_type
+            related_object_type=self.custom_object_type.object_type,
         )
         field  # To silence ruff error
 
         model = self.custom_object_type.get_model()
 
-        # Create parent instance
         parent = model.objects.create(name="Parent Instance")
-
-        # Create child instance with parent reference
         child = model.objects.create(name="Child Instance", parent=parent)
 
         self.assertEqual(child.parent, parent)
 
-    @skip("Causes infinite recursion error")
     def test_self_referential_multiobject_field(self):
-        """Test creating a self-referential multiobject field."""
-        # Add a self-referential multiobject field
+        """#263 – A COT may have a M2M multiobject field pointing to itself."""
         field = self.create_custom_object_type_field(
             self.custom_object_type,
             name="children",
             label="Children",
             type="multiobject",
-            related_object_type=self.custom_object_type.object_type
+            related_object_type=self.custom_object_type.object_type,
         )
         field  # To silence ruff error
 
         model = self.custom_object_type.get_model()
 
-        # Create parent instance
         parent = model.objects.create(name="Parent Instance")
-
-        # Create child instances
         child1 = model.objects.create(name="Child 1")
         child2 = model.objects.create(name="Child 2")
 
-        # Add children to parent
         parent.children.add(child1, child2)
 
         self.assertEqual(parent.children.count(), 2)
@@ -852,3 +850,245 @@ class CrossReferentialFieldTestCase(FieldTypeTestCase):
         self.assertEqual(obj1.related_objects.count(), 2)
         self.assertIn(obj2_1, obj1.related_objects.all())
         self.assertIn(obj2_2, obj1.related_objects.all())
+
+
+class MultipleObjectFieldsToSameCOTTestCase(FieldTypeTestCase):
+    """Test cases for multiple object/multiobject fields pointing to the same COT.
+
+    Issue #237: multiple FK/M2M fields targeting the same related COT should all
+    be created without name collisions and must remain independently queryable.
+    """
+
+    def test_two_fk_fields_to_same_cot(self):
+        """#237 – Two FK object fields on the same COT can point to the same target COT."""
+        # Create a second COT that will be the shared target
+        target = self.create_custom_object_type(name="SharedTarget", slug="shared-target")
+        self.create_custom_object_type_field(
+            target,
+            name="name",
+            label="Name",
+            type="text",
+            primary=True,
+            required=True,
+        )
+
+        # Add two independent FK fields on the existing COT pointing to target
+        self.create_custom_object_type_field(
+            self.custom_object_type,
+            name="primary_ref",
+            label="Primary Reference",
+            type="object",
+            related_object_type=target.object_type,
+        )
+        self.create_custom_object_type_field(
+            self.custom_object_type,
+            name="secondary_ref",
+            label="Secondary Reference",
+            type="object",
+            related_object_type=target.object_type,
+        )
+
+        target_model = target.get_model()
+        model = self.custom_object_type.get_model()
+
+        t1 = target_model.objects.create(name="Target 1")
+        t2 = target_model.objects.create(name="Target 2")
+
+        obj = model.objects.create(name="Source Object", primary_ref=t1, secondary_ref=t2)
+
+        self.assertEqual(obj.primary_ref, t1)
+        self.assertEqual(obj.secondary_ref, t2)
+
+    def test_two_m2m_fields_to_same_cot(self):
+        """#237 – Two M2M multiobject fields on the same COT can point to the same target COT."""
+        target = self.create_custom_object_type(name="M2MTarget", slug="m2m-target")
+        self.create_custom_object_type_field(
+            target,
+            name="name",
+            label="Name",
+            type="text",
+            primary=True,
+            required=True,
+        )
+
+        self.create_custom_object_type_field(
+            self.custom_object_type,
+            name="primary_refs",
+            label="Primary References",
+            type="multiobject",
+            related_object_type=target.object_type,
+        )
+        self.create_custom_object_type_field(
+            self.custom_object_type,
+            name="secondary_refs",
+            label="Secondary References",
+            type="multiobject",
+            related_object_type=target.object_type,
+        )
+
+        target_model = target.get_model()
+        model = self.custom_object_type.get_model()
+
+        t1 = target_model.objects.create(name="Target 1")
+        t2 = target_model.objects.create(name="Target 2")
+        t3 = target_model.objects.create(name="Target 3")
+
+        obj = model.objects.create(name="Source Object")
+        obj.primary_refs.add(t1, t2)
+        obj.secondary_refs.add(t2, t3)
+
+        # The two M2M relations are independent
+        self.assertEqual(obj.primary_refs.count(), 2)
+        self.assertEqual(obj.secondary_refs.count(), 2)
+        self.assertIn(t1, obj.primary_refs.all())
+        self.assertIn(t3, obj.secondary_refs.all())
+        # t2 appears in both without conflict
+        self.assertIn(t2, obj.primary_refs.all())
+        self.assertIn(t2, obj.secondary_refs.all())
+
+    def test_fk_and_m2m_fields_to_same_cot(self):
+        """#237 – One FK and one M2M field pointing to the same target COT coexist."""
+        target = self.create_custom_object_type(name="MixedTarget", slug="mixed-target")
+        self.create_custom_object_type_field(
+            target,
+            name="name",
+            label="Name",
+            type="text",
+            primary=True,
+            required=True,
+        )
+
+        self.create_custom_object_type_field(
+            self.custom_object_type,
+            name="single_ref",
+            label="Single Reference",
+            type="object",
+            related_object_type=target.object_type,
+        )
+        self.create_custom_object_type_field(
+            self.custom_object_type,
+            name="multi_refs",
+            label="Multi References",
+            type="multiobject",
+            related_object_type=target.object_type,
+        )
+
+        target_model = target.get_model()
+        model = self.custom_object_type.get_model()
+
+        t1 = target_model.objects.create(name="Target 1")
+        t2 = target_model.objects.create(name="Target 2")
+
+        obj = model.objects.create(name="Source Object", single_ref=t1)
+        obj.multi_refs.add(t1, t2)
+
+        self.assertEqual(obj.single_ref, t1)
+        self.assertEqual(obj.multi_refs.count(), 2)
+
+
+class PrimaryFieldChangeTestCase(FieldTypeTestCase):
+    """Test changing which field is designated as the primary (display) field.
+
+    Issue #348: switching the primary flag to a different field while object
+    references exist must not break __str__ or queryset access.
+    """
+
+    def test_change_primary_field_updates_str(self):
+        """#348 – __str__ on existing instances reflects the new primary field after change."""
+        # The base FieldTypeTestCase already has a primary 'name' text field.
+        # Add a second text field and then switch primary to it.
+        second_field = self.create_custom_object_type_field(
+            self.custom_object_type,
+            name="label",
+            label="Label",
+            type="text",
+        )
+        model = self.custom_object_type.get_model()
+        instance = model.objects.create(name="OldPrimary", label="NewPrimary")
+
+        # Before the switch, __str__ uses 'name'
+        self.assertIn("OldPrimary", str(instance))
+
+        # Promote 'label' to primary, demote 'name'.
+        # Re-fetch from DB so that _original is populated (required by save()).
+        existing_primary = CustomObjectTypeField.objects.filter(
+            custom_object_type=self.custom_object_type, primary=True
+        ).first()
+        self.assertIsNotNone(existing_primary, "Expected a primary field to exist on the COT.")
+        existing_primary.primary = False
+        existing_primary.save()
+
+        fresh_second_field = CustomObjectTypeField.objects.get(pk=second_field.pk)
+        fresh_second_field.primary = True
+        fresh_second_field.save()
+
+        # Refresh instance after cache invalidation
+        self.custom_object_type.clear_model_cache(self.custom_object_type.id)
+        new_model = self.custom_object_type.get_model()
+        refreshed = new_model.objects.get(pk=instance.pk)
+
+        # __str__ should now reflect the 'label' field value
+        self.assertIn("NewPrimary", str(refreshed))
+
+    def test_change_primary_field_with_object_references(self):
+        """#348 – Changing the primary field does not break object fields that reference the COT."""
+        # Build a second COT that holds a reference to self.custom_object_type
+        ref_cot = self.create_custom_object_type(name="RefHolder", slug="ref-holder")
+        self.create_custom_object_type_field(
+            ref_cot,
+            name="name",
+            label="Name",
+            type="text",
+            primary=True,
+        )
+        self.create_custom_object_type_field(
+            ref_cot,
+            name="ref",
+            label="Reference",
+            type="object",
+            related_object_type=self.custom_object_type.object_type,
+        )
+
+        model_target = self.custom_object_type.get_model()
+        model_ref = ref_cot.get_model()
+
+        target_instance = model_target.objects.create(name="Target")
+        ref_instance = model_ref.objects.create(name="Holder", ref=target_instance)
+
+        # Change the primary field on the target COT.
+        # Re-fetch from DB so that _original is populated (required by save()).
+        second_field = self.create_custom_object_type_field(
+            self.custom_object_type,
+            name="code",
+            label="Code",
+            type="text",
+        )
+
+        # Give the target instance a 'code' value now that the column exists,
+        # so the __str__ assertion below is meaningful after the primary swap.
+        self.custom_object_type.clear_model_cache(self.custom_object_type.id)
+        model_target_v2 = self.custom_object_type.get_model()
+        model_target_v2.objects.filter(pk=target_instance.pk).update(code="T-001")
+
+        existing_primary = CustomObjectTypeField.objects.filter(
+            custom_object_type=self.custom_object_type, primary=True
+        ).first()
+        self.assertIsNotNone(existing_primary, "Expected a primary field to exist on the COT.")
+        existing_primary.primary = False
+        existing_primary.save()
+
+        fresh_second_field = CustomObjectTypeField.objects.get(pk=second_field.pk)
+        fresh_second_field.primary = True
+        fresh_second_field.save()
+
+        # The FK relationship must still be intact after the primary field swap
+        self.custom_object_type.clear_model_cache(self.custom_object_type.id)
+        ref_cot.clear_model_cache(ref_cot.id)
+
+        new_target_model = self.custom_object_type.get_model()
+        refreshed_ref = model_ref.objects.get(pk=ref_instance.pk)
+        self.assertEqual(refreshed_ref.ref_id, target_instance.pk)
+
+        # __str__ on the referenced target must reflect the new primary field ('code')
+        refreshed_target = new_target_model.objects.get(pk=target_instance.pk)
+        self.assertIn("T-001", str(refreshed_target))

--- a/netbox_custom_objects/tests/test_filtersets.py
+++ b/netbox_custom_objects/tests/test_filtersets.py
@@ -1,3 +1,6 @@
+"""
+Tests for filtersets used by the plugin's UI and API views.
+"""
 from django.test import TestCase
 
 from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site

--- a/netbox_custom_objects/tests/test_models.py
+++ b/netbox_custom_objects/tests/test_models.py
@@ -1,3 +1,6 @@
+"""
+Tests for the concrete and dynamically generated models that are managed by this plugin.
+"""
 from unittest import skip
 from decimal import Decimal
 

--- a/netbox_custom_objects/tests/test_navigation.py
+++ b/netbox_custom_objects/tests/test_navigation.py
@@ -1,3 +1,6 @@
+"""
+Tests for the UI sidebar navigation menu.
+"""
 from unittest.mock import patch
 
 from django.test import TestCase

--- a/netbox_custom_objects/tests/test_schema_operations.py
+++ b/netbox_custom_objects/tests/test_schema_operations.py
@@ -11,22 +11,12 @@ from django.core.management import call_command
 from django.test import TransactionTestCase
 
 from netbox_custom_objects.constants import APP_LABEL
-from netbox_custom_objects.models import CustomObjectType
 
-from .base import CustomObjectsTestCase
+from .base import CustomObjectsTestCase, TransactionCleanupMixin
 
 
-class SchemaOperationsTestCase(CustomObjectsTestCase, TransactionTestCase):
+class SchemaOperationsTestCase(TransactionCleanupMixin, CustomObjectsTestCase, TransactionTestCase):
     """Test database schema operations and related cache/registry behaviour."""
-
-    def tearDown(self):
-        """Clean up dynamic tables created during tests."""
-        for cot in CustomObjectType.objects.all():
-            try:
-                cot.delete()
-            except Exception as exc:
-                print(f"WARNING: tearDown could not delete COT {cot.pk}: {exc}")
-        super().tearDown()
 
     # ------------------------------------------------------------------
     # Cache invalidation
@@ -176,11 +166,8 @@ class SchemaOperationsTestCase(CustomObjectsTestCase, TransactionTestCase):
         try:
             call_command('migrate', '--check', verbosity=0, stdout=out, stderr=out)
         except SystemExit as exc:
-            # Exit code 1 means unapplied migrations; any non-zero code is a failure.
-            self.assertEqual(
-                exc.code, 0,
-                f"migrate --check detected unapplied migrations: {out.getvalue()}",
-            )
+            # If we reach here, migrate --check found unapplied migrations or the plugin crashed.
+            self.fail(f"migrate --check exited with code {exc.code}: {out.getvalue()}")
 
     def test_collectstatic_without_database(self):
         """#347 – collectstatic should complete without requiring database access."""

--- a/netbox_custom_objects/tests/test_schema_operations.py
+++ b/netbox_custom_objects/tests/test_schema_operations.py
@@ -1,0 +1,200 @@
+"""
+Tests for database schema operations and model-cache behaviour.
+
+Uses TransactionTestCase so DDL and on_commit callbacks behave exactly as they
+do in production (no wrapping savepoint prevents commits).
+"""
+from io import StringIO
+
+from django.apps import apps
+from django.core.management import call_command
+from django.test import TransactionTestCase
+
+from netbox_custom_objects.constants import APP_LABEL
+from netbox_custom_objects.models import CustomObjectType
+
+from .base import CustomObjectsTestCase
+
+
+class SchemaOperationsTestCase(CustomObjectsTestCase, TransactionTestCase):
+    """Test database schema operations and related cache/registry behaviour."""
+
+    def tearDown(self):
+        """Clean up dynamic tables created during tests."""
+        for cot in CustomObjectType.objects.all():
+            try:
+                cot.delete()
+            except Exception as exc:
+                print(f"WARNING: tearDown could not delete COT {cot.pk}: {exc}")
+        super().tearDown()
+
+    # ------------------------------------------------------------------
+    # Cache invalidation
+    # ------------------------------------------------------------------
+
+    def test_cache_invalidation_on_cotf_save(self):
+        """#340 – cache_timestamp on the parent COT is updated when a field is saved."""
+        cot = self.create_custom_object_type(name='cachetest', slug='cache-test')
+        # Capture the initial timestamp
+        initial_timestamp = cot.cache_timestamp
+
+        # Adding a field triggers CustomObjectTypeField.save(), which calls
+        # cot.save(update_fields=['cache_timestamp']).
+        self.create_custom_object_type_field(
+            cot,
+            name='myfield',
+            label='My Field',
+            type='text',
+        )
+
+        cot.refresh_from_db()
+        self.assertNotEqual(
+            cot.cache_timestamp,
+            initial_timestamp,
+            "cache_timestamp must be updated after a field is saved.",
+        )
+
+    def test_cache_invalidation_on_cotf_delete(self):
+        """cache_timestamp is updated when a field is deleted."""
+        cot = self.create_custom_object_type(name='cachedel', slug='cache-del')
+        field = self.create_custom_object_type_field(
+            cot,
+            name='tempfield',
+            label='Temp Field',
+            type='text',
+        )
+        cot.refresh_from_db()
+        timestamp_after_add = cot.cache_timestamp
+
+        field.delete()
+
+        cot.refresh_from_db()
+        self.assertNotEqual(
+            cot.cache_timestamp,
+            timestamp_after_add,
+            "cache_timestamp must be updated after a field is deleted.",
+        )
+
+    # ------------------------------------------------------------------
+    # Model registry
+    # ------------------------------------------------------------------
+
+    def test_model_registered_in_apps_after_cotf_save(self):
+        """#335 – The regenerated model is present in apps.get_models() after a field change."""
+        cot = self.create_custom_object_type(name='regtest', slug='reg-test')
+        self.create_custom_object_type_field(
+            cot,
+            name='fieldone',
+            label='Field One',
+            type='text',
+            primary=True,
+        )
+
+        # Force model generation and registration
+        model = cot.get_model()
+        model_name = model.__name__.lower()
+
+        # The model must appear in the app registry
+        self.assertIn(
+            model_name,
+            apps.all_models.get(APP_LABEL, {}),
+            "Generated model should be registered in Django's app registry.",
+        )
+        self.assertIn(
+            model,
+            apps.get_models(),
+            "Generated model should be returned by apps.get_models().",
+        )
+
+    def test_model_regenerated_after_field_added(self):
+        """Adding a field clears the model cache so get_model() reflects the new schema."""
+        cot = self.create_custom_object_type(name='regentest', slug='regen-test')
+        self.create_custom_object_type_field(
+            cot,
+            name='name',
+            label='Name',
+            type='text',
+            primary=True,
+        )
+        old_model = cot.get_model()
+        self.assertFalse(
+            'extra' in {f.name for f in old_model._meta.get_fields()},
+            "Field 'extra' should not exist before it is added.",
+        )
+
+        # Add a new field — this invalidates the cache
+        self.create_custom_object_type_field(
+            cot,
+            name='extra',
+            label='Extra',
+            type='text',
+        )
+
+        new_model = cot.get_model()
+        self.assertIn(
+            'extra',
+            {f.name for f in new_model._meta.get_fields()},
+            "Field 'extra' should be present on the regenerated model.",
+        )
+
+    def test_model_not_in_registry_after_cot_deleted(self):
+        """Deleting a COT removes its generated model from Django's app registry."""
+        cot = self.create_custom_object_type(name='delregtest', slug='del-reg-test')
+        self.create_custom_object_type_field(
+            cot,
+            name='name',
+            label='Name',
+            type='text',
+            primary=True,
+        )
+        model = cot.get_model()
+        model_name = model.__name__.lower()
+
+        self.assertIn(
+            model_name,
+            apps.all_models.get(APP_LABEL, {}),
+            "Model should be in registry before deletion.",
+        )
+
+        cot.delete()
+
+        self.assertNotIn(
+            model_name,
+            apps.all_models.get(APP_LABEL, {}),
+            "Deleted COT's model must be removed from the app registry.",
+        )
+
+    # ------------------------------------------------------------------
+    # Management commands
+    # ------------------------------------------------------------------
+
+    def test_migration_with_call_command(self):
+        """#326 – Running migrate via call_command() should not raise."""
+        out = StringIO()
+        # --check exits with code 1 if unapplied migrations exist; any other
+        # error (e.g. the plugin crashing during the migrate run) would raise.
+        try:
+            call_command('migrate', '--check', verbosity=0, stdout=out, stderr=out)
+        except SystemExit as exc:
+            # Exit code 1 means unapplied migrations; any non-zero code is a failure.
+            self.assertEqual(
+                exc.code, 0,
+                f"migrate --check detected unapplied migrations: {out.getvalue()}",
+            )
+
+    def test_collectstatic_without_database(self):
+        """#347 – collectstatic should complete without requiring database access."""
+        out = StringIO()
+        err = StringIO()
+        # --dry-run does not write files; --no-input skips confirmation prompts.
+        # The important assertion is that no exception (especially no database
+        # error originating from the plugin's AppConfig) is raised.
+        call_command(
+            'collectstatic',
+            '--dry-run',
+            '--no-input',
+            verbosity=0,
+            stdout=out,
+            stderr=err,
+        )
+        # No uncaught exceptions reaching here means success.

--- a/netbox_custom_objects/tests/test_views.py
+++ b/netbox_custom_objects/tests/test_views.py
@@ -1,3 +1,6 @@
+"""
+Tests for all UI views.
+"""
 from django.urls import reverse
 from extras.models import CustomFieldChoiceSet
 from utilities.testing import ViewTestCases


### PR DESCRIPTION
### Closes: #395 

Fully implements all stubbed-out and skipped tests, and expands coverage of existing test areas, as well as adding new test suites for schema operations and deletion.