### PR TITLE
Closes #425: Update and pin GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/lint-tests.yaml
+++ b/.github/workflows/lint-tests.yaml
@@ -19,9 +19,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
       - name: Install dependencies
@@ -58,15 +58,15 @@ jobs:
           - 5432:5432
     steps:
       - name: Checkout netbox-custom-objects
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: netbox-custom-objects
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
       - name: Checkout netbox (${{ matrix.netbox-ref }})
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "netbox-community/netbox"
           path: netbox

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,10 +12,10 @@ jobs:
     name: Build distribution
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: "3.x"
     - name: Install pypa/build
@@ -25,7 +25,7 @@ jobs:
       run: |
         python3 -m build
     - name: Upload distribution package
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: python-package-distributions
         path: dist/
@@ -40,9 +40,9 @@ jobs:
       id-token: write
     steps:
     - name: Download distribution package
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: python-package-distributions
         path: dist/
     - name: Publish distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0


### PR DESCRIPTION
<!--
    Please note that pull requests are accepted ONLY for approved
    issues. Specify the issue resolved by this PR below.
-->
### Fixes: #425

This PR updates the affected GitHub Actions for GitHub Actions' Node 20 deprecation and pins all referenced actions to full commit SHAs instead of version tags. This helps reduce supply chain risk from tag retargeting while preparing the workflows for the transition to Node 24.

The Node.js version used for CI testing is unchanged; this update only affects the GitHub Actions used by the workflows themselves.

Updated actions:
- `actions/checkout` to `v6.0.2`
- `actions/setup-python` to `v6.2.0`
- `actions/download-artifact` to `v8.0.1`
- `actions/upload-artifact` to `v7.0.1`
- `pypa/gh-action-pypi-publish` to `v1.14.0`