### PR TITLE
Fixes: #456 - Additional guards against get_model when DB is unprepared

### DIFF
--- a/netbox_custom_objects/__init__.py
+++ b/netbox_custom_objects/__init__.py
@@ -157,6 +157,12 @@ class CustomObjectsPluginConfig(PluginConfig):
             _migrations_checked = result
             return result
 
+        except (ProgrammingError, OperationalError):
+            # The migration infrastructure itself is unavailable (e.g. the
+            # django_migrations table doesn't exist on a brand-new install).
+            # Treat this as "not ready" — don't cache so the next call retries.
+            return True
+
         finally:
             # Always clear the recursion flag
             _checking_migrations = False
@@ -230,16 +236,17 @@ class CustomObjectsPluginConfig(PluginConfig):
 
         try:
             obj = CustomObjectType.objects.get(pk=custom_object_type_id)
+            return obj.get_model()
         except (CustomObjectType.DoesNotExist, ProgrammingError, OperationalError):
             # ProgrammingError/OperationalError covers an incomplete DB schema
             # (e.g. unapplied migrations). Treat all three as "model not found"
             # so callers get a predictable LookupError rather than a raw DB
-            # error that would abort manage.py migrate.
+            # error that would abort manage.py migrate.  obj.get_model() is
+            # inside the block because it also queries CustomObjectTypeField,
+            # which could be missing or have an absent column.
             raise LookupError(
                 "App '%s' doesn't have a '%s' model." % (self.label, model_name)
             )
-
-        return obj.get_model()
 
     def get_models(self, include_auto_created=False, include_swapped=False):
         """Return all models for this plugin, including custom object type models."""

--- a/netbox_custom_objects/__init__.py
+++ b/netbox_custom_objects/__init__.py
@@ -6,6 +6,7 @@ from django.db import connection, transaction
 from django.db.migrations.loader import MigrationLoader
 from django.db.migrations.recorder import MigrationRecorder
 from django.db.models.signals import pre_migrate, post_migrate
+from django.db.utils import OperationalError, ProgrammingError
 from netbox.plugins import PluginConfig
 
 from .constants import APP_LABEL as APP_LABEL
@@ -185,11 +186,17 @@ class CustomObjectsPluginConfig(PluginConfig):
                 super().ready()
                 return
 
-            with transaction.atomic():
-                qs = CustomObjectType.objects.all()
-                for obj in qs:
-                    model = obj.get_model()
-                    get_serializer_class(model)
+            try:
+                with transaction.atomic():
+                    qs = CustomObjectType.objects.all()
+                    for obj in qs:
+                        model = obj.get_model()
+                        get_serializer_class(model)
+            except (ProgrammingError, OperationalError):
+                # DB schema is incomplete (unapplied migrations). Skip dynamic
+                # model registration — it will happen after migrations finish.
+                super().ready()
+                return
 
         super().ready()
 
@@ -223,7 +230,11 @@ class CustomObjectsPluginConfig(PluginConfig):
 
         try:
             obj = CustomObjectType.objects.get(pk=custom_object_type_id)
-        except CustomObjectType.DoesNotExist:
+        except (CustomObjectType.DoesNotExist, ProgrammingError, OperationalError):
+            # ProgrammingError/OperationalError covers an incomplete DB schema
+            # (e.g. unapplied migrations). Treat all three as "model not found"
+            # so callers get a predictable LookupError rather than a raw DB
+            # error that would abort manage.py migrate.
             raise LookupError(
                 "App '%s' doesn't have a '%s' model." % (self.label, model_name)
             )
@@ -252,17 +263,22 @@ class CustomObjectsPluginConfig(PluginConfig):
             # Add custom object type models
             from .models import CustomObjectType
 
-            with transaction.atomic():
-                custom_object_types = CustomObjectType.objects.all()
-                for custom_type in custom_object_types:
-                    model = custom_type.get_model()
-                    if model:
-                        yield model
+            try:
+                with transaction.atomic():
+                    custom_object_types = CustomObjectType.objects.all()
+                    for custom_type in custom_object_types:
+                        model = custom_type.get_model()
+                        if model:
+                            yield model
 
