### PR TITLE
Fixes: #396 - Require add permission for add URL, not change

### DIFF
--- a/netbox_custom_objects/tests/test_views.py
+++ b/netbox_custom_objects/tests/test_views.py
@@ -371,6 +371,12 @@ class CustomObjectViewTestCase(CustomObjectsTestCase, ViewTestCases.PrimaryObjec
         edit_url = self._get_url('edit', self.instance1)
         self.assertHttpStatus(self.client.get(edit_url), 403)
 
+        # Symmetrical: change-only permission must not grant access to the add URL
+        obj_perm.actions = ['change']
+        obj_perm.save()
+        self.assertHttpStatus(self.client.get(add_url), 403)
+        self.assertHttpStatus(self.client.get(edit_url), 200)
+
 
 class ComplexCustomObjectViewTestCase(CustomObjectsTestCase, ViewTestCases.PrimaryObjectViewTestCase):
     """Test cases for complex custom objects with various field types."""

--- a/netbox_custom_objects/tests/test_views.py
+++ b/netbox_custom_objects/tests/test_views.py
@@ -5,6 +5,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 from django.urls import reverse
 from extras.models import CustomFieldChoiceSet
+from users.models import ObjectPermission
 from utilities.testing import ViewTestCases, create_test_user
 
 from netbox_custom_objects.models import CustomObjectType, CustomObjectTypeField
@@ -353,6 +354,22 @@ class CustomObjectViewTestCase(CustomObjectsTestCase, ViewTestCases.PrimaryObjec
 
     def test_bulk_delete_objects_with_constrained_permission(self):
         ...
+
+    def test_add_permission_is_sufficient_to_access_add_url(self):
+        """Regression #396: add-only permission must grant access to the add URL, not require change."""
+        model = self.model
+        content_type = ContentType.objects.get_for_model(model)
+        obj_perm = ObjectPermission(name='add-only', actions=['add'])
+        obj_perm.save()
+        obj_perm.users.add(self.user)
+        obj_perm.object_types.add(content_type)
+
+        add_url = self._get_url('add')
+        self.assertHttpStatus(self.client.get(add_url), 200)
+
+        # User with only 'add' must not be able to edit existing objects
+        edit_url = self._get_url('edit', self.instance1)
+        self.assertHttpStatus(self.client.get(edit_url), 403)
 
 
 class ComplexCustomObjectViewTestCase(CustomObjectsTestCase, ViewTestCases.PrimaryObjectViewTestCase):

--- a/netbox_custom_objects/views.py
+++ b/netbox_custom_objects/views.py
@@ -27,6 +27,7 @@ from utilities.forms.widgets import HTMXSelect
 from utilities.htmx import htmx_partial
 from utilities.object_types import object_type_name
 from utilities.templatetags.builtins.filters import bettertitle
+from utilities.permissions import get_permission_for_model
 from utilities.views import ConditionalLoginRequiredMixin, ViewTab, get_viewname, register_model_view
 
 from netbox_custom_objects.filtersets import get_filterset_class
@@ -604,6 +605,15 @@ class CustomObjectEditView(generic.ObjectEditView):
     form = None
     queryset = None
     object = None
+
+    def get_required_permission(self):
+        # ObjectEditView.dispatch() sets _permission_action based on whether kwargs is
+        # truthy. Our add URL always includes 'custom_object_type', so kwargs is truthy
+        # even when adding — causing 'change' permission to be required instead of 'add'.
+        # setup() → get_object() pops 'custom_object_type' from self.kwargs, so checking
+        # self.kwargs.get('pk') correctly distinguishes add (no pk) from edit (pk present).
+        action = 'change' if self.kwargs.get('pk') else 'add'
+        return get_permission_for_model(self.queryset.model, action)
 
     def setup(self, request, *args, **kwargs):
         super().setup(request, *args, **kwargs)

--- a/netbox_custom_objects/views.py
+++ b/netbox_custom_objects/views.py
@@ -610,9 +610,9 @@ class CustomObjectEditView(generic.ObjectEditView):
         # ObjectEditView.dispatch() sets _permission_action based on whether kwargs is
         # truthy. Our add URL always includes 'custom_object_type', so kwargs is truthy
         # even when adding — causing 'change' permission to be required instead of 'add'.
-        # setup() → get_object() pops 'custom_object_type' from self.kwargs, so checking
-        # self.kwargs.get('pk') correctly distinguishes add (no pk) from edit (pk present).
-        action = 'change' if self.kwargs.get('pk') else 'add'
+        # setup() sets self.object before dispatch() runs, so self.object.pk is the
+        # semantically correct way to distinguish a new object (no pk) from an edit.
+        action = 'change' if (self.object and self.object.pk) else 'add'
         return get_permission_for_model(self.queryset.model, action)
 
     def setup(self, request, *args, **kwargs):


### PR DESCRIPTION
### Fixes: #396 

## Summary

- `ObjectEditView.dispatch()` sets `_permission_action` based on whether `kwargs` is truthy. Custom object add URLs always include `custom_object_type` in kwargs, so `kwargs` is truthy even when adding — causing `change` permission to be required instead of `add`.
- Override `get_required_permission()` in `CustomObjectEditView` to check `self.kwargs.get('pk')`. By the time the permission check runs, `setup()` → `get_object()` has already popped `custom_object_type` from `self.kwargs`, leaving `pk` only for edits.
- Adds a regression test verifying that a user with only `add` permission can access the add URL (200) but is denied the edit URL (403).

## Test plan

- [ ] Run `test_add_permission_is_sufficient_to_access_add_url` in `CustomObjectViewTestCase`
- [ ] Manually assign only "Add" permission to a user in NetBox and confirm they can add custom objects without needing "Change"

Closes: #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)