### PR TITLE
Fixes #500: Remove deprecated user kwarg from ObjectChangeTable

### DIFF
--- a/netbox_custom_objects/tests/test_views.py
+++ b/netbox_custom_objects/tests/test_views.py
@@ -308,7 +308,9 @@ class CustomObjectViewTestCase(CustomObjectsTestCase, ViewTestCases.PrimaryObjec
         ...
 
     def test_get_object_changelog(self):
-        ...
+        """Regression #500: changelog tab must return 200, not 500 from deprecated user kwarg."""
+        url = self._get_url('changelog', self.instance1)
+        self.assertHttpStatus(self.client.get(url), 200)
 
     def test_create_object_with_permission(self):
         ...
@@ -516,7 +518,9 @@ class ComplexCustomObjectViewTestCase(CustomObjectsTestCase, ViewTestCases.Prima
         ...
 
     def test_get_object_changelog(self):
-        ...
+        """Regression #500: changelog tab must return 200, not 500 from deprecated user kwarg."""
+        url = self._get_url('changelog', self.instance_1)
+        self.assertHttpStatus(self.client.get(url), 200)
 
     def test_create_object_with_permission(self):
         ...
@@ -680,7 +684,11 @@ class ObjectFieldViewTestCase(CustomObjectsTestCase, ViewTestCases.PrimaryObject
         ...
 
     def test_get_object_changelog(self):
-        ...
+        """Regression #500: changelog tab must return 200, not 500 from deprecated user kwarg."""
+        if self.instance_1 is None:
+            self.skipTest("DCIM models not available")
+        url = self._get_url('changelog', self.instance_1)
+        self.assertHttpStatus(self.client.get(url), 200)
 
     def test_create_object_with_permission(self):
         ...

--- a/netbox_custom_objects/views.py
+++ b/netbox_custom_objects/views.py
@@ -1399,7 +1399,7 @@ class CustomObjectChangeLogView(ConditionalLoginRequiredMixin, View):
         )
 
         objectchanges_table = ObjectChangeTable(
-            data=objectchanges, orderable=False, user=request.user
+            data=objectchanges, orderable=False
         )
         objectchanges_table.configure(request)
 


### PR DESCRIPTION
## Summary

- Removes `user=request.user` from the `ObjectChangeTable(...)` instantiation in `CustomObjectChangeLogView`
- NetBox moved per-user column personalisation out of `BaseTable.__init__` into `configure(request)` (since v4.3); `__init__` now passes `**kwargs` straight through to django-tables2, which does not accept a `user` argument, causing `TypeError: Table.__init__() got an unexpected keyword argument 'user'` on every visit to the changelog tab
- The `configure(request)` call on the very next line already handles per-user preferences, so the kwarg was always redundant

**Compatible with NetBox 4.4+** — `configure(request)` has been available since NetBox v4.3.

## Test plan

- [ ] Create a Custom Object Type and an instance, navigate to the instance Changelog tab — confirm HTTP 200 and no TypeError

Closes: #500

Generated with [Claude Code](https://claude.com/claude-code)