### PR TITLE
Release v0.4.9

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.4.9
+---
+
+### Bug Fixes
+
+- [#456](https://github.com/netboxlabs/netbox-custom-objects/issues/456) - Error executing migration due to missing `group_name` column when upgrading from v0.4.6
+
+
 ## 0.4.8
 ---
 

--- a/netbox_custom_objects/__init__.py
+++ b/netbox_custom_objects/__init__.py
@@ -70,7 +70,7 @@ class CustomObjectsPluginConfig(PluginConfig):
     name = "netbox_custom_objects"
     verbose_name = "Custom Objects"
     description = "A plugin to manage custom objects in NetBox"
-    version = "0.4.8"
+    version = "0.4.9"
     author = 'Netbox Labs'
     author_email = 'support@netboxlabs.com'
     base_url = "custom-objects"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netboxlabs-netbox-custom-objects"
-version = "0.4.8"
+version = "0.4.9"
 description = "A plugin to manage custom objects in NetBox"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- Bump version to `0.4.9` in `pyproject.toml` and `__init__.py`
- Update changelog

## Changes since v0.4.8

- [#456](https://github.com/netboxlabs/netbox-custom-objects/issues/456) — Fix `manage.py migrate` crash (`column group_name does not exist`) when upgrading from v0.4.6. `CustomObjectsPluginConfig.get_model()` was querying the DB unconditionally during Django's system-check URL loading phase, before the migration adding `group_name` had run. Added the same `should_skip_dynamic_model_creation()` guard that already existed in `get_models()`, plus a regression test suite (`PluginConfigGetModelTestCase`).

## Test plan

- [ ] Run full test suite: `python netbox/manage.py test netbox_custom_objects.tests --keepdb`
- [ ] Confirm `PluginConfigGetModelTestCase` (3 tests) passes
- [ ] Install on a NetBox instance running v0.4.6 DB schema, run `manage.py migrate`, confirm no error

Generated with [Claude Code](https://claude.com/claude-code)