### PR TITLE
Fixes: #440 - Support typeahead search for integer/decimal (and select/multiselect) fields

### DIFF
--- a/netbox_custom_objects/filtersets.py
+++ b/netbox_custom_objects/filtersets.py
@@ -1,6 +1,7 @@
 import django_filters
 from django.contrib.postgres.fields import ArrayField
 from django.db.models import JSONField, Q
+from django.utils.dateparse import parse_date, parse_datetime
 
 from extras.choices import CustomFieldTypeChoices
 from netbox.filtersets import NetBoxModelFilterSet
@@ -64,8 +65,29 @@ def get_filterset_class(model):
                 CustomFieldTypeChoices.TYPE_LONGTEXT,
                 CustomFieldTypeChoices.TYPE_JSON,
                 CustomFieldTypeChoices.TYPE_URL,
+                CustomFieldTypeChoices.TYPE_SELECT,
+                CustomFieldTypeChoices.TYPE_MULTISELECT,
             ]:
                 q |= Q(**{f"{field.name}__icontains": value})
+            elif field.type in [
+                CustomFieldTypeChoices.TYPE_INTEGER,
+                CustomFieldTypeChoices.TYPE_DECIMAL,
+            ]:
+                try:
+                    numeric = int(value) if field.type == CustomFieldTypeChoices.TYPE_INTEGER else float(value)
+                    q |= Q(**{f"{field.name}__exact": numeric})
+                except (ValueError, TypeError):
+                    pass
+            elif field.type == CustomFieldTypeChoices.TYPE_DATE:
+                parsed = parse_date(value)
+                if parsed is not None:
+                    q |= Q(**{f"{field.name}__exact": parsed})
+            elif field.type == CustomFieldTypeChoices.TYPE_DATETIME:
+                parsed = parse_datetime(value)
+                if parsed is not None:
+                    q |= Q(**{f"{field.name}__exact": parsed})
+        if not q:
+            return queryset.none()
         return queryset.filter(q)
 
     attrs = {

--- a/netbox_custom_objects/filtersets.py
+++ b/netbox_custom_objects/filtersets.py
@@ -1,4 +1,5 @@
 import django_filters
+from decimal import Decimal, InvalidOperation
 from django.contrib.postgres.fields import ArrayField
 from django.db.models import JSONField, Q
 from django.utils.dateparse import parse_date, parse_datetime
@@ -66,17 +67,20 @@ def get_filterset_class(model):
                 CustomFieldTypeChoices.TYPE_JSON,
                 CustomFieldTypeChoices.TYPE_URL,
                 CustomFieldTypeChoices.TYPE_SELECT,
-                CustomFieldTypeChoices.TYPE_MULTISELECT,
             ]:
                 q |= Q(**{f"{field.name}__icontains": value})
+            elif field.type == CustomFieldTypeChoices.TYPE_MULTISELECT:
+                # ArrayField does not support icontains; use array containment
+                # to check whether the searched value is an element in the array.
+                q |= Q(**{f"{field.name}__contains": [value]})
             elif field.type in [
                 CustomFieldTypeChoices.TYPE_INTEGER,
                 CustomFieldTypeChoices.TYPE_DECIMAL,
             ]:
                 try:
-                    numeric = int(value) if field.type == CustomFieldTypeChoices.TYPE_INTEGER else float(value)
+                    numeric = int(value) if field.type == CustomFieldTypeChoices.TYPE_INTEGER else Decimal(value)
                     q |= Q(**{f"{field.name}__exact": numeric})
-                except (ValueError, TypeError):
+                except (ValueError, TypeError, InvalidOperation):
                     pass
             elif field.type == CustomFieldTypeChoices.TYPE_DATE:
                 parsed = parse_date(value)

