### PR TITLE
Fixes: #523 - Delete NetBox CustomField references before dropping ObjectType

### DIFF
--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -31,6 +31,7 @@ from extras.choices import (
     CustomFieldUIEditableChoices,
     CustomFieldUIVisibleChoices,
 )
+from extras.models import CustomField
 from extras.models.customfields import SEARCH_TYPES
 from extras.utils import run_validators
 from netbox.config import get_config
@@ -976,6 +977,12 @@ class CustomObjectType(NetBoxModel):
 
         object_type = ObjectType.objects.get_for_model(model)
         ObjectChange.objects.filter(changed_object_type=object_type).delete()
+
+        # Delete any NetBox CustomField records (extras) with related_object_type pointing
+        # to this COT's ObjectType. CustomField.related_object_type uses on_delete=PROTECT,
+        # so these must be removed before object_type.delete() is called below.
+        CustomField.objects.filter(related_object_type=object_type).delete()
+
         super().delete(*args, **kwargs)
 
         # Temporarily disconnect the pre_delete handler to skip the ObjectType deletion

--- a/netbox_custom_objects/tests/test_schema_operations.py
+++ b/netbox_custom_objects/tests/test_schema_operations.py
@@ -154,6 +154,33 @@ class SchemaOperationsTestCase(TransactionCleanupMixin, CustomObjectsTestCase, T
             "Deleted COT's model must be removed from the app registry.",
         )
 
+    def test_delete_cot_with_netbox_custom_field_referencing_object_type(self):
+        """#523 – Deleting a COT must not raise ProtectedError when a NetBox CustomField
+        has related_object_type pointing to the COT's underlying ObjectType."""
+        from core.models import ObjectType
+        from extras.choices import CustomFieldTypeChoices
+        from extras.models import CustomField
+
+        cot = self.create_custom_object_type(name='protectedtest', slug='protected-test')
+        object_type = ObjectType.objects.get_for_model(cot.get_model())
+
+        # Create a regular NetBox CustomField of type "object" whose related_object_type
+        # points at the COT's ContentType. This is the scenario that triggered the
+        # ProtectedError because CustomField.related_object_type uses on_delete=PROTECT.
+        cf = CustomField.objects.create(
+            name='cat_ref',
+            type=CustomFieldTypeChoices.TYPE_OBJECT,
+            related_object_type=object_type,
+        )
+
+        # Should delete cleanly without raising ProtectedError.
+        cot.delete()
+
+        self.assertFalse(
+            CustomField.objects.filter(pk=cf.pk).exists(),
+            "The referencing CustomField must be deleted along with the COT.",
+        )
+
     # ------------------------------------------------------------------
     # Management commands
     # ------------------------------------------------------------------


### PR DESCRIPTION
### Fixes: #523

## Summary

- Deleting a CustomObjectType that has a NetBox CustomField (extras) with related_object_type pointing at the COT ObjectType now succeeds cleanly
- CustomObjectType.delete() already cleaned up CustomObjectTypeField records; this PR extends it to also delete matching extras.CustomField rows before calling object_type.delete()
- Adds a regression test covering this exact scenario

## Root Cause

CustomField.related_object_type is declared with on_delete=PROTECT. When CustomObjectType.delete() called object_type.delete(), Django refused because at least one CustomField row still referenced that ObjectType. The plugin already handled its own CustomObjectTypeField foreign keys but missed the standard NetBox custom field.

A secondary symptom (NoReverseMatch with pk=None) occurred because super().delete() runs before object_type.delete() — once the COT row is gone, self.pk is None, so the error handler get_absolute_url() call failed. This is resolved implicitly since the ProtectedError no longer fires.

## Test Plan

- [x] New test test_delete_cot_with_netbox_custom_field_referencing_object_type in test_schema_operations.py creates a COT, attaches a CustomField with related_object_type set to the COT ObjectType, deletes the COT, and asserts both the COT and the CustomField are gone

Closes: #523

Generated with [Claude Code](https://claude.com/claude-code)