### PR TITLE
Fixes: #353 - Prevent AttributeError in __str__ when primary field missing from generated model

### DIFF
--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -131,9 +131,12 @@ class CustomObject(
         primary_field_value = None
         if primary_field:
             field_type = FIELD_TYPE_CLASS[primary_field["field"].type]()
-            primary_field_value = field_type.get_display_value(
-                self, primary_field["name"]
-            )
+            try:
+                primary_field_value = field_type.get_display_value(
+                    self, primary_field["name"]
+                )
+            except AttributeError:
+                primary_field_value = None
         if not primary_field_value:
             return f"{self.custom_object_type.display_name} {self.id}"
         return str(primary_field_value) or str(self.id)
@@ -454,7 +457,7 @@ class CustomObjectType(NetBoxModel):
                         field.name, field.pk, self.slug,
                     )
                 else:
-                    logger.debug(
+                    logger.warning(
                         "Skipping field %r (pk=%s) on COT %r: related_object_type_id=%s "
                         "references a ContentType that no longer exists.",
                         field.name, field.pk, self.slug, field.related_object_type_id,

--- a/netbox_custom_objects/template_content.py
+++ b/netbox_custom_objects/template_content.py
@@ -56,7 +56,7 @@ class CustomObjectLink(PluginTemplateExtension):
         target_obj = self.context["object"]
 
         for field in list(non_poly_fields) + list(poly_fields):
-            model = field.custom_object_type.get_model(no_cache=True)
+            model = field.custom_object_type.get_model()
 
             if field.type == CustomFieldTypeChoices.TYPE_MULTIOBJECT:
                 if field.is_polymorphic:
@@ -80,11 +80,7 @@ class CustomObjectLink(PluginTemplateExtension):
                     })
                 else:
                     # Filter by PK rather than by instance to avoid Django's
-                    # isinstance check in check_query_object_type.  When
-                    # no_cache=True generates a fresh class object, a
-                    # self-referential field's target_obj (from the cached
-                    # class) and model (the fresh class) are not identity-equal,
-                    # causing "Must be TableNModel instance" ValueError (#508).
+                    # isinstance check in check_query_object_type (#508).
                     linked_objects = model.objects.filter(**{f"{field.name}_id": target_obj.pk})
 
             for model_object in linked_objects:

--- a/netbox_custom_objects/tests/test_models.py
+++ b/netbox_custom_objects/tests/test_models.py
@@ -25,7 +25,7 @@ from netbox.search import registry
 from netbox.search.backends import get_backend
 from netbox_custom_objects.api.serializers import get_serializer_class
 from netbox_custom_objects.constants import APP_LABEL
-from netbox_custom_objects.field_types import LazyForeignKey
+from netbox_custom_objects.field_types import LazyForeignKey, ObjectFieldType, TextFieldType
 from netbox_custom_objects.jobs import ReindexCustomObjectTypeJob
 from netbox_custom_objects.models import CustomObjectType, CustomObjectTypeField
 from netbox_custom_objects.utilities import extract_cot_id_from_model_name
@@ -241,6 +241,31 @@ class CustomObjectTypeTestCase(CustomObjectsTestCase, TestCase):
                          "OBJECT field must be absent from stub model")
         # Must not raise FieldDoesNotExist, RecursionError, or any other exception.
         cot.register_custom_object_search_index(stub_model)
+
+    def test_skipped_object_field_with_stale_content_type_logs_warning(self):
+        """When get_model_field raises NotImplementedError for an object field whose
+        related_object_type_id is non-null (stale/deleted ContentType), a WARNING must
+        be emitted — not just DEBUG — so operators can identify the broken field.
+        Regression test for the fix in _fetch_and_generate_field_attrs (issue #353).
+        """
+        cot = self.create_custom_object_type(name="StaleCtTest", slug="stale-ct-test")
+        self.create_custom_object_type_field(
+            cot,
+            name="device",
+            label="Device",
+            type="object",
+            related_object_type=self.get_device_object_type(),
+        )
+        CustomObjectType.clear_model_cache(cot.id)
+        # Simulate a stale ContentType: get_model_field raises NotImplementedError
+        # while related_object_type_id is still set (non-null).
+        with patch.object(ObjectFieldType, 'get_model_field', side_effect=NotImplementedError):
+            with self.assertLogs('netbox_custom_objects.models', level='WARNING') as cm:
+                cot.get_model()
+        self.assertTrue(
+            any('device' in msg for msg in cm.output),
+            f"Expected WARNING mentioning field name 'device'; got: {cm.output}",
+        )
 
     @skip("Fails in suite but not individually")
     def test_custom_object_type_delete_removes_table(self):
@@ -889,6 +914,22 @@ class CustomObjectTestCase(CustomObjectsTestCase, TestCase):
         instance = self.model(name="ab")
         with self.assertRaises(ValidationError):
             instance.full_clean()
+
+    def test_str_falls_back_when_primary_field_raises_attribute_error(self):
+        """CustomObject.__str__ must return "<display_name> <id>" rather than
+        propagating an AttributeError when get_display_value fails.  This can
+        happen when the generated model class is missing an attribute for the
+        primary field (e.g. the field was silently skipped during regeneration
+        due to a stale ContentType).  Regression test for issue #353.
+        """
+        instance = self.model.objects.create(name="Test Instance")
+        # Confirm normal __str__ works first.
+        self.assertEqual(str(instance), "Test Instance")
+        # Simulate the stale-model scenario: get_display_value raises AttributeError.
+        with patch.object(TextFieldType, 'get_display_value', side_effect=AttributeError("missing attr")):
+            result = str(instance)
+        expected = f"{self.custom_object_type.display_name} {instance.id}"
+        self.assertEqual(result, expected)
 
 
 class RelatedNameTestCase(CustomObjectsTestCase, TestCase):


### PR DESCRIPTION
### Fixes: #353 

## Summary

- Remove `no_cache=True` from `template_content.py` so the `cache_timestamp` invalidation path handles staleness correctly instead of bypassing the cache on every request (which caused a transiently bad regeneration to be written back permanently)
- Guard `CustomObject.__str__` with `try/except AttributeError` so an incomplete generated model falls back gracefully to `"<DisplayName> <id>"` instead of crashing
- Upgrade silent-skip log from `DEBUG` to `WARNING` in `_fetch_and_generate_field_attrs` when a field is dropped due to a missing ContentType, so operators have a visible signal in logs

## Test plan

- [ ] Reproduce the issue: create a COT with an object field pointing to a now-deleted ContentType; navigate to a built-in NetBox object detail page with a linked custom object — confirm no `AttributeError` and the object displays its fallback label
- [ ] Confirm edit/save of a COTF still invalidates the cache and regenerates the model correctly
- [ ] Confirm self-referential object fields still work (no "Must be TableNModel instance" ValueError from #508)
- [ ] Check logs show a `WARNING` (not just `DEBUG`) when a field is skipped due to a stale `related_object_type_id`

Closes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)