### PR TITLE
Fixes #503: Replace ModelChoiceFilter with NonPolymorphicObjectFilter in filtersets

### DIFF
--- a/netbox_custom_objects/filtersets.py
+++ b/netbox_custom_objects/filtersets.py
@@ -191,7 +191,7 @@ class NonPolymorphicMultiObjectFilter(django_filters.Filter):
     def filter(self, qs, value):
         if not value:
             return qs
-        pks = [obj.pk for obj in value]
+        pks = list(value.values_list("pk", flat=True))
         return qs.filter(**{f"{self.field_name}__in": pks}).distinct()
 
 

--- a/netbox_custom_objects/filtersets.py
+++ b/netbox_custom_objects/filtersets.py
@@ -17,6 +17,8 @@ from .models import CustomObjectType
 __all__ = (
     "ArrayContainsFilter",
     "CustomObjectTypeFilterSet",
+    "NonPolymorphicMultiObjectFilter",
+    "NonPolymorphicObjectFilter",
     "PolymorphicMultiObjectFilter",
     "PolymorphicObjectFilter",
     "get_filterset_class",
@@ -140,6 +142,59 @@ class ArrayContainsFilter(django_filters.MultipleChoiceFilter):
         return qs.filter(q).distinct()
 
 
+class NonPolymorphicObjectFilter(django_filters.Filter):
+    """
+    Filter for non-polymorphic FK Object fields on dynamically-generated COT models.
+
+    Inherits from django_filters.Filter (not ModelChoiceFilter) so that
+    NetBoxModelFilterSet.get_additional_lookups() exits early without attempting
+    to validate the filter name against real model fields via get_model_field().
+    After apps.clear_cache() has cleared _meta._forward_fields_map, that
+    validation falls through to _relation_tree → apps.get_models() →
+    recursive get_model() calls → ValueError (issue #503).
+
+    Filters by {field_name}_id to also sidestep Django's isinstance check in
+    check_query_object_type, consistent with the fix for issue #508.
+    """
+
+    field_class = django_forms.ModelChoiceField
+
+    def __init__(self, *args, queryset, **kwargs):
+        kwargs.setdefault("required", False)
+        super().__init__(*args, queryset=queryset, **kwargs)
+
+    def filter(self, qs, value):
+        if value is None:
+            return qs
+        return qs.filter(**{f"{self.field_name}_id": value.pk})
+
+
+class NonPolymorphicMultiObjectFilter(django_filters.Filter):
+    """
+    Filter for non-polymorphic M2M MultiObject fields on dynamically-generated
+    COT models.
+
+    Inherits from django_filters.Filter (not ModelMultipleChoiceFilter) for the
+    same reason as NonPolymorphicObjectFilter: avoids get_additional_lookups()
+    introspecting _meta after apps.clear_cache() has cleared _forward_fields_map.
+
+    Filters by {field_name}__in=pks (M2M JOIN via through table) using PKs
+    rather than instances to sidestep Django's isinstance check.
+    """
+
+    field_class = django_forms.ModelMultipleChoiceField
+
+    def __init__(self, *args, queryset, **kwargs):
+        kwargs.setdefault("required", False)
+        super().__init__(*args, queryset=queryset, **kwargs)
+
+    def filter(self, qs, value):
+        if not value:
+            return qs
+        pks = [obj.pk for obj in value]
+        return qs.filter(**{f"{self.field_name}__in": pks}).distinct()
+
+
 @dataclass
 class FilterSpec:
     """
@@ -193,13 +248,10 @@ FIELD_TYPE_FILTERS = {
         ArrayContainsFilter,
         extra_kwargs={"choices": lambda f: f.choices}
     ),
-    CustomFieldTypeChoices.TYPE_OBJECT: FilterSpec(django_filters.ModelChoiceFilter),
-    # CustomManyToManyField inherits ManyToManyField, so Django's ORM translates
-    # `field__in=values` to a JOIN through the through table at the SQL level.
-    # The custom descriptor/manager only affects instance-level access (e.g.
-    # `instance.field.all()`), not queryset filtering, so ModelMultipleChoiceFilter
-    # is correct here without needing explicit through-table queries.
-    CustomFieldTypeChoices.TYPE_MULTIOBJECT: FilterSpec(django_filters.ModelMultipleChoiceFilter),
+    CustomFieldTypeChoices.TYPE_OBJECT: FilterSpec(NonPolymorphicObjectFilter),
+    # NonPolymorphicMultiObjectFilter uses field__in=pks, which Django's ORM
+    # translates to a JOIN through the through table at the SQL level.
+    CustomFieldTypeChoices.TYPE_MULTIOBJECT: FilterSpec(NonPolymorphicMultiObjectFilter),
 }
 
 

--- a/netbox_custom_objects/tests/test_filtersets.py
+++ b/netbox_custom_objects/tests/test_filtersets.py
@@ -555,7 +555,7 @@ class FiltersetAfterClearCacheTestCase(CustomObjectsTestCase, TestCase):
 
         fs = get_filterset_class(model)({"manufacturer": self.mfr.pk}, model.objects.all())
         pks = list(fs.qs.values_list("pk", flat=True))
-        self.assertEqual(pks, [obj.pk])
+        self.assertEqual(set(pks), {obj.pk})
 
     def test_filter_by_m2m_value_returns_matching_objects(self):
         """NonPolymorphicMultiObjectFilter correctly filters by M2M value."""
@@ -567,7 +567,7 @@ class FiltersetAfterClearCacheTestCase(CustomObjectsTestCase, TestCase):
         Site.objects.create(name="Other503", slug="other-site-503")
         fs = get_filterset_class(model)({"sites": [self.site.pk]}, model.objects.all())
         pks = list(fs.qs.values_list("pk", flat=True))
-        self.assertIn(obj.pk, pks)
+        self.assertEqual(set(pks), {obj.pk})
 
 
 # ---------------------------------------------------------------------------

--- a/netbox_custom_objects/tests/test_filtersets.py
+++ b/netbox_custom_objects/tests/test_filtersets.py
@@ -561,13 +561,33 @@ class FiltersetAfterClearCacheTestCase(CustomObjectsTestCase, TestCase):
         """NonPolymorphicMultiObjectFilter correctly filters by M2M value."""
         model = self.cot_m2m.get_model()
         obj = model.objects.create(name="linked")
-        getattr(obj, "sites").add(self.site)
+        obj.sites.add(self.site)
         model.objects.create(name="unlinked")
 
         Site.objects.create(name="Other503", slug="other-site-503")
         fs = get_filterset_class(model)({"sites": [self.site.pk]}, model.objects.all())
         pks = list(fs.qs.values_list("pk", flat=True))
         self.assertEqual(set(pks), {obj.pk})
+
+    def test_object_filter_none_value_returns_full_queryset(self):
+        """NonPolymorphicObjectFilter short-circuits on None and returns qs unchanged."""
+        model = self.cot_obj.get_model()
+        model.objects.create(name="obj-a", manufacturer=self.mfr)
+        model.objects.create(name="obj-b")
+        total = model.objects.count()
+
+        fs = get_filterset_class(model)({}, model.objects.all())
+        self.assertEqual(fs.qs.count(), total)
+
+    def test_multiobject_filter_empty_value_returns_full_queryset(self):
+        """NonPolymorphicMultiObjectFilter short-circuits on empty list and returns qs unchanged."""
+        model = self.cot_m2m.get_model()
+        model.objects.create(name="obj-a")
+        model.objects.create(name="obj-b")
+        total = model.objects.count()
+
+        fs = get_filterset_class(model)({}, model.objects.all())
+        self.assertEqual(fs.qs.count(), total)
 
 
 # ---------------------------------------------------------------------------

--- a/netbox_custom_objects/tests/test_filtersets.py
+++ b/netbox_custom_objects/tests/test_filtersets.py
@@ -5,16 +5,19 @@ import datetime
 from decimal import Decimal
 from unittest.mock import MagicMock
 
+import django_filters
 from django.test import TestCase
 from django.utils import timezone
 
+from core.models import ObjectType
 from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site
 from extras.choices import CustomFieldTypeChoices
 from extras.models import CustomFieldChoiceSet
 
 from netbox_custom_objects.field_types import MultiObjectFieldType, ObjectFieldType
 from netbox_custom_objects.filtersets import (
-    ArrayContainsFilter, PolymorphicMultiObjectFilter, PolymorphicObjectFilter,
+    ArrayContainsFilter, NonPolymorphicMultiObjectFilter, NonPolymorphicObjectFilter,
+    PolymorphicMultiObjectFilter, PolymorphicObjectFilter,
     build_filter_for_field, get_filterset_class,
 )
 from netbox_custom_objects.models import CustomObjectTypeField
@@ -459,6 +462,112 @@ class BuildFilterForFieldGuardsTestCase(TestCase):
             build_filter_for_field(self._field(CustomFieldTypeChoices.TYPE_MULTIOBJECT, related_ot)),
             {},
         )
+
+
+# ---------------------------------------------------------------------------
+# Regression: get_filterset_class must not raise after apps.clear_cache()
+# (issue #503)
+# ---------------------------------------------------------------------------
+
+
+class FiltersetAfterClearCacheTestCase(CustomObjectsTestCase, TestCase):
+    """
+    Regression for #503: get_filterset_class() must not raise ValueError when
+    apps.clear_cache() has cleared _meta._forward_fields_map on the model.
+
+    When get_model() generates a fresh class it calls apps.clear_cache() at the
+    end of the method (models.py line ~828).  This runs _expire_cache() on all
+    registered models, deleting _forward_fields_map.  A subsequent call to
+    get_filterset_class() in the same request builds a ModelChoiceFilter /
+    ModelMultipleChoiceFilter in declared_filters; NetBoxModelFilterSet's
+    get_additional_lookups() then calls get_model_field(), which falls through
+    to _relation_tree → apps.get_models() → recursive get_model() → ValueError.
+
+    The fix uses NonPolymorphicObjectFilter / NonPolymorphicMultiObjectFilter
+    (both inheriting from django_filters.Filter, not ModelChoiceFilter) so that
+    _get_filter_lookup_dict returns None and get_additional_lookups exits early.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.site = Site.objects.create(name="Site503", slug="site-503")
+        cls.mfr = Manufacturer.objects.create(name="Mfr503", slug="mfr-503")
+        mfr_ot = ObjectType.objects.get(app_label="dcim", model="manufacturer")
+        site_ot = ObjectType.objects.get(app_label="dcim", model="site")
+
+        # COT with a non-polymorphic FK Object field (→ dcim.Manufacturer)
+        cls.cot_obj = cls.create_custom_object_type(name="C503Obj", slug="c503obj")
+        cls.create_custom_object_type_field(
+            cls.cot_obj, name="name", label="Name", type="text", primary=True, required=True
+        )
+        cls.create_custom_object_type_field(
+            cls.cot_obj, name="manufacturer", label="Manufacturer",
+            type="object", related_object_type=mfr_ot,
+        )
+
+        # COT with a non-polymorphic M2M MultiObject field (→ dcim.Site)
+        cls.cot_m2m = cls.create_custom_object_type(name="C503M2m", slug="c503m2m")
+        cls.create_custom_object_type_field(
+            cls.cot_m2m, name="name", label="Name", type="text", primary=True, required=True
+        )
+        cls.create_custom_object_type_field(
+            cls.cot_m2m, name="sites", label="Sites",
+            type="multiobject", related_object_type=site_ot,
+        )
+
+    def test_filterset_builds_after_expire_cache_object_field(self):
+        """get_filterset_class() does not raise after _expire_cache() on an Object-field COT."""
+        model = self.cot_obj.get_model()
+        model._meta._expire_cache()
+        filterset_class = get_filterset_class(model)
+        self.assertIsNotNone(filterset_class)
+
+    def test_filterset_builds_after_expire_cache_multiobject_field(self):
+        """get_filterset_class() does not raise after _expire_cache() on a MultiObject-field COT."""
+        model = self.cot_m2m.get_model()
+        model._meta._expire_cache()
+        filterset_class = get_filterset_class(model)
+        self.assertIsNotNone(filterset_class)
+
+    def test_filter_class_is_non_polymorphic_object_filter(self):
+        """The object-field filter is a NonPolymorphicObjectFilter, not ModelChoiceFilter."""
+        model = self.cot_obj.get_model()
+        filterset_class = get_filterset_class(model)
+        manufacturer_filter = filterset_class.base_filters.get("manufacturer")
+        self.assertIsInstance(manufacturer_filter, NonPolymorphicObjectFilter)
+        self.assertNotIsInstance(manufacturer_filter, django_filters.ModelChoiceFilter)
+
+    def test_filter_class_is_non_polymorphic_multiobject_filter(self):
+        """The multiobject-field filter is a NonPolymorphicMultiObjectFilter, not ModelMultipleChoiceFilter."""
+        model = self.cot_m2m.get_model()
+        filterset_class = get_filterset_class(model)
+        sites_filter = filterset_class.base_filters.get("sites")
+        self.assertIsInstance(sites_filter, NonPolymorphicMultiObjectFilter)
+        self.assertNotIsInstance(sites_filter, django_filters.ModelMultipleChoiceFilter)
+
+    def test_filter_by_fk_value_returns_matching_objects(self):
+        """NonPolymorphicObjectFilter correctly filters by FK value."""
+        model = self.cot_obj.get_model()
+        obj = model.objects.create(name="test-obj", manufacturer=self.mfr)
+        other_mfr = Manufacturer.objects.create(name="Other503", slug="other-503")
+        model.objects.create(name="other-obj", manufacturer=other_mfr)
+
+        fs = get_filterset_class(model)({"manufacturer": self.mfr.pk}, model.objects.all())
+        pks = list(fs.qs.values_list("pk", flat=True))
+        self.assertEqual(pks, [obj.pk])
+
+    def test_filter_by_m2m_value_returns_matching_objects(self):
+        """NonPolymorphicMultiObjectFilter correctly filters by M2M value."""
+        model = self.cot_m2m.get_model()
+        obj = model.objects.create(name="linked")
+        getattr(obj, "sites").add(self.site)
+        model.objects.create(name="unlinked")
+
+        Site.objects.create(name="Other503", slug="other-site-503")
+        fs = get_filterset_class(model)({"sites": [self.site.pk]}, model.objects.all())
+        pks = list(fs.qs.values_list("pk", flat=True))
+        self.assertIn(obj.pk, pks)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Fixes: #503 

## Summary

- Introduces `NonPolymorphicObjectFilter` and `NonPolymorphicMultiObjectFilter` — two filter classes that inherit from `django_filters.Filter` (not `ModelChoiceFilter`) for non-polymorphic FK and M2M Object fields
- Replaces `ModelChoiceFilter`/`ModelMultipleChoiceFilter` in `FIELD_TYPE_FILTERS` with the new classes
- Adds 6 regression tests including direct `_expire_cache()` simulation

## Root cause

`get_model()` calls `apps.clear_cache()` after generating a fresh COT model class (line ~828). This runs `_expire_cache()` on all registered models, deleting `_meta._forward_fields_map`. Immediately after, in the same request, `get_filterset_class()` builds a `ModelChoiceFilter(field_name='manufacturer', ...)` and places it in `declared_filters`.

NetBox's `get_additional_lookups()` then processes this filter: `_get_filter_lookup_dict` returns `FILTER_NEGATION_LOOKUP_MAP` for `ModelChoiceFilter` (non-null), so it calls `get_model_field(model, 'manufacturer')`. With `_forward_fields_map` cleared, `_meta.get_field('manufacturer')` falls through to `fields_map → _relation_tree → apps.get_models()` — which triggers recursive `get_model()` calls. Eventually `get_model_field` returns `None`, and since the filter is in `declared_filters`, `get_additional_lookups` raises `ValueError: "Invalid field name/lookup on manufacturer: manufacturer"`.

This matches the comment already present at `models.py:492–499` warning about exactly this `_relation_tree` recursion path.

## Fix

The existing `PolymorphicObjectFilter` already solved this for polymorphic fields by inheriting from `django_filters.Filter` instead of `ModelChoiceFilter` — causing `_get_filter_lookup_dict` to return `None` and `get_additional_lookups` to exit early. The new classes apply the same pattern to non-polymorphic Object and MultiObject fields.

Both new filters also use PK-based filtering (`{field_name}_id=pk` / `{field_name}__in=pks`) rather than passing model instances, sidestepping Django's `isinstance` check in `check_query_object_type` — consistent with the fix for #508.

## Why intermittent

The bug only fires on cache-miss `get_model()` calls (first access after cache invalidation), because that is the only code path that calls `apps.clear_cache()`. On a cache hit, `_forward_fields_map` is still populated and `get_model_field` succeeds.

## Test plan

- [x] `FiltersetAfterClearCacheTestCase.test_filterset_builds_after_expire_cache_object_field` — survives `_expire_cache()` on Object-field COT
- [x] `FiltersetAfterClearCacheTestCase.test_filterset_builds_after_expire_cache_multiobject_field` — survives `_expire_cache()` on MultiObject-field COT
- [x] `FiltersetAfterClearCacheTestCase.test_filter_class_is_non_polymorphic_object_filter` — correct class type
- [x] `FiltersetAfterClearCacheTestCase.test_filter_class_is_non_polymorphic_multiobject_filter` — correct class type
- [x] `FiltersetAfterClearCacheTestCase.test_filter_by_fk_value_returns_matching_objects` — FK filtering still works
- [x] `FiltersetAfterClearCacheTestCase.test_filter_by_m2m_value_returns_matching_objects` — M2M filtering still works
- [x] All 101 existing filterset tests pass
- [x] `ruff check` clean

Closes: #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)