### PR TITLE
Release v0.4.7

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,14 +6,14 @@
 ### Enhancements
 
 - [#25](https://github.com/netboxlabs/netbox-custom-objects/issues/25) - Linked custom objects should show up in the API response for related objects
-- [#193](https://github.com/netboxlabs/netbox-custom-objects/issues/193) - Grouping custom objects
+- [#193](https://github.com/netboxlabs/netbox-custom-objects/issues/193) - Grouping custom object types in nav menu
 - [#292](https://github.com/netboxlabs/netbox-custom-objects/issues/292) - Move COTF to their own standard ViewTab in the COT detail view
 - [#308](https://github.com/netboxlabs/netbox-custom-objects/issues/308) - Limit rows qty in "Custom Objects linking to this object" panels
 
 ### Bug Fixes
 
-- [#382](https://github.com/netboxlabs/netbox-custom-objects/issues/382) - Primary name field breaks related custom objects and netbox objects
-- [#383](https://github.com/netboxlabs/netbox-custom-objects/issues/383) - Related objects and count on Netbox Objects are rendered twice
+- [#382](https://github.com/netboxlabs/netbox-custom-objects/issues/382) - Primary name field breaks related custom objects and NetBox objects
+- [#383](https://github.com/netboxlabs/netbox-custom-objects/issues/383) - Related objects and count on NetBox Objects are rendered twice
 - [#394](https://github.com/netboxlabs/netbox-custom-objects/issues/394) - Reindex CachedValues when COT fields are changed
 - [#407](https://github.com/netboxlabs/netbox-custom-objects/issues/407) - Custom object types visible in menu without permissions
 - [#409](https://github.com/netboxlabs/netbox-custom-objects/issues/409) - Required Fields also required when bulk editing

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.4.7
+---
+
+### Enhancements
+
+- [#25](https://github.com/netboxlabs/netbox-custom-objects/issues/25) - Linked custom objects should show up in the API response for related objects
+- [#193](https://github.com/netboxlabs/netbox-custom-objects/issues/193) - Grouping custom objects
+- [#292](https://github.com/netboxlabs/netbox-custom-objects/issues/292) - Move COTF to their own standard ViewTab in the COT detail view
+- [#308](https://github.com/netboxlabs/netbox-custom-objects/issues/308) - Limit rows qty in "Custom Objects linking to this object" panels
+
+### Bug Fixes
+
+- [#382](https://github.com/netboxlabs/netbox-custom-objects/issues/382) - Primary name field breaks related custom objects and netbox objects
+- [#383](https://github.com/netboxlabs/netbox-custom-objects/issues/383) - Related objects and count on Netbox Objects are rendered twice
+- [#394](https://github.com/netboxlabs/netbox-custom-objects/issues/394) - Reindex CachedValues when COT fields are changed
+- [#407](https://github.com/netboxlabs/netbox-custom-objects/issues/407) - Custom object types visible in menu without permissions
+- [#409](https://github.com/netboxlabs/netbox-custom-objects/issues/409) - Required Fields also required when bulk editing
+- [#417](https://github.com/netboxlabs/netbox-custom-objects/issues/417) - Filtering objects by multiple-object field does not work
+- [#423](https://github.com/netboxlabs/netbox-custom-objects/issues/423) - Can't use custom object as field type in POST /api/plugins/custom-objects/custom-object-type-fields/
+- [#429](https://github.com/netboxlabs/netbox-custom-objects/issues/429) - Deleting Custom Object and Custom Object Type Together Causes Missing Relation Error
+- [#440](https://github.com/netboxlabs/netbox-custom-objects/issues/440) - Typeahead search returns no results for non-text primary fields
+
+
 ## 0.4.6
 ---
 

--- a/netbox_custom_objects/__init__.py
+++ b/netbox_custom_objects/__init__.py
@@ -35,7 +35,7 @@ class CustomObjectsPluginConfig(PluginConfig):
     name = "netbox_custom_objects"
     verbose_name = "Custom Objects"
     description = "A plugin to manage custom objects in NetBox"
-    version = "0.4.6"
+    version = "0.4.7"
     author = 'Netbox Labs'
     author_email = 'support@netboxlabs.com'
     base_url = "custom-objects"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netboxlabs-netbox-custom-objects"
-version = "0.4.6"
+version = "0.4.7"
 description = "A plugin to manage custom objects in NetBox"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Bumps version to `0.4.7` and updates the changelog.

## Changelog

### Enhancements

- [#25](https://github.com/netboxlabs/netbox-custom-objects/issues/25) - Linked custom objects should show up in the API response for related objects
- [#193](https://github.com/netboxlabs/netbox-custom-objects/issues/193) - Grouping custom objects
- [#292](https://github.com/netboxlabs/netbox-custom-objects/issues/292) - Move COTF to their own standard ViewTab in the COT detail view
- [#308](https://github.com/netboxlabs/netbox-custom-objects/issues/308) - Limit rows qty in "Custom Objects linking to this object" panels

### Bug Fixes

- [#382](https://github.com/netboxlabs/netbox-custom-objects/issues/382) - Primary name field breaks related custom objects and netbox objects
- [#383](https://github.com/netboxlabs/netbox-custom-objects/issues/383) - Related objects and count on Netbox Objects are rendered twice
- [#394](https://github.com/netboxlabs/netbox-custom-objects/issues/394) - Reindex CachedValues when COT fields are changed
- [#407](https://github.com/netboxlabs/netbox-custom-objects/issues/407) - Custom object types visible in menu without permissions
- [#409](https://github.com/netboxlabs/netbox-custom-objects/issues/409) - Required Fields also required when bulk editing
- [#417](https://github.com/netboxlabs/netbox-custom-objects/issues/417) - Filtering objects by multiple-object field does not work
- [#423](https://github.com/netboxlabs/netbox-custom-objects/issues/423) - Can't use custom object as field type in POST /api/plugins/custom-objects/custom-object-type-fields/
- [#429](https://github.com/netboxlabs/netbox-custom-objects/issues/429) - Deleting Custom Object and Custom Object Type Together Causes Missing Relation Error
- [#440](https://github.com/netboxlabs/netbox-custom-objects/issues/440) - Typeahead search returns no results for non-text primary fields

Generated with [Claude Code](https://claude.com/claude-code)
