### PR TITLE
Fixes #507: Make migration 0011 idempotent and safe for long table names

### DIFF
--- a/netbox_custom_objects/migrations/0011_non_deferrable_fk_constraints.py
+++ b/netbox_custom_objects/migrations/0011_non_deferrable_fk_constraints.py
@@ -7,7 +7,27 @@ because it has pending trigger events". Recreate any existing DEFERRABLE FKs
 on custom_objects_* tables as non-DEFERRABLE.
 """
 
+import hashlib
+
 from django.db import migrations
+
+_PG_MAX_IDENTIFIER_LEN = 63
+
+
+def _safe_constraint_name(table_name, column_name, suffix='_fk_cascade'):
+    """
+    Return a constraint name that fits within PostgreSQL's 63-char identifier limit.
+
+    Uses the same truncate-and-hash strategy as field_types._safe_pg_identifier so
+    that long through-table names (e.g. custom_objects_14_technical_account_accounts)
+    combined with column names do not silently collide after PostgreSQL truncation.
+    """
+    full_name = f'{table_name}_{column_name}{suffix}'
+    if len(full_name) <= _PG_MAX_IDENTIFIER_LEN:
+        return full_name
+    digest = hashlib.md5(full_name.encode()).hexdigest()[:8]
+    prefix = full_name[:_PG_MAX_IDENTIFIER_LEN - 9].rstrip('_')
+    return f'{prefix}_{digest}'
 
 
 def fix_deferrable_fk_constraints(apps, schema_editor):
@@ -36,9 +56,17 @@ def fix_deferrable_fk_constraints(apps, schema_editor):
         rows = cursor.fetchall()
 
         for table_name, constraint_name, column_name, foreign_table in rows:
-            new_constraint_name = f'{table_name}_{column_name}_fk_cascade'
+            new_constraint_name = _safe_constraint_name(table_name, column_name)
+            # IF EXISTS on the old name handles partial re-runs where the old constraint
+            # was already dropped in a previous (failed) attempt.
             cursor.execute(
-                f'ALTER TABLE "{table_name}" DROP CONSTRAINT "{constraint_name}"'
+                f'ALTER TABLE "{table_name}" DROP CONSTRAINT IF EXISTS "{constraint_name}"'
+            )
+            # Pre-drop the new name too: if a previous run converted this constraint and
+            # then failed later (leaving the non-DEFERRABLE copy behind), the ADD below
+            # would collide. Dropping first makes every iteration idempotent.
+            cursor.execute(
+                f'ALTER TABLE "{table_name}" DROP CONSTRAINT IF EXISTS "{new_constraint_name}"'
             )
             cursor.execute(f"""
                 ALTER TABLE "{table_name}"

--- a/netbox_custom_objects/migrations/0011_non_deferrable_fk_constraints.py
+++ b/netbox_custom_objects/migrations/0011_non_deferrable_fk_constraints.py
@@ -18,9 +18,13 @@ def _safe_constraint_name(table_name, column_name, suffix='_fk_cascade'):
     """
     Return a constraint name that fits within PostgreSQL's 63-char identifier limit.
 
-    Uses the same truncate-and-hash strategy as field_types._safe_pg_identifier so
-    that long through-table names (e.g. custom_objects_14_technical_account_accounts)
-    combined with column names do not silently collide after PostgreSQL truncation.
+    Intentionally duplicates the logic from field_types._safe_pg_identifier rather
+    than importing it: migrations must be self-contained so they remain correct even
+    if the live codebase is later refactored.
+
+    Uses the same truncate-and-hash strategy so that long through-table names
+    (e.g. custom_objects_14_technical_account_accounts) combined with column names
+    do not silently collide after PostgreSQL truncation.
     """
     full_name = f'{table_name}_{column_name}{suffix}'
     if len(full_name) <= _PG_MAX_IDENTIFIER_LEN:

