### PR TITLE
Add table_schema filter to migration 0011 query

### DIFF
--- a/netbox_custom_objects/migrations/0011_non_deferrable_fk_constraints.py
+++ b/netbox_custom_objects/migrations/0011_non_deferrable_fk_constraints.py
@@ -54,6 +54,7 @@ def fix_deferrable_fk_constraints(apps, schema_editor):
                 ON tc.constraint_name = rc.constraint_name
                 AND tc.table_schema = rc.constraint_schema
             WHERE tc.constraint_type = 'FOREIGN KEY'
+                AND tc.table_schema = current_schema()
                 AND tc.table_name LIKE 'custom_objects\\_%'
                 AND tc.is_deferrable = 'YES'
         """)


### PR DESCRIPTION
## Summary

Migration 0011's `information_schema.table_constraints` query was missing `AND tc.table_schema = current_schema()`. Without this filter, the query returns DEFERRABLE constraints from **all schemas** accessible to the current PostgreSQL user, not just the current one.

On installations where the NetBox database uses a non-public schema (or where `search_path` exposes multiple schemas), this causes:

1. The query returns a DEFERRABLE constraint found in a **different** schema
2. `DROP CONSTRAINT IF EXISTS` operates on the **current** schema's table — silently no-ops because the constraint isn't there
3. `ADD CONSTRAINT` tries to add to the current schema's table where a constraint with that name **already exists** → `psycopg.errors.DuplicateObject`

The fix is a one-line addition matching the pattern already used elsewhere in the codebase (e.g. `_ensure_field_fk_constraint` in `models.py`).

## Test plan

- [ ] Upgrade from 0.4.9 to 0.5.x on a standard public-schema PostgreSQL setup — migration applies cleanly (no regression)
- [ ] Upgrade on a non-public-schema setup — migration now correctly scopes the query to the current schema and applies without `DuplicateObject`

🤖 Generated with [Claude Code](https://claude.com/claude-code)