### PR TITLE
Fixes: #491 - Extend cycle depth-first-search to traverse polymorphic field edges

### DIFF
--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -1734,6 +1734,7 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
                 CustomFieldTypeChoices.TYPE_OBJECT,
                 CustomFieldTypeChoices.TYPE_MULTIOBJECT,
             ],
+            is_polymorphic=False,
             related_object_type__isnull=False,
             related_object_type__app_label=APP_LABEL
         ):

--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -1725,22 +1725,10 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
         # Add this type to visited set
         visited.add(custom_object_type.id)
 
-        # Check all *non-polymorphic* object and multiobject fields in this COT.
-        #
-        # KNOWN LIMITATION: polymorphic fields (is_polymorphic=True) store their
-        # allowed target types on the related_object_types M2M, not on the
-        # related_object_type FK.  This DFS therefore does not traverse edges
-        # introduced by polymorphic fields.  A cycle that passes entirely through
-        # polymorphic legs (e.g. A →(poly) B →(poly) A) will go undetected.
-        #
-        # Fixing this requires also iterating field.related_object_types.filter(
-        # app_label=APP_LABEL) and recursing into each.  The check_polymorphic_recursion
-        # signal already guards the direct A→B assignment, but cannot see multi-hop
-        # cycles that depend on polymorphic fields already on intermediate types.
-        #
-        # TODO: extend this DFS to also traverse polymorphic related_object_types
-        # so that multi-hop polymorphic cycles are detected at assignment time.
+        # Track ContentTypes already enqueued for recursion to avoid redundant work.
         related_objects_checked = set()