--- a/netbox_custom_objects/tests/test_migration_0011.py
+++ b/netbox_custom_objects/tests/test_migration_0011.py
@@ -1,0 +1,271 @@
+"""
+Regression tests for migration 0011 (fix_deferrable_fk_constraints).
+
+Covers:
+- Basic conversion: DEFERRABLE FK constraints are recreated as non-DEFERRABLE.
+- Long table names: constraint names exceeding PostgreSQL's 63-char limit are
+  handled via _safe_constraint_name (truncate + MD5 digest) so that two columns
+  on the same long-named table never collide.
+- Partial re-run / idempotency: if a previous migration attempt left behind a
+  non-DEFERRABLE _fk_cascade constraint alongside the original DEFERRABLE one
+  (possible in non-atomic or interrupted runs), the migration succeeds instead
+  of raising DuplicateObject.
+"""
+
+import importlib
+
+from django.db import connection
+from django.test import TransactionTestCase
+
+from .base import TransactionCleanupMixin
+
+# Import the migration module whose name starts with a digit.
+_m0011 = importlib.import_module(
+    'netbox_custom_objects.migrations.0011_non_deferrable_fk_constraints'
+)
+fix_deferrable_fk_constraints = _m0011.fix_deferrable_fk_constraints
+_safe_constraint_name = _m0011._safe_constraint_name
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_REF_TABLE = 'django_content_type'  # always present; provides a real FK target
+
+
+class _FakeSchemaEditor:
+    """Minimal stand-in accepted by fix_deferrable_fk_constraints."""
+    connection = connection
+
+
+def _get_fk_constraints(table_name):
+    """Return {constraint_name: is_deferrable} for all FK constraints on *table_name*."""
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT tc.constraint_name, tc.is_deferrable
+            FROM information_schema.table_constraints AS tc
+            WHERE tc.constraint_type = 'FOREIGN KEY'
+              AND tc.table_name = %s
+              AND tc.table_schema = current_schema()
+            """,
+            [table_name],
+        )
+        return {row[0]: row[1] for row in cursor.fetchall()}
+
+
+def _add_deferrable_fk(table_name, constraint_name, column_name, ref_table=_REF_TABLE):
+    with connection.cursor() as cursor:
+        cursor.execute(
+            f"""
+            ALTER TABLE "{table_name}"
+            ADD CONSTRAINT "{constraint_name}"
+            FOREIGN KEY ("{column_name}")
+            REFERENCES "{ref_table}" ("id")
+            ON DELETE CASCADE
+            DEFERRABLE INITIALLY DEFERRED
+            """
+        )
+
+
+def _add_nondeferrable_fk(table_name, constraint_name, column_name, ref_table=_REF_TABLE):
+    with connection.cursor() as cursor:
+        cursor.execute(
+            f"""
+            ALTER TABLE "{table_name}"
+            ADD CONSTRAINT "{constraint_name}"
+            FOREIGN KEY ("{column_name}")
+            REFERENCES "{ref_table}" ("id")
+            ON DELETE CASCADE
+            """
+        )
+
+
+# ---------------------------------------------------------------------------
+# Base TestCase
+# ---------------------------------------------------------------------------
+
+class Migration0011TestCase(TransactionCleanupMixin, TransactionTestCase):
+    """
+    Each subclass creates its own scratch table(s) in setUp and drops them in
+    tearDown.  Tables use IDs in the 99900+ range to avoid colliding with any
+    real CustomObjectType rows.
+    """
+
+    scratch_tables: list[str] = []
+
+    def setUp(self):
+        super().setUp()
+        self._created_tables: list[str] = []
+
+    def tearDown(self):
+        with connection.cursor() as cursor:
+            for table in reversed(self._created_tables):
+                cursor.execute(f'DROP TABLE IF EXISTS "{table}" CASCADE')
+        super().tearDown()
+
+    def _create_scratch_table(self, table_name: str, columns: list[str]):
+        """CREATE TABLE with nullable integer columns; register for tearDown."""
+        col_defs = ', '.join(f'"{c}" INTEGER' for c in columns)
+        with connection.cursor() as cursor:
+            cursor.execute(
+                f'CREATE TABLE "{table_name}" (id SERIAL PRIMARY KEY, {col_defs})'
+            )
+        self._created_tables.append(table_name)
+
+    def _run_migration(self):
+        fix_deferrable_fk_constraints(None, _FakeSchemaEditor())
+
+
+# ---------------------------------------------------------------------------
+# Test: basic conversion (short names)
+# ---------------------------------------------------------------------------
+
+class BasicConversionTestCase(Migration0011TestCase):
+    """DEFERRABLE constraints on a short-named table are converted to non-DEFERRABLE."""
+
+    TABLE = 'custom_objects_99901'
+
+    def setUp(self):
+        super().setUp()
+        self._create_scratch_table(self.TABLE, ['site_id', 'device_id'])
+        _add_deferrable_fk(self.TABLE, f'{self.TABLE}_site_id_old', 'site_id')
+        _add_deferrable_fk(self.TABLE, f'{self.TABLE}_device_id_old', 'device_id')
+
+    def test_constraints_become_non_deferrable(self):
+        self._run_migration()
+        constraints = _get_fk_constraints(self.TABLE)
+        self.assertTrue(constraints, 'Expected at least one FK constraint after migration')
+        for name, deferrable in constraints.items():
+            self.assertEqual(
+                deferrable, 'NO',
+                f'Constraint {name!r} should be non-DEFERRABLE but is_deferrable={deferrable!r}',
+            )
+
+    def test_new_constraint_names_have_fk_cascade_suffix(self):
+        self._run_migration()
+        constraints = _get_fk_constraints(self.TABLE)
+        for name in constraints:
+            self.assertTrue(
+                name.endswith('_fk_cascade'),
+                f'Expected _fk_cascade suffix on {name!r}',
+            )
+
+    def test_one_constraint_per_column(self):
+        self._run_migration()
+        constraints = _get_fk_constraints(self.TABLE)
+        self.assertEqual(len(constraints), 2, f'Expected 2 constraints, got: {list(constraints)}')
+
+
+# ---------------------------------------------------------------------------
+# Test: long table name — truncation safety
+# ---------------------------------------------------------------------------
+
+class LongTableNameTestCase(Migration0011TestCase):
+    """
+    Through-table with a 47-char name + columns whose combined constraint name
+    exceeds 63 chars.  The old code would silently truncate and potentially
+    collide; the new _safe_constraint_name must keep names unique and ≤ 63 chars.
+    """
+
+    # 47 chars — long enough that any column with name > 5 chars overflows 63.
+    TABLE = 'custom_objects_99902_long_through_table_name_abc'
+
+    def setUp(self):
+        super().setUp()
+        # Two columns whose first 18 chars are identical.  With the old naïve
+        # naming they would both truncate to the same 63-char string and the
+        # second ADD CONSTRAINT would raise DuplicateObject.
+        self._create_scratch_table(
+            self.TABLE,
+            ['applicant_user_id_first_variant', 'applicant_user_id_secnd_variant'],
+        )
+        # Use short hash-style names for the original DEFERRABLE constraints,
+        # matching how Django's migration system auto-names them in production.
+        _add_deferrable_fk(
+            self.TABLE,
+            'old_deferrable_col1_99902a',
+            'applicant_user_id_first_variant',
+        )
+        _add_deferrable_fk(
+            self.TABLE,
+            'old_deferrable_col2_99902b',
+            'applicant_user_id_secnd_variant',
+        )
+
+    def test_migration_succeeds_without_duplicate_object_error(self):
+        """Should not raise DuplicateObject even though naïve names would collide."""
+        try:
+            self._run_migration()
+        except Exception as exc:
+            self.fail(f'fix_deferrable_fk_constraints raised unexpectedly: {exc}')
+
+    def test_all_constraints_non_deferrable(self):
+        self._run_migration()
+        constraints = _get_fk_constraints(self.TABLE)
+        self.assertEqual(len(constraints), 2, f'Expected 2 constraints, got: {list(constraints)}')
+        for name, deferrable in constraints.items():
+            self.assertEqual(deferrable, 'NO', f'{name!r} should be non-DEFERRABLE')
+
+    def test_constraint_names_within_pg_limit(self):
+        self._run_migration()
+        for name in _get_fk_constraints(self.TABLE):
+            self.assertLessEqual(
+                len(name), 63,
+                f'Constraint name {name!r} ({len(name)} chars) exceeds PostgreSQL 63-char limit',
+            )
+
+    def test_constraint_names_are_unique(self):
+        self._run_migration()
+        names = list(_get_fk_constraints(self.TABLE))
+        self.assertEqual(len(names), len(set(names)), f'Duplicate constraint names: {names}')
+
+    def test_safe_constraint_name_unit(self):
+        """_safe_constraint_name produces distinct names for the two colliding columns."""
+        n1 = _safe_constraint_name(self.TABLE, 'applicant_user_id_first_variant')
+        n2 = _safe_constraint_name(self.TABLE, 'applicant_user_id_secnd_variant')
+        self.assertNotEqual(n1, n2)
+        self.assertLessEqual(len(n1), 63)
+        self.assertLessEqual(len(n2), 63)
+
+
+# ---------------------------------------------------------------------------
+# Test: partial re-run / idempotency
+# ---------------------------------------------------------------------------
+
+class PartialRerunTestCase(Migration0011TestCase):
+    """
+    Simulate a database left in partial state: one column still has its original
+    DEFERRABLE constraint PLUS the _fk_cascade non-DEFERRABLE constraint already
+    present (as if a prior run succeeded for that column but failed to commit, then
+    was retried with autocommit on).  The migration must not raise DuplicateObject.
+    """
+
+    TABLE = 'custom_objects_99903'
+
+    def setUp(self):
+        super().setUp()
+        self._create_scratch_table(self.TABLE, ['site_id', 'tenant_id'])
+
+        # site_id: partial state — old DEFERRABLE constraint still present
+        # AND the new _fk_cascade non-DEFERRABLE one already exists.
+        _add_deferrable_fk(self.TABLE, f'{self.TABLE}_site_id_old_hash', 'site_id')
+        new_site_name = _safe_constraint_name(self.TABLE, 'site_id')
+        _add_nondeferrable_fk(self.TABLE, new_site_name, 'site_id')
+
+        # tenant_id: normal state — only old DEFERRABLE constraint.
+        _add_deferrable_fk(self.TABLE, f'{self.TABLE}_tenant_id_old_hash', 'tenant_id')
+
+    def test_migration_succeeds_with_pre_existing_fk_cascade_constraint(self):
+        try:
+            self._run_migration()
+        except Exception as exc:
+            self.fail(f'fix_deferrable_fk_constraints raised unexpectedly: {exc}')
+
+    def test_all_constraints_non_deferrable_after_rerun(self):
+        self._run_migration()
+        constraints = _get_fk_constraints(self.TABLE)
+        self.assertEqual(len(constraints), 2, f'Expected 2 constraints, got: {list(constraints)}')
+        for name, deferrable in constraints.items():
+            self.assertEqual(deferrable, 'NO', f'{name!r} should be non-DEFERRABLE')

--- a/netbox_custom_objects/tests/test_migrations.py
+++ b/netbox_custom_objects/tests/test_migrations.py
@@ -177,7 +177,7 @@ class LongTableNameTestCase(_Migration0011TestCase):
     collide; _safe_constraint_name must keep names unique and ≤ 63 chars.
     """
 
