### PR TITLE
Fixes: #369 - Show choice label instead of raw key for Selection fields

### DIFF
--- a/netbox_custom_objects/field_types.py
+++ b/netbox_custom_objects/field_types.py
@@ -556,12 +556,7 @@ class MultiSelectFieldType(FieldType):
         values = getattr(instance, field_name) or []
         if not values:
             return ''
-        choices_dict = dict(
-            next(
-                (f.base_field.choices for f in instance._meta.local_fields if f.name == field_name),
-                [],
-            )
-        )
+        choices_dict = dict(instance._meta.get_field(field_name).base_field.choices)
         return ', '.join(choices_dict.get(v, v) for v in values)
 
     def get_model_field(self, field, **kwargs):

--- a/netbox_custom_objects/field_types.py
+++ b/netbox_custom_objects/field_types.py
@@ -472,6 +472,21 @@ class JSONFieldType(FieldType):
 
 
 class SelectFieldType(FieldType):
+    def get_display_value(self, instance, field_name):
+        value = getattr(instance, field_name)
+        if value is None:
+            return ''
+        return getattr(instance, f'get_{field_name}_display')() or value
+
+    def get_table_column_field(self, field, **kwargs):
+        choices_dict = dict(field.choices)
+
+        class _SelectLabelColumn(tables.Column):
+            def render(self, value):
+                return choices_dict.get(value, value)
+
+        return _SelectLabelColumn()
+
     def get_filterform_field(self, field, **kwargs):
         return DynamicMultipleChoiceField(
             choices=field.choice_set.choices,
@@ -536,7 +551,16 @@ class MultiSelectFieldType(FieldType):
         )
 
     def get_display_value(self, instance, field_name):
-        return ", ".join(getattr(instance, field_name) or [])
+        values = getattr(instance, field_name) or []
+        if not values:
+            return ''
+        choices_dict = dict(
+            next(
+                (f.base_field.choices for f in instance._meta.local_fields if f.name == field_name),
+                [],
+            )
+        )
+        return ', '.join(choices_dict.get(v, v) for v in values)
 
     def get_model_field(self, field, **kwargs):
         field_kwargs = self._safe_kwargs(**kwargs)
@@ -583,8 +607,16 @@ class MultiSelectFieldType(FieldType):
     #         choices=field.choices, required=required, label=label, **kwargs
     #     )
 
-    def render_table_column(self, value):
-        return ", ".join(value)
+    def get_table_column_field(self, field, **kwargs):
+        choices_dict = dict(field.choices)
+
+        class _MultiSelectLabelColumn(tables.Column):
+            def render(self, value):
+                if not value:
+                    return self.default
+                return ', '.join(choices_dict.get(v, v) for v in value)
+
+        return _MultiSelectLabelColumn()
 
 
 class ObjectFieldType(FieldType):

--- a/netbox_custom_objects/field_types.py
+++ b/netbox_custom_objects/field_types.py
@@ -483,6 +483,8 @@ class SelectFieldType(FieldType):
 
         class _SelectLabelColumn(tables.Column):
             def render(self, value):
+                if value is None:
+                    return self.default
                 return choices_dict.get(value, value)
 
         return _SelectLabelColumn()

--- a/netbox_custom_objects/templatetags/custom_object_utils.py
+++ b/netbox_custom_objects/templatetags/custom_object_utils.py
@@ -27,8 +27,14 @@ def get_field_type_verbose_name(field: CustomObjectTypeField) -> str:
 
 
 @register.filter(name="get_field_value")
-def get_field_value(obj, field: CustomObjectTypeField) -> str:
-    return getattr(obj, field.name)
+def get_field_value(obj, field: CustomObjectTypeField):
+    value = getattr(obj, field.name)
+    if field.type == CustomFieldTypeChoices.TYPE_SELECT and value:
+        return getattr(obj, f'get_{field.name}_display')() or value
+    if field.type == CustomFieldTypeChoices.TYPE_MULTISELECT and value:
+        choices_dict = dict(obj._meta.get_field(field.name).base_field.choices)
+        return [choices_dict.get(v, v) for v in value]
+    return value
 
 
 @register.filter(name="get_field_is_ui_visible")