+
+        # Non-polymorphic object/multiobject fields: target stored on related_object_type FK.
         for field in custom_object_type.fields.filter(
             type__in=[
                 CustomFieldTypeChoices.TYPE_OBJECT,
@@ -1752,16 +1740,31 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
             if field.related_object_type in related_objects_checked:
                 continue
             related_objects_checked.add(field.related_object_type)
-
-            # Get the related custom object type directly from the object_type relationship
             try:
                 next_custom_object_type = CustomObjectType.objects.get(object_type=field.related_object_type)
             except CustomObjectType.DoesNotExist:
                 continue
-
-            # Recursively check this dependency
             if self._has_circular_reference(next_custom_object_type, visited):
                 return True
+
+        # Polymorphic object/multiobject fields: targets stored on related_object_types M2M.
+        for poly_field in custom_object_type.fields.filter(
+            type__in=[
+                CustomFieldTypeChoices.TYPE_OBJECT,
+                CustomFieldTypeChoices.TYPE_MULTIOBJECT,
+            ],
+            is_polymorphic=True,
+        ):
+            for ot in poly_field.related_object_types.filter(app_label=APP_LABEL):
+                if ot in related_objects_checked:
+                    continue
+                related_objects_checked.add(ot)
+                try:
+                    next_custom_object_type = CustomObjectType.objects.get(object_type=ot)
+                except CustomObjectType.DoesNotExist:
+                    continue
+                if self._has_circular_reference(next_custom_object_type, visited):
+                    return True
 
         return False
 

--- a/netbox_custom_objects/tests/test_polymorphic_fields.py
+++ b/netbox_custom_objects/tests/test_polymorphic_fields.py
@@ -1171,19 +1171,26 @@ class PolymorphicCycleDetectionTest(
     def setUp(self):
         super().setUp()
 
-        for slug, name, plural in [
-            ("cycle-a", "CycleA", "Cycle As"),
-            ("cycle-b", "CycleB", "Cycle Bs"),
-            ("cycle-c", "CycleC", "Cycle Cs"),
-        ]:
-            cot = CustomObjectType.objects.create(
-                name=name, slug=slug, verbose_name_plural=plural,
-            )
-            CustomObjectTypeField.objects.create(
-                custom_object_type=cot,
-                name="name", type="text", primary=True, required=True,
-            )
-            setattr(self, f"cot_{slug[-1]}", cot)
+        self.cot_a = CustomObjectType.objects.create(
+            name="CycleA", slug="cycle-a", verbose_name_plural="Cycle As",
+        )
+        CustomObjectTypeField.objects.create(
+            custom_object_type=self.cot_a, name="name", type="text", primary=True, required=True,
+        )
+
+        self.cot_b = CustomObjectType.objects.create(
+            name="CycleB", slug="cycle-b", verbose_name_plural="Cycle Bs",
+        )
+        CustomObjectTypeField.objects.create(
+            custom_object_type=self.cot_b, name="name", type="text", primary=True, required=True,
+        )
+
+        self.cot_c = CustomObjectType.objects.create(
+            name="CycleC", slug="cycle-c", verbose_name_plural="Cycle Cs",
+        )
+        CustomObjectTypeField.objects.create(
+            custom_object_type=self.cot_c, name="name", type="text", primary=True, required=True,
+        )
 
         # Generate models so ContentTypes are registered.
         self.cot_a.get_model()
@@ -1244,3 +1251,20 @@ class PolymorphicCycleDetectionTest(
         )
         with self.assertRaises(ValidationError):
             field_c.related_object_types.set([self.ot_a])  # closes A→B→C→A cycle
+
+    def test_mixed_leg_cycle_is_detected(self):
+        """A →(non-poly) B →(poly) A must be rejected."""
+        # Non-polymorphic object field on A pointing to B.
+        CustomObjectTypeField.objects.create(
+            custom_object_type=self.cot_a,
+            name="link_to_b", type="object",
+            related_object_type=self.ot_b,
+        )
+
+        # Polymorphic object field on B attempting to point back to A.
+        field_b = CustomObjectTypeField.objects.create(
+            custom_object_type=self.cot_b,
+            name="link_to_a", type="object", is_polymorphic=True,
+        )
+        with self.assertRaises(ValidationError):
+            field_b.related_object_types.set([self.ot_a])  # closes A→B→A cycle

--- a/netbox_custom_objects/tests/test_polymorphic_fields.py
+++ b/netbox_custom_objects/tests/test_polymorphic_fields.py
@@ -7,6 +7,7 @@ Covers both API and UI (form) paths for:
 """
 import json
 
+from django.core.exceptions import ValidationError
 from django.test import TransactionTestCase
 from django.urls import reverse
 from rest_framework import status
@@ -1152,74 +1153,49 @@ class ReferencedObjectDeletionTest(
 
 
 # ---------------------------------------------------------------------------
-# Cycle-detection gap: multi-hop polymorphic cycles
+# Cycle-detection: multi-hop polymorphic cycles
 # ---------------------------------------------------------------------------
 
-class PolymorphicCycleDetectionGapTest(
+class PolymorphicCycleDetectionTest(
     TransactionCleanupMixin, CustomObjectsTestCase, TransactionTestCase
 ):
     """
-    Pins the KNOWN LIMITATION in CustomObjectTypeField._has_circular_reference:
-    a cycle that passes entirely through polymorphic legs is NOT detected.
+    Verifies that _has_circular_reference detects cycles that pass entirely
+    through polymorphic legs.
 
-    The DFS in _has_circular_reference only follows non-polymorphic object/
-    multiobject fields (those with related_object_type set).  Polymorphic fields
-    store their allowed types on the related_object_types M2M and are therefore
-    invisible to the traversal.
-
-    Scenario: COT-A has a polymorphic field that allows COT-B objects, and COT-B
-    has a polymorphic field that allows COT-A objects.  This is a cycle, but the
-    check_polymorphic_recursion signal cannot see it because _has_circular_reference
-    returns False for every hop that uses a polymorphic field.
-
-    TODO: when _has_circular_reference is extended to traverse polymorphic legs,
-    the assertions below should be changed to assertRaises(ValidationError) and
-    this docstring updated accordingly.
+    Polymorphic fields store their allowed target types on the related_object_types
+    M2M rather than the related_object_type FK, so the DFS must explicitly walk
+    that M2M to catch multi-hop polymorphic cycles.
     """
 
     def setUp(self):
         super().setUp()
 
-        # COT A
-        self.cot_a = CustomObjectType.objects.create(
-            name="CycleA", slug="cycle-a", verbose_name_plural="Cycle As",
-        )
-        CustomObjectTypeField.objects.create(
-            custom_object_type=self.cot_a,
-            name="name", type="text", primary=True, required=True,
-        )
+        for slug, name, plural in [
+            ("cycle-a", "CycleA", "Cycle As"),
+            ("cycle-b", "CycleB", "Cycle Bs"),
+            ("cycle-c", "CycleC", "Cycle Cs"),
+        ]:
+            cot = CustomObjectType.objects.create(
+                name=name, slug=slug, verbose_name_plural=plural,
+            )
+            CustomObjectTypeField.objects.create(
+                custom_object_type=cot,
+                name="name", type="text", primary=True, required=True,
+            )
+            setattr(self, f"cot_{slug[-1]}", cot)
 
-        # COT B
-        self.cot_b = CustomObjectType.objects.create(
-            name="CycleB", slug="cycle-b", verbose_name_plural="Cycle Bs",
-        )
-        CustomObjectTypeField.objects.create(
-            custom_object_type=self.cot_b,
-            name="name", type="text", primary=True, required=True,
-        )
-
-        # Ensure both models are generated so their ObjectTypes exist in the registry.
+        # Generate models so ContentTypes are registered.
         self.cot_a.get_model()
         self.cot_b.get_model()
+        self.cot_c.get_model()
 
-        # Resolve the ObjectType (ContentType) for each generated model.
         self.ot_a = ObjectType.objects.get_for_model(self.cot_a.get_model())
         self.ot_b = ObjectType.objects.get_for_model(self.cot_b.get_model())
+        self.ot_c = ObjectType.objects.get_for_model(self.cot_c.get_model())
 
-    def test_multihop_polymorphic_cycle_is_not_detected(self):
-        """
-        KNOWN LIMITATION: A →(poly) B →(poly) A is silently accepted.
-
-        The first set() (A allows B) succeeds because neither COT has any
-        non-polymorphic back-edges yet.  The second set() (B allows A) also
-        succeeds because _has_circular_reference traverses only non-polymorphic
-        fields, so the A→B poly edge is invisible.
-
-        Neither call should raise ValidationError under the current implementation.
-        If this test starts failing with ValidationError it means the gap has
-        been fixed and the test should be updated to assert the opposite.
-        """
-        # Step 1: create a polymorphic object field on A that allows B objects.
+    def test_first_poly_edge_is_accepted(self):
+        """A →(poly) B: no cycle yet, must succeed."""
         field_a = CustomObjectTypeField.objects.create(
             custom_object_type=self.cot_a,
             name="link_to_b", type="object", is_polymorphic=True,
@@ -1229,27 +1205,42 @@ class PolymorphicCycleDetectionGapTest(
         except Exception as exc:
             self.fail(
                 f"Adding COT-B as allowed type for COT-A's poly field raised "
-                f"{type(exc).__name__}: {exc}. Expected no error (no cycle yet)."
+                f"{type(exc).__name__}: {exc}."
             )
+        self.assertIn(self.ot_b, field_a.related_object_types.all())
 
-        # Step 2: create a polymorphic object field on B that allows A objects.
-        # This creates a cycle A →(poly) B →(poly) A, but _has_circular_reference
-        # does not traverse poly legs so it goes undetected.
+    def test_two_hop_polymorphic_cycle_is_detected(self):
+        """A →(poly) B →(poly) A must be rejected."""
+        field_a = CustomObjectTypeField.objects.create(
+            custom_object_type=self.cot_a,
+            name="link_to_b", type="object", is_polymorphic=True,
+        )
+        field_a.related_object_types.set([self.ot_b])  # no cycle yet
+
         field_b = CustomObjectTypeField.objects.create(
             custom_object_type=self.cot_b,
             name="link_to_a", type="object", is_polymorphic=True,
         )
-        try:
-            field_b.related_object_types.set([self.ot_a])
-        except Exception as exc:
-            self.fail(
-                f"Adding COT-A as allowed type for COT-B's poly field raised "
-                f"{type(exc).__name__}: {exc}. "
-                f"This is a known limitation — multi-hop polymorphic cycles are not "
-                f"detected by _has_circular_reference. If the TODO has been resolved "
-                f"and a ValidationError is now expected here, update this test."
-            )
+        with self.assertRaises(ValidationError):
+            field_b.related_object_types.set([self.ot_a])  # closes A→B→A cycle
 
-        # Confirm the M2M rows were actually written.
-        self.assertIn(self.ot_b, field_a.related_object_types.all())
-        self.assertIn(self.ot_a, field_b.related_object_types.all())
+    def test_three_hop_polymorphic_cycle_is_detected(self):
+        """A →(poly) B →(poly) C →(poly) A must be rejected."""
+        field_a = CustomObjectTypeField.objects.create(
+            custom_object_type=self.cot_a,
+            name="link_to_b", type="object", is_polymorphic=True,
+        )
+        field_a.related_object_types.set([self.ot_b])  # no cycle
+
+        field_b = CustomObjectTypeField.objects.create(
+            custom_object_type=self.cot_b,
+            name="link_to_c", type="object", is_polymorphic=True,
+        )
+        field_b.related_object_types.set([self.ot_c])  # no cycle
+
+        field_c = CustomObjectTypeField.objects.create(
+            custom_object_type=self.cot_c,
+            name="link_to_a", type="object", is_polymorphic=True,
+        )
+        with self.assertRaises(ValidationError):
+            field_c.related_object_types.set([self.ot_a])  # closes A→B→C→A cycle


### PR DESCRIPTION
### Closes: #491

## Summary

- Extends `_has_circular_reference` to walk polymorphic field edges, so cycles that pass entirely through polymorphic legs are now detected at M2M assignment time (via the existing `check_polymorphic_recursion` signal)
- Removes the KNOWN LIMITATION comment block from `models.py`
- Replaces `PolymorphicCycleDetectionGapTest` (which pinned the broken behaviour) with `PolymorphicCycleDetectionTest` covering the 2-hop (A→B→A) and 3-hop (A→B→C→A) cases, plus a guard that the first non-cyclic edge is still accepted

## How it works

`_has_circular_reference` previously only followed non-polymorphic `related_object_type` FK edges. Polymorphic fields store their allowed types on the `related_object_types` M2M, so any cycle passing entirely through those was invisible to the DFS.

The fix adds a second traversal loop after the existing one: for each `is_polymorphic=True` field on the current COT, it iterates `related_object_types.filter(app_label=APP_LABEL)` and recurses into each reachable COT. The shared `related_objects_checked` set deduplicates across both loops.

Because `check_polymorphic_recursion` already delegates to `_has_circular_reference`, the signal guard inherits the fix automatically — no changes to the signal itself are needed.

Closes: #491

## Test plan

- [x] `test_first_poly_edge_is_accepted` — A→B with no back-edge is allowed
- [x] `test_two_hop_polymorphic_cycle_is_detected` — A→B→A raises `ValidationError`
- [x] `test_three_hop_polymorphic_cycle_is_detected` — A→B→C→A raises `ValidationError`
- [x] Full `test_polymorphic_fields` module (47 tests) passes

Generated with [Claude Code](https://claude.com/claude-code)