-    # 47 chars — long enough that any column with name > 5 chars overflows 63.
+    # 47 chars — long enough that any column with name > 4 chars overflows 63.
     TABLE = 'custom_objects_99902_long_through_table_name_abc'
 
     def setUp(self):
@@ -266,3 +266,24 @@ class PartialRerunTestCase(_Migration0011TestCase):
         self.assertEqual(len(constraints), 2, f'Expected 2 constraints, got: {list(constraints)}')
         for name, deferrable in constraints.items():
             self.assertEqual(deferrable, 'NO', f'{name!r} should be non-DEFERRABLE')
+
+    def test_site_id_has_exactly_one_fk_after_rerun(self):
+        """The old DEFERRABLE + pre-existing non-DEFERRABLE must collapse to one constraint."""
+        self._run_migration()
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT count(*)
+                FROM information_schema.table_constraints AS tc
+                JOIN information_schema.key_column_usage AS kcu
+                    ON tc.constraint_name = kcu.constraint_name
+                   AND tc.table_schema = kcu.table_schema
+                WHERE tc.constraint_type = 'FOREIGN KEY'
+                  AND tc.table_name = %s
+                  AND tc.table_schema = current_schema()
+                  AND kcu.column_name = 'site_id'
+                """,
+                [self.TABLE],
+            )
+            count = cursor.fetchone()[0]
+        self.assertEqual(count, 1, f'site_id should have exactly 1 FK constraint after migration, got {count}')

--- a/netbox_custom_objects/tests/test_migrations.py
+++ b/netbox_custom_objects/tests/test_migrations.py
@@ -1,15 +1,16 @@
 """
