### PR TITLE
Fixes: #558 - Avoid "<type> None" in CustomObject.__str__ post-delete

### DIFF
--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -135,6 +135,8 @@ class CustomObject(
                 self, primary_field["name"]
             )
         if not primary_field_value:
+            if self.pk is None:  # post-delete: pk is cleared by Django's Model.delete()
+                return str(self.custom_object_type.display_name)
             return f"{self.custom_object_type.display_name} {self.id}"
         return str(primary_field_value) or str(self.id)
 

--- a/netbox_custom_objects/tests/test_field_types.py
+++ b/netbox_custom_objects/tests/test_field_types.py
@@ -1113,6 +1113,23 @@ class PrimaryFieldChangeTestCase(FieldTypeTestCase):
         refreshed_target = new_target_model.objects.get(pk=target_instance.pk)
         self.assertIn("T-001", str(refreshed_target))
 
+    def test_str_post_delete_no_primary_field_does_not_contain_none(self):
+        """Regression #558: str() on a post-delete instance (pk=None, no primary
+        field value) must return the COT display name, not '<type> None'."""
+        cot = self.create_custom_object_type(
+            name="DeleteStrTest", slug="delete-str-test",
+            verbose_name_plural="Delete Str Tests",
+        )
+        # No primary field — falls through to the pk fallback path in __str__.
+        model = cot.get_model()
+        instance = model.objects.create()
+
+        instance.delete()  # sets instance.pk = None
+
+        result = str(instance)
+        self.assertNotIn("None", result)
+        self.assertEqual(result, cot.display_name)
+
 
 # ---------------------------------------------------------------------------
 # Context field — ts-parent-field widget attribute on get_form_field()


### PR DESCRIPTION
### Fixes: #558 

## Summary

`CustomObject.__str__` includes `self.id` in its fallback output when no field on the COT is marked `primary=True`. But Django's `Model.delete()` sets `self.pk` to `None` after the database row is removed — and NetBox's delete-toast and changelog renderers call `str()` on the **post-delete** instance. The result is a literal "None" in the user-facing message:

```
Deleted SmokeTabTarget SmokeTabTarget None
```

## Fix

Branch on `self.pk` inside the no-primary-field path:

- **`self.pk is None`** (post-delete) → return just the COT's display name (`"SmokeTabTarget"`).
- **`self.pk` is set** (normal rendering) → behave as before (`"SmokeTabTarget 5"`).

8 lines, no behavioural change for any code path with a live `pk`.

## Verification

Observed while smoke-testing PR #482's related-tabs work.

## Context

Surfaced during the related-object-tabs smoke testing (PR #482); independent of that work and easy enough to land standalone.
