### PR TITLE
Fixes: #384 - Patch stale FK refs and fix false-positive cycle detection

### DIFF
--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -816,6 +816,30 @@ class CustomObjectType(NetBoxModel):
                 target_field.__dict__.pop('path_infos', None)
                 target_field.__dict__.pop('reverse_path_infos', None)
 
+            # Same staleness problem exists for direct FK fields (TYPE_OBJECT):
+            # when this COT is regenerated, any cached model for another COT that
+            # holds a LazyForeignKey pointing here still references the old class.
+            # Walk inbound non-polymorphic object fields and patch them too.
+            for inbound_fk_field in CustomObjectTypeField.objects.filter(
+                related_object_type=self.object_type,
+                type=CustomFieldTypeChoices.TYPE_OBJECT,
+                is_polymorphic=False,
+            ).iterator():
+                owner_model = CustomObjectType.get_cached_model(inbound_fk_field.custom_object_type_id)
+                if owner_model is None:
+                    continue
+                # Use local_fields list — avoids _relation_tree → get_models() recursion.
+                fk_field = next(
+                    (f for f in owner_model._meta.local_fields if f.name == inbound_fk_field.name),
+                    None,
+                )
+                if fk_field is None:
+                    continue
+                fk_field.remote_field.model = model
+                fk_field.related_model = model
+                fk_field.__dict__.pop('path_infos', None)
+                fk_field.__dict__.pop('reverse_path_infos', None)
+
             # Only cache fully-generated models.  Models generated with
             # skip_object_fields=True omit FK fields to other COTs; caching them
             # would permanently hide those fields if a dependent COT triggers