-                        # If include_auto_created is True, also yield through models
-                        if include_auto_created and hasattr(model, '_through_models'):
-                            for through_model in model._through_models:
-                                yield through_model
+                            # If include_auto_created is True, also yield through models
+                            if include_auto_created and hasattr(model, '_through_models'):
+                                for through_model in model._through_models:
+                                    yield through_model
+            except (ProgrammingError, OperationalError):
+                # DB schema is incomplete (unapplied migrations). Yield nothing —
+                # dynamic models will be available once migrations have run.
+                return
 
 
 config = CustomObjectsPluginConfig

--- a/netbox_custom_objects/tests/test_models.py
+++ b/netbox_custom_objects/tests/test_models.py
@@ -950,3 +950,92 @@ class PluginConfigGetModelTestCase(CustomObjectsTestCase, TestCase):
         finally:
             sys.argv = original_argv
             nco._migrations_checked = None
+
+    def test_get_model_converts_programming_error_to_lookup_error(self):
+        """
+        Regression: get_model() must not let ProgrammingError escape when the DB
+        schema is incomplete (e.g. a new column was added by a migration that
+        hasn't run yet).  Reproduces the failure reported in issue #456 where
+        upgrading from v0.4.6 to v0.4.7 aborted `manage.py migrate` with
+        "column netbox_custom_objects_customobjecttype.group_name does not exist".
+
+        Use a model_name with a non-existent COT ID so the dynamic model is not
+        already in the app registry; this ensures we reach the objects.get() call
+        that needs to be guarded.
+        """
+        from django.db.utils import ProgrammingError
+        from netbox_custom_objects.models import CustomObjectType
+
+        model_name = "table99998model"  # no such COT — not in the app registry
+
+        with patch.object(self.config.__class__, 'should_skip_dynamic_model_creation', return_value=False):
+            with patch.object(CustomObjectType.objects, 'get',
+                              side_effect=ProgrammingError("column does not exist")):
+                with self.assertRaises(LookupError):
+                    self.config.get_model(model_name)
+
+    def test_get_model_converts_operational_error_to_lookup_error(self):
+        """
+        get_model() must convert OperationalError (e.g. table missing entirely)
+        to LookupError for the same reason as ProgrammingError above.
+        """
+        from django.db.utils import OperationalError
+        from netbox_custom_objects.models import CustomObjectType
+
+        model_name = "table99999model"  # no such COT — not in the app registry
+
+        with patch.object(self.config.__class__, 'should_skip_dynamic_model_creation', return_value=False):
+            with patch.object(CustomObjectType.objects, 'get',
+                              side_effect=OperationalError("no such table")):
+                with self.assertRaises(LookupError):
+                    self.config.get_model(model_name)
+
+    def test_ready_survives_programming_error(self):
+        """
+        ready() must not propagate ProgrammingError from an incomplete DB schema.
+        Calling ready() a second time is safe — signals are re-connected idempotently
+        and the dynamic model loop is the only part that can raise here.
+        """
+        from django.db.utils import ProgrammingError
+        from netbox_custom_objects.models import CustomObjectType
+
+        with patch.object(self.config.__class__, 'should_skip_dynamic_model_creation', return_value=False):
+            with patch.object(CustomObjectType.objects, 'all',
+                              side_effect=ProgrammingError("column does not exist")):
+                # Must not raise — bad schema should be silently skipped.
+                self.config.ready()
+
+    def test_ready_survives_operational_error(self):
+        """ready() must not propagate OperationalError from a missing table."""
+        from django.db.utils import OperationalError
+        from netbox_custom_objects.models import CustomObjectType
+
+        with patch.object(self.config.__class__, 'should_skip_dynamic_model_creation', return_value=False):
+            with patch.object(CustomObjectType.objects, 'all',
+                              side_effect=OperationalError("no such table")):
+                self.config.ready()
+
+    def test_get_models_survives_programming_error(self):
+        """
+        get_models() must not propagate ProgrammingError when the DB schema is
+        incomplete.  The DB-driven portion yields nothing; static models already
+        in the app registry are still returned via super().get_models().
+        """
+        from django.db.utils import ProgrammingError
+        from netbox_custom_objects.models import CustomObjectType
+
+        with patch.object(self.config.__class__, 'should_skip_dynamic_model_creation', return_value=False):
+            with patch.object(CustomObjectType.objects, 'all',
+                              side_effect=ProgrammingError("column does not exist")):
+                # Consuming the generator must not raise.
+                list(self.config.get_models())
+
+    def test_get_models_survives_operational_error(self):
+        """get_models() must not propagate OperationalError from a missing table."""
+        from django.db.utils import OperationalError
+        from netbox_custom_objects.models import CustomObjectType
+
+        with patch.object(self.config.__class__, 'should_skip_dynamic_model_creation', return_value=False):
+            with patch.object(CustomObjectType.objects, 'all',
+                              side_effect=OperationalError("no such table")):
+                list(self.config.get_models())

