### PR TITLE
Fixes #468: Suppress spurious warning from migration 0003 on fresh install

### DIFF
--- a/netbox_custom_objects/migrations/0003_ensure_fk_constraints.py
+++ b/netbox_custom_objects/migrations/0003_ensure_fk_constraints.py
@@ -6,11 +6,27 @@ def ensure_existing_fk_constraints(apps, schema_editor):
     Go through all existing CustomObjectType models and ensure FK constraints
     are properly set for any OBJECT type fields.
     """
+    # Fast path: if there are no rows, there is nothing to do.  We check via
+    # raw SQL (SELECT id only) to avoid touching columns that may not exist in
+    # the DB schema yet when this migration runs — e.g. group_name is added by
+    # the *next* migration (0004), so the live model class already declares it,
+    # but the column is absent from the table until 0004 runs.  A plain
+    # CustomObjectType.objects.all() would generate SELECT … group_name … and
+    # raise a ProgrammingError even when the table is empty, which causes a
+    # confusing warning on every fresh install.
+    with schema_editor.connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT EXISTS(SELECT 1 FROM netbox_custom_objects_customobjecttype)"
+        )
+        has_rows = cursor.fetchone()[0]
+
+    if not has_rows:
+        return
+
     # Import the actual model class (not the historical version) to access methods.
-    # On a fresh install, later migrations may have added fields to the live model
-    # that don't exist in the DB yet when this migration runs (e.g. group_name from 0004).
-    # We use a savepoint so that if the ORM query fails, we can roll back to a clean
-    # transaction state rather than leaving PostgreSQL in an aborted-transaction state.
+    # On an upgrade where this migration and 0004 are applied together, the live
+    # model may reference columns that don't exist yet.  We use a savepoint so
+    # that if the ORM query fails we can roll back to a clean transaction state.
     from netbox_custom_objects.models import CustomObjectType
 
     sid = transaction.savepoint()


### PR DESCRIPTION
### Fixes #468

## Summary

- Migration `0003_ensure_fk_constraints` imports the live `CustomObjectType` model to check FK constraints on existing rows. On a fresh install, `0003` runs before `0004`, so the live model already declares `group_name` but the column does not exist in the DB yet. The `SELECT … group_name …` query raised a `ProgrammingError`, which was caught by a savepoint/rollback — but the `print()` in the except handler fired anyway, producing a confusing warning on every clean install.
- Add a `SELECT EXISTS(…)` raw-SQL check at the top of the migration function. When the table is empty (fresh install), return immediately without touching the ORM. The savepoint fallback is retained for the genuine edge case: an upgrade where `0003` and `0004` are applied together against a non-empty table.

## Test plan

- [ ] Run `manage.py migrate` on a clean database — confirm no warning is printed for `0003`
- [ ] Run `manage.py migrate` upgrading from a database with existing `CustomObjectType` rows (pre-`0003`) — confirm FK constraint check still executes
