### PR TITLE
Fixes: #559 - Add slug filter to CustomObjectTypeFilterSet

### DIFF
--- a/netbox_custom_objects/filtersets.py
+++ b/netbox_custom_objects/filtersets.py
@@ -261,6 +261,7 @@ class CustomObjectTypeFilterSet(NetBoxModelFilterSet):
         fields = (
             "id",
             "name",
+            "slug",
             "group_name",
         )
 


### PR DESCRIPTION
### Fixes: #559 

## Summary

`GET /api/plugins/custom-objects/custom-object-types/?slug=foo` previously returned **every** Custom Object Type — `django-filter` silently dropped the unrecognised query parameter because `CustomObjectTypeFilterSet.Meta.fields` didn't include `slug`. Adding `slug` to the tuple lets `django-filter` auto-generate the full lookup family (`exact`, `__ic`, `__isw`, `__regex`, ...) backed by the `CustomObjectType.slug` SlugField.

## Verification

Verified via `manage.py shell`:

```python
from netbox_custom_objects.filtersets import CustomObjectTypeFilterSet
'slug' in CustomObjectTypeFilterSet.base_filters
# True
```

After the change, all of these now narrow the result set:

- `?slug=vendor-policies`
- `?slug__ic=policies` (icontains)
- `?slug__isw=vendor` (istartswith)

## Context

Surfaced during the related-object-tabs smoke test on 2026-05-26 (PR #482).