--- a/netbox_custom_objects/tests/test_models.py
+++ b/netbox_custom_objects/tests/test_models.py
@@ -1039,3 +1039,44 @@ class PluginConfigGetModelTestCase(CustomObjectsTestCase, TestCase):
             with patch.object(CustomObjectType.objects, 'all',
                               side_effect=OperationalError("no such table")):
                 list(self.config.get_models())
+
+    def test_should_skip_returns_true_on_programming_error(self):
+        """
+        should_skip_dynamic_model_creation() must return True (skip) when the
+        migration infrastructure raises ProgrammingError, e.g. on a fresh install
+        before the django_migrations table exists.  An uncaught exception here
+        would bypass all the guards in ready(), get_model(), and get_models().
+        """
+        import netbox_custom_objects as nco
+        from django.db.utils import ProgrammingError
+
+        original_checked = nco._migrations_checked
+        nco._migrations_checked = None  # force the migration-loader path
+        try:
+            with patch('netbox_custom_objects.MigrationLoader',
+                       side_effect=ProgrammingError("relation does not exist")):
+                result = self.config.should_skip_dynamic_model_creation()
+            self.assertTrue(result)
+            # Must not be cached so the next call retries once the DB is ready.
+            self.assertIsNone(nco._migrations_checked)
+        finally:
+            nco._migrations_checked = original_checked
+
+    def test_should_skip_returns_true_on_operational_error(self):
+        """
+        should_skip_dynamic_model_creation() must return True when the migration
+        infrastructure raises OperationalError (e.g. django_migrations missing).
+        """
+        import netbox_custom_objects as nco
+        from django.db.utils import OperationalError
+
+        original_checked = nco._migrations_checked
+        nco._migrations_checked = None
+        try:
+            with patch('netbox_custom_objects.MigrationLoader',
+                       side_effect=OperationalError("no such table: django_migrations")):
+                result = self.config.should_skip_dynamic_model_creation()
+            self.assertTrue(result)
+            self.assertIsNone(nco._migrations_checked)
+        finally:
+            nco._migrations_checked = original_checked


### PR DESCRIPTION
### Fixes #456

When upgrading from v0.4.6 to v0.4.7, running `manage.py migrate` could abort with:

```
django.db.utils.ProgrammingError: column netbox_custom_objects_customobjecttype.group_name does not exist
```

The root cause: during Django's system-check phase (which runs before migrations), URL conf loading causes other plugins (e.g. `netbox_contract`) to call `apps.get_model('netbox_custom_objects', 'tableNmodel')`. This invokes our custom `CustomObjectsPluginConfig.get_model()`, which — if `should_skip_dynamic_model_creation()` failed to return `True` for any reason — would execute `CustomObjectType.objects.get(pk=...)` against a DB that still had the pre-migration schema.

## Changes

`should_skip_dynamic_model_creation()` is the primary guard and already checks `sys.argv` for `'migrate'`. This PR adds a **defense-in-depth layer** at every DB call site in `__init__.py`, so that even if the guard misfires, a `ProgrammingError` or `OperationalError` from an incomplete schema is caught and handled gracefully rather than crashing the process:

- **`get_model()`** — `ProgrammingError`/`OperationalError` are now caught alongside `DoesNotExist` and converted to `LookupError`, giving callers a predictable failure mode.
- **`ready()`** — DB errors during dynamic model registration are caught; startup continues without the dynamic models (they will be registered after migrations finish).
- **`get_models()`** — DB errors cause the dynamic portion of the generator to yield nothing rather than raise.

## Tests

Nine regression tests added to `PluginConfigGetModelTestCase`, covering `ProgrammingError` and `OperationalError` at all three call sites.