@@ -1718,9 +1742,14 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
         Returns:
             bool: True if a circular reference is detected, False otherwise
         """
-        # If we've already visited this type, we have a cycle
+        # If we've already visited this node, it's a genuine cycle only when the
+        # node is the origin COT (the one that owns the field being validated).
+        # Re-encountering a non-origin node that was already explored in a
+        # different branch of the DFS is NOT a cycle — returning True there
+        # would cause a false positive when an intermediate COT has a
+        # self-referencing field (e.g. a multiobject pointing back to itself).
         if custom_object_type.id in visited:
-            return True
+            return custom_object_type.id == self.custom_object_type.id
 
         # Add this type to visited set
         visited.add(custom_object_type.id)

--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -837,6 +837,7 @@ class CustomObjectType(NetBoxModel):
                     continue
                 fk_field.remote_field.model = model
                 fk_field.related_model = model
+                fk_field.to = model
                 fk_field.__dict__.pop('path_infos', None)
                 fk_field.__dict__.pop('reverse_path_infos', None)
 

--- a/netbox_custom_objects/tests/query_counts.json
+++ b/netbox_custom_objects/tests/query_counts.json
@@ -1,0 +1,6 @@
+{
+  "customobjecttype:list_objects_with_permission": 32,
+  "table285model:list_objects_with_permission": 39,
+  "table289model:list_objects_with_permission": 33,
+  "table290model:list_objects_with_permission": 50
+}

--- a/netbox_custom_objects/tests/test_models.py
+++ b/netbox_custom_objects/tests/test_models.py
@@ -1846,3 +1846,214 @@ class LazyForeignKeySaveResolutionTestCase(CustomObjectsTestCase, TestCase):
         )
         self.assertEqual(field.name, "target_ref")
         self.assertEqual(field.type, "object")
+
+
+class CycleDetectionFalsePositiveRegressionTest(CustomObjectsTestCase, TestCase):
+    """Regression test for the false-positive in _has_circular_reference.
+
+    When an intermediate COT has a self-referencing field (e.g. a multiobject
+    that points back to itself), the DFS can re-encounter that COT's ID in the
+    ``visited`` set.  Before the fix, any node already in ``visited`` caused an
+    immediate ``return True``, so validating a perfectly legal
+    EC → Control FK raised "Circular reference detected" even though there is
+    no actual cycle.
+
+    After the fix, ``return custom_object_type.id == self.custom_object_type.id``
+    only signals a real cycle when the DFS finds its way back to the ORIGIN node.
+    """
+
+    def setUp(self):
+        super().setUp()
+        # COT Control: has a self-referencing multiobject field
+        self.cot_control = CustomObjectType.objects.create(
+            name="ControlCycle", slug="control-cycle",
+            verbose_name_plural="ControlCycles",
+        )
+        CustomObjectTypeField.objects.create(
+            custom_object_type=self.cot_control,
+            name="name", type="text", primary=True, required=True,
+        )
+        # Self-referencing M:N field
+        self.cot_control.get_model()
+        CustomObjectTypeField.objects.create(
+            custom_object_type=self.cot_control,
+            name="refs", type="multiobject",
+            related_object_type=self.cot_control.object_type,
+        )
+
+        # COT EC: will hold the FK to Control
+        self.cot_ec = CustomObjectType.objects.create(
+            name="ECCycle", slug="ec-cycle",
+            verbose_name_plural="ECCycles",
+        )
+        CustomObjectTypeField.objects.create(
+            custom_object_type=self.cot_ec,
+            name="name", type="text", primary=True, required=True,
+        )
+        self.cot_ec.get_model()
+
+    def test_fk_into_self_referencing_cot_is_not_false_positive(self):
+        """A non-circular FK from EC to Control must not raise ValidationError.
+
+        Control has a self-referencing M:N field.  Validating a new EC→Control
+        FK field must NOT report "Circular reference detected" — that would be a
+        false positive.
+        """
+        # Build an unsaved field (EC → Control) and invoke the recursion check
+        # directly.  _check_recursion() is the method called from clean().
+        field = CustomObjectTypeField(
+            custom_object_type=self.cot_ec,
+            name="control_ref",
+            type="object",
+            related_object_type=self.cot_control.object_type,
+        )
+        # Must NOT raise ValidationError ("Circular reference detected")
+        try:
+            field._check_recursion()
+        except ValidationError as exc:
+            self.fail(
+                f"_check_recursion() raised ValidationError for a valid EC→Control FK "
+                f"(Control has a self-referencing M:N field). "
+                f"This is a false positive. Error: {exc}"
+            )
+
+    def test_genuine_cycle_is_still_detected(self):
+        """A genuine A → B → A cycle must still be detected."""
+        # Create COT Alpha and Beta
+        cot_alpha = CustomObjectType.objects.create(
+            name="AlphaCycle", slug="alpha-cycle",
+            verbose_name_plural="AlphaCycles",
+        )
+        CustomObjectTypeField.objects.create(
+            custom_object_type=cot_alpha,
+            name="name", type="text", primary=True, required=True,
+        )
+        cot_alpha.get_model()
+
+        cot_beta = CustomObjectType.objects.create(
+            name="BetaCycle", slug="beta-cycle",
+            verbose_name_plural="BetaCycles",
+        )
+        CustomObjectTypeField.objects.create(
+            custom_object_type=cot_beta,
+            name="name", type="text", primary=True, required=True,
+        )
+        cot_beta.get_model()
+
+        # Beta → Alpha (legitimate so far)
+        CustomObjectTypeField.objects.create(
+            custom_object_type=cot_beta,
+            name="alpha_ref",
+            type="object",
+            related_object_type=cot_alpha.object_type,
+        )
+
+        # Alpha → Beta: this creates a genuine cycle A → B → A
+        field = CustomObjectTypeField(
+            custom_object_type=cot_alpha,
+            name="beta_ref",
+            type="object",
+            related_object_type=cot_beta.object_type,
+        )
+        with self.assertRaises(ValidationError):
+            field._check_recursion()
+
+
+class StaleFKReferenceRegressionTest(CustomObjectsTestCase, TestCase):
+    """Regression test for issue #384: stale FK reference after COT model regeneration.
+
+    When COT A's model is regenerated (cache miss, e.g. after a schema change
+    on another worker bumps cache_timestamp), any other COT model (B) that has a
+    FK field pointing to A must have that FK field's ``remote_field.model``
+    updated to the new A class.
+
+    Without the fix, B's FK field keeps referencing the old A class object.
+    Assigning a new-class A instance to B's FK field then raises::
+
+        ValueError: Cannot assign "<TableNModel: ...>": "TableMModel.ref_a" must
+        be a "TableNModel" instance.
+
+    (Both class names are identical but they are different Python objects.)
+    """
+
+    def setUp(self):
+        super().setUp()
+        # COT A (target of the FK)
+        self.cot_a = CustomObjectType.objects.create(
+            name="FkTargetA", slug="fk-target-a",
+            verbose_name_plural="FkTargetAs",
+        )
+        CustomObjectTypeField.objects.create(
+            custom_object_type=self.cot_a,
+            name="name", type="text", primary=True, required=True,
+        )
+
+        # COT B (source: has a direct FK to COT A)
+        self.cot_b = CustomObjectType.objects.create(
+            name="FkSourceB", slug="fk-source-b",
+            verbose_name_plural="FkSourceBs",
+        )
+        CustomObjectTypeField.objects.create(
+            custom_object_type=self.cot_b,
+            name="name", type="text", primary=True, required=True,
+        )
+
+        # Generate A first so its ObjectType exists, then create the FK field on B
+        self.model_a_v1 = self.cot_a.get_model()
+        CustomObjectTypeField.objects.create(
+            custom_object_type=self.cot_b,
+            name="ref_a",
+            label="Ref A",
+            type="object",
+            related_object_type=self.cot_a.object_type,
+        )
+        # Generate B's model; this resolves the LazyForeignKey to model_a_v1
+        self.cot_b.get_model()
+        # Fetch fresh from cache to get the fully-resolved model
+        self.model_b = CustomObjectType.get_cached_model(self.cot_b.id)
+
+    def _get_fk_field(self, model, field_name):
+        """Return the FK field from model._meta.local_fields by name (avoids _relation_tree)."""
+        return next(
+            (f for f in model._meta.local_fields if f.name == field_name),
+            None,
+        )
+
+    def test_b_fk_resolves_to_a_v1_before_regeneration(self):
+        """Sanity: B's FK field must already reference A's model after initial generation."""
+        fk = self._get_fk_field(self.model_b, 'ref_a')
+        self.assertIsNotNone(fk, "B must have an 'ref_a' FK field")
+        # remote_field.model must be the class (not a string) after generation
+        self.assertNotIsInstance(
+            fk.remote_field.model, str,
+            "FK must be resolved to a class, not a string reference",
+        )
+        self.assertIs(
+            fk.remote_field.model, self.model_a_v1,
+            "B's FK must initially point to A's first model class",
+        )
+
+    def test_b_fk_is_patched_after_a_regeneration(self):
+        """After A is regenerated, B's FK field must reference the new A class.
+
+        This is the core regression for issue #384: the isinstance check in
+        ForeignKey.__set__ compares the assigned value against
+        ``self.field.remote_field.model``.  If that attribute still points to the
+        old A class after A is regenerated, assigning a new-A instance raises
+        ValueError.
+        """
+        # Force regeneration of A (simulates a cache miss, e.g. timestamp mismatch)
+        model_a_v2 = self.cot_a.get_model(no_cache=True)
+
+        # The regenerated class must be a distinct Python object
+        self.assertIsNot(model_a_v2, self.model_a_v1,
+                         "Regenerated A must be a new Python class object")
+
+        # B's FK field must now reference A v2, not v1
+        fk = self._get_fk_field(self.model_b, 'ref_a')
+        self.assertIsNotNone(fk, "B must still have an 'ref_a' FK field")
+        self.assertIs(
+            fk.remote_field.model, model_a_v2,
+            "B's FK field must be patched to the newly generated A class; "
+            "a stale reference would cause ValueError on FK assignment",
+        )


### PR DESCRIPTION
### Fixes: #384

## Summary

Two bugs that together produce "fields disappear / Cannot assign TableNModel instance" failures in multi-worker deployments:

### Bug 1: False-positive cycle detection in `_has_circular_reference`

The DFS seeds `visited` with the origin COT's ID, then treats **any** re-encounter of a visited node as a genuine cycle. When an intermediate COT (e.g. **Control**) has a self-referencing multiobject field, the DFS re-encounters Control's ID in `visited` and returns `True` — falsely blocking a valid **EC → Control** FK with "Circular reference detected".

**Fix:** `return custom_object_type.id == self.custom_object_type.id` — only a genuine cycle when the DFS traces back to the **origin** COT.

### Bug 2: Stale FK reference after model regeneration

When a COT's model is regenerated on a cache miss (e.g. `cache_timestamp` bumped after a schema change on another worker), the existing patch loop updated inbound M:N through-model FKs (`TYPE_MULTIOBJECT`) but not inbound **direct FK fields** (`TYPE_OBJECT`). Any cached model that held a `LazyForeignKey` to the regenerated COT then carried a stale class reference, causing Django's isinstance check in `ForeignKey.__set__` to raise:

```
ValueError: Cannot assign "<TableNModel: ...>": "TableMModel.ref_field"
must be a "TableNModel" instance.
```
(Both names are identical — the two objects are different Python classes from different `get_model()` calls.)

**Fix:** After the existing through-model patch loop, add an analogous loop over inbound `TYPE_OBJECT` fields. For each, find the FK field in the owner model's `local_fields` list (uses `local_fields` to avoid `_relation_tree` recursion) and patch `remote_field.model`, `related_model`, and the cached `path_infos`.

## Test plan

- [ ] `CycleDetectionFalsePositiveRegressionTest.test_fk_into_self_referencing_cot_is_not_false_positive` — a valid EC→Control FK (Control has self-referencing M:N) no longer raises ValidationError
- [ ] `CycleDetectionFalsePositiveRegressionTest.test_genuine_cycle_is_still_detected` — a genuine A→B→A cycle still raises ValidationError
- [ ] `StaleFKReferenceRegressionTest.test_b_fk_resolves_to_a_v1_before_regeneration` — sanity: B's FK initially points to A's model class
- [ ] `StaleFKReferenceRegressionTest.test_b_fk_is_patched_after_a_regeneration` — after A is regenerated, B's FK field references the new class

🤖 Generated with [Claude Code](https://claude.com/claude-code)