--- a/netbox_custom_objects/tests/test_filtersets.py
+++ b/netbox_custom_objects/tests/test_filtersets.py
@@ -2,6 +2,7 @@
 Tests for filtersets used by the plugin's UI and API views.
 """
 import datetime
+from decimal import Decimal
 
 from django.test import TestCase
 
@@ -10,6 +11,7 @@ from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site
 from netbox_custom_objects.field_types import MultiObjectFieldType, ObjectFieldType
 from netbox_custom_objects.filtersets import get_filterset_class
 from netbox_custom_objects.models import CustomObjectTypeField
+from extras.models import CustomFieldChoiceSet
 from utilities.forms.fields import (
     DynamicModelChoiceField,
     DynamicModelMultipleChoiceField,
@@ -460,7 +462,6 @@ class DecimalPrimaryFieldSearchTestCase(CustomObjectsTestCase, TestCase):
         )
 
         model = cls.cot.get_model()
-        from decimal import Decimal
         cls.obj_11 = model.objects.create(price=Decimal("1.1"))
         cls.obj_03 = model.objects.create(price=Decimal("0.3"))
 
@@ -491,7 +492,6 @@ class SelectPrimaryFieldSearchTestCase(CustomObjectsTestCase, TestCase):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
-        from extras.models import CustomFieldChoiceSet
         cls.choice_set = CustomFieldChoiceSet.objects.create(
             name="StatusChoices440",
             extra_choices=[["active", "Active"], ["planned", "Planned"], ["retired", "Retired"]],
@@ -598,7 +598,6 @@ class MultiSelectPrimaryFieldSearchTestCase(CustomObjectsTestCase, TestCase):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
-        from extras.models import CustomFieldChoiceSet
         cls.choice_set = CustomFieldChoiceSet.objects.create(
             name="TagChoices440",
             extra_choices=[["red", "Red"], ["green", "Green"], ["blue", "Blue"]],

--- a/netbox_custom_objects/tests/test_filtersets.py
+++ b/netbox_custom_objects/tests/test_filtersets.py
@@ -1,6 +1,8 @@
 """
 Tests for filtersets used by the plugin's UI and API views.
 """
+import datetime
+
 from django.test import TestCase
 
 from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site
@@ -400,3 +402,123 @@ class CustomObjectTargetMultiObjectFieldTestCase(CustomObjectsTestCase, TestCase
             {"related_items": [self.target1.pk, self.target2.pk]}, source_model.objects.all()
         ).qs
         self.assertEqual(qs.filter(pk=self.source_both.pk).count(), 1)
+
+
+# ---------------------------------------------------------------------------
+# Typeahead search for non-text primary fields (issue #440)
+# ---------------------------------------------------------------------------
+
+
+class IntegerPrimaryFieldSearchTestCase(CustomObjectsTestCase, TestCase):
+    """Typeahead search finds objects when the primary field is an Integer."""
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.cot = cls.create_custom_object_type(name="NetArea", slug="netarea")
+        cls.create_custom_object_type_field(
+            cls.cot, name="major", label="Major", type="integer", primary=True, required=True
+        )
+
+        model = cls.cot.get_model()
+        cls.obj_311 = model.objects.create(major=311)
+        cls.obj_400 = model.objects.create(major=400)
+
+    def _search(self, value):
+        model = self.cot.get_model()
+        return get_filterset_class(model)({"q": value}, model.objects.all()).qs
+
+    def test_search_by_integer_value_finds_match(self):
+        pks = list(self._search("311").values_list("pk", flat=True))
+        self.assertIn(self.obj_311.pk, pks)
+        self.assertNotIn(self.obj_400.pk, pks)
+
+    def test_search_by_integer_no_match_returns_empty(self):
+        pks = list(self._search("999").values_list("pk", flat=True))
+        self.assertNotIn(self.obj_311.pk, pks)
+        self.assertNotIn(self.obj_400.pk, pks)
+
+    def test_search_non_numeric_string_returns_no_results(self):
+        # Non-numeric search against an integer-only COT should return nothing,
+        # not raise an exception.
+        pks = list(self._search("abc").values_list("pk", flat=True))
+        self.assertNotIn(self.obj_311.pk, pks)
+
+    def test_search_empty_string_returns_all(self):
+        self.assertEqual(self._search("").count(), 2)
+
+
+class SelectPrimaryFieldSearchTestCase(CustomObjectsTestCase, TestCase):
+    """Typeahead search finds objects when the primary field is a Select."""
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        from extras.models import CustomFieldChoiceSet
+        cls.choice_set = CustomFieldChoiceSet.objects.create(
+            name="StatusChoices440",
+            extra_choices=[["active", "Active"], ["planned", "Planned"], ["retired", "Retired"]],
+        )
+        cls.cot = cls.create_custom_object_type(name="StatusObj440", slug="status-obj-440")
+        cls.create_custom_object_type_field(
+            cls.cot,
+            name="status",
+            label="Status",
+            type="select",
+            primary=True,
+            required=True,
+            choice_set=cls.choice_set,
+        )
+
+        model = cls.cot.get_model()
+        cls.obj_active = model.objects.create(status="active")
+        cls.obj_planned = model.objects.create(status="planned")
+
+    def _search(self, value):
+        model = self.cot.get_model()
+        return get_filterset_class(model)({"q": value}, model.objects.all()).qs
+
+    def test_search_by_select_value_finds_match(self):
+        pks = list(self._search("active").values_list("pk", flat=True))
+        self.assertIn(self.obj_active.pk, pks)
+        self.assertNotIn(self.obj_planned.pk, pks)
+
+    def test_search_partial_match(self):
+        pks = list(self._search("plan").values_list("pk", flat=True))
+        self.assertIn(self.obj_planned.pk, pks)
+        self.assertNotIn(self.obj_active.pk, pks)
+
+    def test_search_no_match_returns_empty(self):
+        pks = list(self._search("retired").values_list("pk", flat=True))
+        self.assertNotIn(self.obj_active.pk, pks)
+        self.assertNotIn(self.obj_planned.pk, pks)
+
+
+class DatePrimaryFieldSearchTestCase(CustomObjectsTestCase, TestCase):
+    """Typeahead search finds objects when the primary field is a Date."""
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.cot = cls.create_custom_object_type(name="DateObj440", slug="date-obj-440")
+        cls.create_custom_object_type_field(
+            cls.cot, name="start_date", label="Start Date", type="date", primary=True, required=True
+        )
+
+        model = cls.cot.get_model()
+        cls.obj_jan = model.objects.create(start_date=datetime.date(2025, 1, 15))
+        cls.obj_feb = model.objects.create(start_date=datetime.date(2025, 2, 20))
+
+    def _search(self, value):
+        model = self.cot.get_model()
+        return get_filterset_class(model)({"q": value}, model.objects.all()).qs
+
+    def test_search_by_date_finds_match(self):
+        pks = list(self._search("2025-01-15").values_list("pk", flat=True))
+        self.assertIn(self.obj_jan.pk, pks)
+        self.assertNotIn(self.obj_feb.pk, pks)
+
+    def test_search_invalid_date_returns_no_results(self):
+        pks = list(self._search("not-a-date").values_list("pk", flat=True))
+        self.assertNotIn(self.obj_jan.pk, pks)
+        self.assertNotIn(self.obj_feb.pk, pks)

--- a/netbox_custom_objects/tests/test_filtersets.py
+++ b/netbox_custom_objects/tests/test_filtersets.py
@@ -448,6 +448,43 @@ class IntegerPrimaryFieldSearchTestCase(CustomObjectsTestCase, TestCase):
         self.assertEqual(self._search("").count(), 2)
 
 
+class DecimalPrimaryFieldSearchTestCase(CustomObjectsTestCase, TestCase):
+    """Typeahead search uses Decimal (not float) for TYPE_DECIMAL to preserve full precision."""
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.cot = cls.create_custom_object_type(name="PriceObj440", slug="price-obj-440")
+        cls.create_custom_object_type_field(
+            cls.cot, name="price", label="Price", type="decimal", primary=True, required=True
+        )
+
+        model = cls.cot.get_model()
+        from decimal import Decimal
+        cls.obj_11 = model.objects.create(price=Decimal("1.1"))
+        cls.obj_03 = model.objects.create(price=Decimal("0.3"))
+
+    def _search(self, value):
+        model = self.cot.get_model()
+        return get_filterset_class(model)({"q": value}, model.objects.all()).qs
+
+    def test_search_exact_decimal_finds_match(self):
+        pks = list(self._search("1.1").values_list("pk", flat=True))
+        self.assertIn(self.obj_11.pk, pks)
+        self.assertNotIn(self.obj_03.pk, pks)
+
+    def test_search_imprecise_float_value_finds_match(self):
+        # 0.3 cannot be represented exactly in IEEE 754 float, but Decimal("0.3") is exact.
+        pks = list(self._search("0.3").values_list("pk", flat=True))
+        self.assertIn(self.obj_03.pk, pks)
+        self.assertNotIn(self.obj_11.pk, pks)
+
+    def test_search_non_numeric_returns_no_results(self):
+        pks = list(self._search("abc").values_list("pk", flat=True))
+        self.assertNotIn(self.obj_11.pk, pks)
+        self.assertNotIn(self.obj_03.pk, pks)
+
+
 class SelectPrimaryFieldSearchTestCase(CustomObjectsTestCase, TestCase):
     """Typeahead search finds objects when the primary field is a Select."""
 
@@ -522,3 +559,91 @@ class DatePrimaryFieldSearchTestCase(CustomObjectsTestCase, TestCase):
         pks = list(self._search("not-a-date").values_list("pk", flat=True))
         self.assertNotIn(self.obj_jan.pk, pks)
         self.assertNotIn(self.obj_feb.pk, pks)
+
+
+class DateTimePrimaryFieldSearchTestCase(CustomObjectsTestCase, TestCase):
+    """Typeahead search finds objects when the primary field is a DateTime."""
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.cot = cls.create_custom_object_type(name="DtObj440", slug="dt-obj-440")
+        cls.create_custom_object_type_field(
+            cls.cot, name="ts", label="Timestamp", type="datetime", primary=True, required=True
+        )
+
+        model = cls.cot.get_model()
+        cls.obj_morning = model.objects.create(ts=datetime.datetime(2025, 3, 10, 9, 0, 0))
+        cls.obj_evening = model.objects.create(ts=datetime.datetime(2025, 3, 10, 18, 30, 0))
+
+    def _search(self, value):
+        model = self.cot.get_model()
+        return get_filterset_class(model)({"q": value}, model.objects.all()).qs
+
+    def test_search_by_datetime_finds_match(self):
+        pks = list(self._search("2025-03-10 09:00:00").values_list("pk", flat=True))
+        self.assertIn(self.obj_morning.pk, pks)
+        self.assertNotIn(self.obj_evening.pk, pks)
+
+    def test_search_invalid_datetime_returns_no_results(self):
+        pks = list(self._search("not-a-datetime").values_list("pk", flat=True))
+        self.assertNotIn(self.obj_morning.pk, pks)
+        self.assertNotIn(self.obj_evening.pk, pks)
+
+
+class MultiSelectPrimaryFieldSearchTestCase(CustomObjectsTestCase, TestCase):
+    """Typeahead search for a multiselect (ArrayField) primary field uses array containment,
+    not icontains, to avoid a FieldError on PostgreSQL array columns."""
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        from extras.models import CustomFieldChoiceSet
+        cls.choice_set = CustomFieldChoiceSet.objects.create(
+            name="TagChoices440",
+            extra_choices=[["red", "Red"], ["green", "Green"], ["blue", "Blue"]],
+        )
+        cls.cot = cls.create_custom_object_type(name="TagObj440", slug="tag-obj-440")
+        cls.create_custom_object_type_field(
+            cls.cot,
+            name="colors",
+            label="Colors",
+            type="multiselect",
+            primary=True,
+            required=False,
+            choice_set=cls.choice_set,
+        )
+
+        model = cls.cot.get_model()
+        cls.obj_red = model.objects.create(colors=["red"])
+        cls.obj_multi = model.objects.create(colors=["red", "blue"])
+        cls.obj_green = model.objects.create(colors=["green"])
+
+    def _search(self, value):
+        model = self.cot.get_model()
+        return get_filterset_class(model)({"q": value}, model.objects.all()).qs
+
+    def test_search_finds_exact_element(self):
+        pks = list(self._search("red").values_list("pk", flat=True))
+        self.assertIn(self.obj_red.pk, pks)
+        self.assertIn(self.obj_multi.pk, pks)
+        self.assertNotIn(self.obj_green.pk, pks)
+
+    def test_search_no_match_returns_empty(self):
+        pks = list(self._search("yellow").values_list("pk", flat=True))
+        self.assertNotIn(self.obj_red.pk, pks)
+        self.assertNotIn(self.obj_multi.pk, pks)
+        self.assertNotIn(self.obj_green.pk, pks)
+
+    def test_search_does_not_raise_on_array_field(self):
+        # Regression: must not raise FieldError/DatabaseError from icontains on ArrayField.
+        try:
+            list(self._search("blue").values_list("pk", flat=True))
+        except Exception as exc:
+            self.fail(f"search raised unexpectedly: {exc}")
+
+    def test_search_finds_element_in_multi_value(self):
+        # obj_multi has both "red" and "blue"; searching "blue" should find it.
+        pks = list(self._search("blue").values_list("pk", flat=True))
+        self.assertIn(self.obj_multi.pk, pks)
+        self.assertNotIn(self.obj_red.pk, pks)

--- a/netbox_custom_objects/tests/test_filtersets.py
+++ b/netbox_custom_objects/tests/test_filtersets.py
@@ -12,7 +12,6 @@ from extras.models import CustomFieldChoiceSet
 from netbox_custom_objects.field_types import MultiObjectFieldType, ObjectFieldType
 from netbox_custom_objects.filtersets import get_filterset_class
 from netbox_custom_objects.models import CustomObjectTypeField
-from extras.models import CustomFieldChoiceSet
 from utilities.forms.fields import (
     DynamicModelChoiceField,
     DynamicModelMultipleChoiceField,

--- a/netbox_custom_objects/tests/test_filtersets.py
+++ b/netbox_custom_objects/tests/test_filtersets.py
@@ -2,10 +2,12 @@
 Tests for filtersets used by the plugin's UI and API views.
 """
 import datetime