-Regression tests for migration 0011 (fix_deferrable_fk_constraints).
+Migration regression tests.
 
-Covers:
-- Basic conversion: DEFERRABLE FK constraints are recreated as non-DEFERRABLE.
-- Long table names: constraint names exceeding PostgreSQL's 63-char limit are
-  handled via _safe_constraint_name (truncate + MD5 digest) so that two columns
-  on the same long-named table never collide.
-- Partial re-run / idempotency: if a previous migration attempt left behind a
-  non-DEFERRABLE _fk_cascade constraint alongside the original DEFERRABLE one
-  (possible in non-atomic or interrupted runs), the migration succeeds instead
-  of raising DuplicateObject.
+Each migration with complex data or schema operations gets its own section here.
+The shared infrastructure (scratch-table base case, FK helpers) is defined once
+and reused across migration-specific groups.
+
+Adding tests for a new migration
+---------------------------------
+1. Load the migration with ``_load_migration('NNNN_migration_name')``.
+2. Subclass ``_MigrationTestCase`` (and optionally a thin migration-specific
+   intermediate) to get scratch-table creation and teardown for free.
+3. Add a clearly-delimited section below.
 """
 
 import importlib
@@ -19,23 +20,21 @@ from django.test import TransactionTestCase
 
 from .base import TransactionCleanupMixin
 
-# Import the migration module whose name starts with a digit.
-_m0011 = importlib.import_module(
-    'netbox_custom_objects.migrations.0011_non_deferrable_fk_constraints'
-)
-fix_deferrable_fk_constraints = _m0011.fix_deferrable_fk_constraints
-_safe_constraint_name = _m0011._safe_constraint_name
+
+def _load_migration(name):
+    """Import a migration module by its migration name (handles digit-prefixed names)."""
+    return importlib.import_module(f'netbox_custom_objects.migrations.{name}')
 
 
 # ---------------------------------------------------------------------------
-# Helpers
+# Shared helpers
 # ---------------------------------------------------------------------------
 
 _REF_TABLE = 'django_content_type'  # always present; provides a real FK target
 
 
 class _FakeSchemaEditor:
-    """Minimal stand-in accepted by fix_deferrable_fk_constraints."""
+    """Minimal stand-in for the schema_editor argument in RunPython functions."""
     connection = connection
 
 
@@ -86,14 +85,14 @@ def _add_nondeferrable_fk(table_name, constraint_name, column_name, ref_table=_R
 # Base TestCase
 # ---------------------------------------------------------------------------
 
-class Migration0011TestCase(TransactionCleanupMixin, TransactionTestCase):
+class _MigrationTestCase(TransactionCleanupMixin, TransactionTestCase):
     """
