### PR TITLE
Closes: #536 - Use stable query_count_model_label for dynamic-model view tests

### DIFF
--- a/netbox_custom_objects/tests/query_counts.json
+++ b/netbox_custom_objects/tests/query_counts.json
@@ -1,6 +1,6 @@
 {
-  "customobject-complex:list_objects_with_permission": 30,
-  "customobject-objectfields:list_objects_with_permission": 38,
-  "customobject-simple:list_objects_with_permission": 26,
+  "customobject-complex:list_objects_with_permission": 39,
+  "customobject-objectfields:list_objects_with_permission": 50,
+  "customobject-simple:list_objects_with_permission": 33,
   "customobjecttype:list_objects_with_permission": 32
 }

--- a/netbox_custom_objects/tests/query_counts.json
+++ b/netbox_custom_objects/tests/query_counts.json
@@ -1,6 +1,6 @@
 {
-  "customobjecttype:list_objects_with_permission": 32,
-  "table285model:list_objects_with_permission": 39,
-  "table289model:list_objects_with_permission": 33,
-  "table290model:list_objects_with_permission": 50
+  "customobject-complex:list_objects_with_permission": 30,
+  "customobject-objectfields:list_objects_with_permission": 38,
+  "customobject-simple:list_objects_with_permission": 26,
+  "customobjecttype:list_objects_with_permission": 32
 }

--- a/netbox_custom_objects/tests/test_views.py
+++ b/netbox_custom_objects/tests/test_views.py
@@ -224,6 +224,8 @@ class CustomObjectTypeFieldViewTestCase(CustomObjectsTestCase, ViewTestCases.Pri
 class CustomObjectViewTestCase(CustomObjectsTestCase, ViewTestCases.PrimaryObjectViewTestCase):
     """Test cases for dynamic CustomObject views."""
 
+    query_count_model_label = 'customobject-simple'
+
     @classmethod
     def setUpTestData(cls):
         """Set up test data."""
@@ -447,6 +449,8 @@ class CustomObjectViewTestCase(CustomObjectsTestCase, ViewTestCases.PrimaryObjec
 class ComplexCustomObjectViewTestCase(CustomObjectsTestCase, ViewTestCases.PrimaryObjectViewTestCase):
     """Test cases for complex custom objects with various field types."""
 
+    query_count_model_label = 'customobject-complex'
+
     @classmethod
     def setUpTestData(cls):
         """Set up test data."""
@@ -656,6 +660,8 @@ class ComplexCustomObjectViewTestCase(CustomObjectsTestCase, ViewTestCases.Prima
 
 class ObjectFieldViewTestCase(CustomObjectsTestCase, ViewTestCases.PrimaryObjectViewTestCase):
     """Test cases for custom objects with object and multi-object fields."""
+
+    query_count_model_label = 'customobject-objectfields'
 
     @classmethod
     def setUpTestData(cls):


### PR DESCRIPTION
### Closes: #536 

## Summary

- Add `query_count_model_label` to `CustomObjectViewTestCase`, `ComplexCustomObjectViewTestCase`, and `ObjectFieldViewTestCase` with stable human-assigned labels (`customobject-simple`, `customobject-complex`, `customobject-objectfields`)
- Regenerate `query_counts.json`, replacing the three unstable `table<N>model` keys with the new stable-label equivalents

## Justification

`query_counts.json` previously contained keys like `table285model:list_objects_with_permission` where the number comes from the PostgreSQL sequence for `CustomObjectType`. These keys differ on every fresh database, causing spurious baseline misses that require manual regeneration per environment.

NetBox PR [#22306](https://github.com/netbox-community/netbox/pull/22306) (now in `main`) introduced `query_count_model_label` precisely for this case. Setting it on the affected test classes makes the baseline keys stable and portable.

## Test plan

- [x] `CustomObjectViewTestCase.test_list_objects_with_permission` passes against new baseline
- [x] `ComplexCustomObjectViewTestCase.test_list_objects_with_permission` passes against new baseline
- [x] `ObjectFieldViewTestCase.test_list_objects_with_permission` passes against new baseline

Closes #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)