--- a/netbox_custom_objects/tests/query_counts.json
+++ b/netbox_custom_objects/tests/query_counts.json
@@ -1,6 +1,6 @@
 {
   "customobjecttype:list_objects_with_permission": 32,
-  "table285model:list_objects_with_permission": 39,
-  "table289model:list_objects_with_permission": 33,
-  "table290model:list_objects_with_permission": 50
+  "table286model:list_objects_with_permission": 41,
+  "table290model:list_objects_with_permission": 33,
+  "table291model:list_objects_with_permission": 50
 }

--- a/netbox_custom_objects/tests/query_counts.json
+++ b/netbox_custom_objects/tests/query_counts.json
@@ -1,5 +1,5 @@
 {
-  "customobject-complex:list_objects_with_permission": 39,
+  "customobject-complex:list_objects_with_permission": 41,
   "customobject-objectfields:list_objects_with_permission": 50,
   "customobject-simple:list_objects_with_permission": 33,
   "customobjecttype:list_objects_with_permission": 32

--- a/netbox_custom_objects/tests/test_field_types.py
+++ b/netbox_custom_objects/tests/test_field_types.py
@@ -534,6 +534,40 @@ class SelectFieldTypeTestCase(FieldTypeTestCase):
 
         self.assertEqual(instance.status, "choice2")
 
+    def test_select_field_display_value_returns_label(self):
+        """get_display_value() must return the human-readable label, not the raw key."""
+        from netbox_custom_objects.field_types import SelectFieldType
+        self.create_custom_object_type_field(
+            self.custom_object_type,
+            name="status",
+            label="Status",
+            type="select",
+            choice_set=self.choice_set,
+        )
+        model = self.custom_object_type.get_model(no_cache=True)
+        instance = model.objects.create(name="Test", status="choice1")
+        field_type = SelectFieldType()
+        self.assertEqual(field_type.get_display_value(instance, "status"), "Choice 1")
+
+    def test_select_primary_field_str_uses_label(self):
+        """When a Selection field is the primary field, __str__ must show the label."""
+        cot = self.create_custom_object_type(
+            name="StrSelectObject",
+            slug="str-select-object",
+            verbose_name_plural="StrSelectObjects",
+        )
+        self.create_custom_object_type_field(
+            cot,
+            name="status",
+            label="Status",
+            type="select",
+            choice_set=self.choice_set,
+            primary=True,
+        )
+        model = cot.get_model()
+        instance = model.objects.create(status="choice2")
+        self.assertEqual(str(instance), "Choice 2")
+
 
 class MultiSelectFieldTypeTestCase(FieldTypeTestCase):
     """Test cases for multiselect field type."""
@@ -589,6 +623,24 @@ class MultiSelectFieldTypeTestCase(FieldTypeTestCase):
         instance = model.objects.create(name="Test", tags=["choice1", "choice3"])
 
         self.assertEqual(instance.tags, ["choice1", "choice3"])
+
+    def test_multiselect_field_display_value_returns_labels(self):
+        """get_display_value() must return comma-joined human-readable labels, not raw keys."""
+        from netbox_custom_objects.field_types import MultiSelectFieldType
+        self.create_custom_object_type_field(
+            self.custom_object_type,
+            name="tags",
+            label="Tags",
+            type="multiselect",
+            choice_set=self.choice_set,
+        )
+        model = self.custom_object_type.get_model(no_cache=True)
+        instance = model.objects.create(name="Test", tags=["choice1", "choice3"])
+        field_type = MultiSelectFieldType()
+        self.assertEqual(
+            field_type.get_display_value(instance, "tags"),
+            "Choice 1, Choice 3",
+        )
 
 
 class ObjectFieldTypeTestCase(FieldTypeTestCase):

--- a/netbox_custom_objects/tests/test_field_types.py
+++ b/netbox_custom_objects/tests/test_field_types.py
@@ -2,6 +2,7 @@
 Tests for all the different field types supported by Custom Object Type Fields.
 """
 from unittest import skip
+from unittest.mock import Mock
 from datetime import date, datetime
 from decimal import Decimal
 from django.core.exceptions import ValidationError
@@ -572,6 +573,21 @@ class SelectFieldTypeTestCase(FieldTypeTestCase):
         instance = model.objects.create(status="choice2")
         self.assertEqual(str(instance), "Choice 2")
 
+    def test_select_column_render_returns_label(self):
+        """get_table_column_field() render() translates a raw key to its human-readable label."""
+        field = Mock()
+        field.choices = [('choice1', 'Choice 1'), ('choice2', 'Choice 2')]
+        column = SelectFieldType().get_table_column_field(field)
+        self.assertEqual(column.render(value='choice1'), 'Choice 1')
+        self.assertEqual(column.render(value='choice2'), 'Choice 2')
+
+    def test_select_column_render_unknown_key_falls_back_to_raw_value(self):
+        """get_table_column_field() render() returns the raw key when it is not in choices."""
+        field = Mock()
+        field.choices = [('choice1', 'Choice 1')]
+        column = SelectFieldType().get_table_column_field(field)
+        self.assertEqual(column.render(value='unknown'), 'unknown')
+
 
 class MultiSelectFieldTypeTestCase(FieldTypeTestCase):
     """Test cases for multiselect field type."""
@@ -644,6 +660,20 @@ class MultiSelectFieldTypeTestCase(FieldTypeTestCase):
             field_type.get_display_value(instance, "tags"),
             "Choice 1, Choice 3",
         )
+
+    def test_multiselect_column_render_returns_labels(self):
+        """get_table_column_field() render() translates raw keys to comma-joined labels."""
+        field = Mock()
+        field.choices = [('choice1', 'Choice 1'), ('choice2', 'Choice 2'), ('choice3', 'Choice 3')]
+        column = MultiSelectFieldType().get_table_column_field(field)
+        self.assertEqual(column.render(value=['choice1', 'choice3']), 'Choice 1, Choice 3')
+
+    def test_multiselect_column_render_unknown_key_falls_back_to_raw_value(self):
+        """get_table_column_field() render() preserves unknown keys in the joined output."""
+        field = Mock()
+        field.choices = [('choice1', 'Choice 1')]
+        column = MultiSelectFieldType().get_table_column_field(field)
+        self.assertEqual(column.render(value=['choice1', 'unknown']), 'Choice 1, unknown')
 
 
 class ObjectFieldTypeTestCase(FieldTypeTestCase):

--- a/netbox_custom_objects/tests/test_field_types.py
+++ b/netbox_custom_objects/tests/test_field_types.py
@@ -588,6 +588,34 @@ class SelectFieldTypeTestCase(FieldTypeTestCase):
         column = SelectFieldType().get_table_column_field(field)
         self.assertEqual(column.render(value='unknown'), 'unknown')
 
+    def test_get_field_value_returns_label_for_select(self):
+        """get_field_value template filter returns the human-readable label for select fields."""
+        from netbox_custom_objects.templatetags.custom_object_utils import get_field_value
+        cotf = self.create_custom_object_type_field(
+            self.custom_object_type,
+            name="status",
+            label="Status",
+            type="select",
+            choice_set=self.choice_set,
+        )
+        model = self.custom_object_type.get_model(no_cache=True)
+        instance = model.objects.create(name="Test", status="choice1")
+        self.assertEqual(get_field_value(instance, cotf), "Choice 1")
+
+    def test_get_field_value_returns_raw_value_when_select_is_none(self):
+        """get_field_value returns None (falsy) when the select field is unset."""
+        from netbox_custom_objects.templatetags.custom_object_utils import get_field_value
+        cotf = self.create_custom_object_type_field(
+            self.custom_object_type,
+            name="status",
+            label="Status",
+            type="select",
+            choice_set=self.choice_set,
+        )
+        model = self.custom_object_type.get_model(no_cache=True)
+        instance = model.objects.create(name="Test")
+        self.assertIsNone(get_field_value(instance, cotf))
+
 
 class MultiSelectFieldTypeTestCase(FieldTypeTestCase):
     """Test cases for multiselect field type."""
@@ -674,6 +702,34 @@ class MultiSelectFieldTypeTestCase(FieldTypeTestCase):
         field.choices = [('choice1', 'Choice 1')]
         column = MultiSelectFieldType().get_table_column_field(field)
         self.assertEqual(column.render(value=['choice1', 'unknown']), 'Choice 1, unknown')
+
+    def test_get_field_value_returns_label_list_for_multiselect(self):
+        """get_field_value template filter returns a list of labels for multiselect fields."""
+        from netbox_custom_objects.templatetags.custom_object_utils import get_field_value
+        cotf = self.create_custom_object_type_field(
+            self.custom_object_type,
+            name="tags",
+            label="Tags",
+            type="multiselect",
+            choice_set=self.choice_set,
+        )
+        model = self.custom_object_type.get_model(no_cache=True)
+        instance = model.objects.create(name="Test", tags=["choice1", "choice3"])
+        self.assertEqual(get_field_value(instance, cotf), ["Choice 1", "Choice 3"])
+
+    def test_get_field_value_returns_empty_list_when_multiselect_is_none(self):
+        """get_field_value returns None (falsy) when the multiselect field is unset."""
+        from netbox_custom_objects.templatetags.custom_object_utils import get_field_value
+        cotf = self.create_custom_object_type_field(
+            self.custom_object_type,
+            name="tags",
+            label="Tags",
+            type="multiselect",
+            choice_set=self.choice_set,
+        )
+        model = self.custom_object_type.get_model(no_cache=True)
+        instance = model.objects.create(name="Test")
+        self.assertIsNone(get_field_value(instance, cotf))
 
 
 class ObjectFieldTypeTestCase(FieldTypeTestCase):

--- a/netbox_custom_objects/tests/test_field_types.py
+++ b/netbox_custom_objects/tests/test_field_types.py
@@ -8,7 +8,12 @@ from django.core.exceptions import ValidationError
 from django.test import TestCase
 
 from core.models import ObjectType
-from netbox_custom_objects.field_types import MultiObjectFieldType, MultiSelectFieldType, ObjectFieldType, SelectFieldType
+from netbox_custom_objects.field_types import (
+    MultiObjectFieldType,
+    MultiSelectFieldType,
+    ObjectFieldType,
+    SelectFieldType,
+)
 from netbox_custom_objects.models import CustomObjectType, CustomObjectTypeField
 from .base import CustomObjectsTestCase
 

--- a/netbox_custom_objects/tests/test_field_types.py
+++ b/netbox_custom_objects/tests/test_field_types.py
@@ -8,7 +8,7 @@ from django.core.exceptions import ValidationError
 from django.test import TestCase
 
 from core.models import ObjectType
-from netbox_custom_objects.field_types import MultiObjectFieldType, ObjectFieldType
+from netbox_custom_objects.field_types import MultiObjectFieldType, MultiSelectFieldType, ObjectFieldType, SelectFieldType
 from netbox_custom_objects.models import CustomObjectType, CustomObjectTypeField
 from .base import CustomObjectsTestCase
 
@@ -536,7 +536,6 @@ class SelectFieldTypeTestCase(FieldTypeTestCase):
 
     def test_select_field_display_value_returns_label(self):
         """get_display_value() must return the human-readable label, not the raw key."""
-        from netbox_custom_objects.field_types import SelectFieldType
         self.create_custom_object_type_field(
             self.custom_object_type,
             name="status",
@@ -626,7 +625,6 @@ class MultiSelectFieldTypeTestCase(FieldTypeTestCase):
 
     def test_multiselect_field_display_value_returns_labels(self):
         """get_display_value() must return comma-joined human-readable labels, not raw keys."""
-        from netbox_custom_objects.field_types import MultiSelectFieldType
         self.create_custom_object_type_field(
             self.custom_object_type,
             name="tags",


### PR DESCRIPTION
### Fixes: #369

## Summary

- `SelectFieldType.get_display_value()` now calls Django's `get_<fieldname>_display()` so the object title, `__str__`, and serializer context return the human-readable label instead of the raw key
- `SelectFieldType.get_table_column_field()` returns a column whose `render()` translates keys via a choices-dict closure, fixing table rows
- `MultiSelectFieldType.get_display_value()` translates each key to its label by reading choices from the model field's `base_field`
- `MultiSelectFieldType.get_table_column_field()` replaces the old `render_table_column` that returned raw keys

Issues #369 and #461 are the same root cause (both in `SelectFieldType` lacking `get_display_value()`/table rendering), covered by a single fix.

## Test plan

- [ ] `SelectFieldTypeTestCase.test_select_field_display_value_returns_label` — asserts `get_display_value()` returns `"Choice 1"` not `"choice1"`
- [ ] `SelectFieldTypeTestCase.test_select_primary_field_str_uses_label` — asserts `str(instance)` returns `"Choice 2"` when a Selection field is primary
- [ ] `MultiSelectFieldTypeTestCase.test_multiselect_field_display_value_returns_labels` — asserts joined labels `"Choice 1, Choice 3"` not raw keys
- [ ] Full test suite: `python manage.py test netbox_custom_objects.tests --keepdb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)