-    Each subclass creates its own scratch table(s) in setUp and drops them in
-    tearDown.  Tables use IDs in the 99900+ range to avoid colliding with any
-    real CustomObjectType rows.
-    """
+    Base for migration tests that need ephemeral custom_objects_* tables.
 
-    scratch_tables: list[str] = []
+    Subclasses call ``_create_scratch_table()`` in setUp; tables are dropped
+    automatically in tearDown.  Use IDs in the 99900+ range to avoid colliding
+    with any real CustomObjectType rows created during the test run.
+    """
 
     def setUp(self):
         super().setUp()
@@ -114,15 +113,29 @@ class Migration0011TestCase(TransactionCleanupMixin, TransactionTestCase):
             )
         self._created_tables.append(table_name)
 
+
+# ===========================================================================
+# Migration 0011 — fix_deferrable_fk_constraints
+# ===========================================================================
+#
+# Covers three failure modes reported in #507:
+#   1. Truncation collision — long through-table names combined with column names
+#      can exceed PostgreSQL's 63-char identifier limit; two columns sharing the
+#      same truncated prefix would collide on ADD CONSTRAINT.
+#   2. DROP without IF EXISTS — a re-run after a partial failure would error when
+#      the old constraint name was already gone.
+#   3. No pre-drop of new name — if a prior run left a non-DEFERRABLE _fk_cascade
+#      constraint behind, the ADD CONSTRAINT would raise DuplicateObject.
+
+_m0011 = _load_migration('0011_non_deferrable_fk_constraints')
+
+
+class _Migration0011TestCase(_MigrationTestCase):
     def _run_migration(self):