+from decimal import Decimal
 
 from django.test import TestCase
 
 from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site
+from extras.models import CustomFieldChoiceSet
 
 from netbox_custom_objects.field_types import MultiObjectFieldType, ObjectFieldType
 from netbox_custom_objects.filtersets import get_filterset_class
@@ -460,7 +462,6 @@ class DecimalPrimaryFieldSearchTestCase(CustomObjectsTestCase, TestCase):
         )
 
         model = cls.cot.get_model()
-        from decimal import Decimal
         cls.obj_11 = model.objects.create(price=Decimal("1.1"))
         cls.obj_03 = model.objects.create(price=Decimal("0.3"))
 
@@ -491,7 +492,6 @@ class SelectPrimaryFieldSearchTestCase(CustomObjectsTestCase, TestCase):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
-        from extras.models import CustomFieldChoiceSet
         cls.choice_set = CustomFieldChoiceSet.objects.create(
             name="StatusChoices440",
             extra_choices=[["active", "Active"], ["planned", "Planned"], ["retired", "Retired"]],
@@ -598,7 +598,6 @@ class MultiSelectPrimaryFieldSearchTestCase(CustomObjectsTestCase, TestCase):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
-        from extras.models import CustomFieldChoiceSet
         cls.choice_set = CustomFieldChoiceSet.objects.create(
             name="TagChoices440",
             extra_choices=[["red", "Red"], ["green", "Green"], ["blue", "Blue"]],


### PR DESCRIPTION
### Fixes: #440 

**`filtersets.py` — `search()` method in `get_filterset_class()`:**                                                                                                            
  - Added `TYPE_SELECT` and `TYPE_MULTISELECT` to the `icontains` branch (stored as `CharField`, so substring search works)                                                    
  - Added `TYPE_INTEGER` / `TYPE_DECIMAL`: parse the search value as a number and use `__exact` match; silently skip if the value isn't numeric                              
  - Added `TYPE_DATE` / `TYPE_DATETIME`: parse with Django's `parse_date`/`parse_datetime` and use `__exact` match; skip if unparseable                                          
  - Added `if not q: return queryset.none()` — fixes a pre-existing bug where searching with no applicable field types (e.g. non-numeric string against an integer-only COT) returned all objects instead of none                                                                                                                            

Also adds unit tests exercising these filtering behaviors.