-        fix_deferrable_fk_constraints(None, _FakeSchemaEditor())
+        _m0011.fix_deferrable_fk_constraints(None, _FakeSchemaEditor())
 
 
-# ---------------------------------------------------------------------------
-# Test: basic conversion (short names)
-# ---------------------------------------------------------------------------
-
-class BasicConversionTestCase(Migration0011TestCase):
+class BasicConversionTestCase(_Migration0011TestCase):
     """DEFERRABLE constraints on a short-named table are converted to non-DEFERRABLE."""
 
     TABLE = 'custom_objects_99901'
@@ -145,8 +158,7 @@ class BasicConversionTestCase(Migration0011TestCase):
 
     def test_new_constraint_names_have_fk_cascade_suffix(self):
         self._run_migration()
-        constraints = _get_fk_constraints(self.TABLE)
-        for name in constraints:
+        for name in _get_fk_constraints(self.TABLE):
             self.assertTrue(
                 name.endswith('_fk_cascade'),
                 f'Expected _fk_cascade suffix on {name!r}',
@@ -158,15 +170,11 @@ class BasicConversionTestCase(Migration0011TestCase):
         self.assertEqual(len(constraints), 2, f'Expected 2 constraints, got: {list(constraints)}')
 
 
-# ---------------------------------------------------------------------------
-# Test: long table name — truncation safety
-# ---------------------------------------------------------------------------
-
-class LongTableNameTestCase(Migration0011TestCase):
+class LongTableNameTestCase(_Migration0011TestCase):
     """
     Through-table with a 47-char name + columns whose combined constraint name
     exceeds 63 chars.  The old code would silently truncate and potentially
-    collide; the new _safe_constraint_name must keep names unique and ≤ 63 chars.
+    collide; _safe_constraint_name must keep names unique and ≤ 63 chars.
     """
 
     # 47 chars — long enough that any column with name > 5 chars overflows 63.
@@ -183,16 +191,8 @@ class LongTableNameTestCase(Migration0011TestCase):
         )
         # Use short hash-style names for the original DEFERRABLE constraints,
         # matching how Django's migration system auto-names them in production.
-        _add_deferrable_fk(
-            self.TABLE,
-            'old_deferrable_col1_99902a',
-            'applicant_user_id_first_variant',
-        )
-        _add_deferrable_fk(
-            self.TABLE,
-            'old_deferrable_col2_99902b',
-            'applicant_user_id_secnd_variant',
-        )
+        _add_deferrable_fk(self.TABLE, 'old_deferrable_col1_99902a', 'applicant_user_id_first_variant')
+        _add_deferrable_fk(self.TABLE, 'old_deferrable_col2_99902b', 'applicant_user_id_secnd_variant')
 
     def test_migration_succeeds_without_duplicate_object_error(self):
         """Should not raise DuplicateObject even though naïve names would collide."""
@@ -223,18 +223,15 @@ class LongTableNameTestCase(Migration0011TestCase):
 
     def test_safe_constraint_name_unit(self):
         """_safe_constraint_name produces distinct names for the two colliding columns."""
-        n1 = _safe_constraint_name(self.TABLE, 'applicant_user_id_first_variant')
-        n2 = _safe_constraint_name(self.TABLE, 'applicant_user_id_secnd_variant')
+        safe = _m0011._safe_constraint_name
+        n1 = safe(self.TABLE, 'applicant_user_id_first_variant')
+        n2 = safe(self.TABLE, 'applicant_user_id_secnd_variant')
         self.assertNotEqual(n1, n2)
         self.assertLessEqual(len(n1), 63)
         self.assertLessEqual(len(n2), 63)
 
 
-# ---------------------------------------------------------------------------
-# Test: partial re-run / idempotency
-# ---------------------------------------------------------------------------
-
-class PartialRerunTestCase(Migration0011TestCase):
+class PartialRerunTestCase(_Migration0011TestCase):
     """
     Simulate a database left in partial state: one column still has its original
     DEFERRABLE constraint PLUS the _fk_cascade non-DEFERRABLE constraint already
@@ -251,7 +248,7 @@ class PartialRerunTestCase(Migration0011TestCase):
         # site_id: partial state — old DEFERRABLE constraint still present
         # AND the new _fk_cascade non-DEFERRABLE one already exists.
         _add_deferrable_fk(self.TABLE, f'{self.TABLE}_site_id_old_hash', 'site_id')
-        new_site_name = _safe_constraint_name(self.TABLE, 'site_id')
+        new_site_name = _m0011._safe_constraint_name(self.TABLE, 'site_id')
         _add_nondeferrable_fk(self.TABLE, new_site_name, 'site_id')
 
         # tenant_id: normal state — only old DEFERRABLE constraint.


### PR DESCRIPTION
### Fixes: #507 

## Summary

- **Truncation collision**: `fix_deferrable_fk_constraints` built new constraint names as `{table_name}_{column_name}_fk_cascade` with no length check. Through-tables with names like `custom_objects_14_technical_account_accounts` (44 chars) plus column names easily exceeded PostgreSQL's 63-char identifier limit. Two columns sharing enough of a prefix produced identical truncated names, causing `DuplicateObject` on the second `ADD CONSTRAINT`. Fixed by introducing `_safe_constraint_name()`, which uses the same truncate-and-MD5-hash strategy already present in `field_types._safe_pg_identifier`.
- **Old DROP without IF EXISTS**: If the migration failed mid-loop and was re-run, the old DEFERRABLE constraint might already be gone, causing `DROP CONSTRAINT "..."` to error. Fixed with `IF EXISTS`.
- **No pre-drop of new name**: If a partial prior run left behind a non-DEFERRABLE `_fk_cascade` constraint (invisible to the `is_deferrable = 'YES'` query), a later iteration could attempt to `ADD CONSTRAINT` with the same name and fail. Fixed by pre-dropping the new constraint name with `IF EXISTS` before the `ADD`.

## Test coverage

Added `netbox_custom_objects/tests/test_migrations.py` with 11 tests across three scenarios, all run against a real PostgreSQL database:

| Group | What it tests |
|---|---|
| `BasicConversionTestCase` | DEFERRABLE constraints on a short-named table are converted to non-DEFERRABLE with `_fk_cascade` names |
| `LongTableNameTestCase` | 47-char through-table + two columns whose naive `_fk_cascade` names share the same 63-char truncation prefix — verifies `_safe_constraint_name` produces distinct names <= 63 chars and the migration completes without `DuplicateObject` |
| `PartialRerunTestCase` | Pre-existing non-DEFERRABLE `_fk_cascade` constraint alongside the original DEFERRABLE one — verifies the migration is idempotent, both columns end up non-DEFERRABLE, and the partially-applied column collapses to exactly one FK constraint |

All 11 tests pass locally (`Ran 11 tests in ~11s — OK`).

Closes: #507