### PR TITLE
Fixes: #538 - Prevent OOM crash when select/multiselect fields use large base choice sets

### DIFF
--- a/netbox_custom_objects/field_types.py
+++ b/netbox_custom_objects/field_types.py
@@ -163,6 +163,33 @@ def _make_lazy_cot_fk(cot, field, on_delete, **field_kwargs):
     )
 
 
+class _LazyAPIMultipleChoiceField(DynamicMultipleChoiceField):
+    """
+    DynamicMultipleChoiceField variant that mirrors the DynamicChoiceField
+    behaviour of clearing choices to [] when no value is currently selected.
+
+    DynamicMultipleChoiceField (NetBox core) has no `else` branch in
+    get_bound_field(), so when the field has no current selection the full
+    choices list is left in place and every option is rendered as an <option>
+    element by the APISelect template (which delegates to Django's standard
+    select.html).  For large built-in choice sets such as IATA (~10 000
+    entries) this generates enough DOM nodes to OOM the browser.
+
+    The APISelectMultiple widget already loads options lazily via AJAX; the
+    static choices list is only needed at POST time to validate submitted
+    values.  Clearing it on GET is safe.
+    """
+    def get_bound_field(self, form, field_name):
+        from django.forms import BoundField as _BF
+        bound_field = _BF(form, self, field_name)
+        data = bound_field.value()
+        if data is not None:
+            self.choices = [c for c in self.choices if c[0] and c[0] in data]
+        else:
+            self.choices = []
+        return bound_field
+
+
 class FieldType:
 
     def get_display_value(self, instance, field_name):
@@ -474,7 +501,7 @@ class JSONFieldType(FieldType):
 class SelectFieldType(FieldType):
     def get_filterform_field(self, field, **kwargs):
         return DynamicMultipleChoiceField(
-            choices=field.choice_set.choices,
+            choices=[],
             label=field,
             required=False,
             widget=APISelectMultiple(
@@ -525,9 +552,8 @@ class SelectFieldType(FieldType):
 
 class MultiSelectFieldType(FieldType):
     def get_filterform_field(self, field, **kwargs):
-        choices = field.choice_set.choices
         return DynamicMultipleChoiceField(
-            choices=choices,
+            choices=[],
             label=field,
             required=False,
             widget=APISelectMultiple(
@@ -566,13 +592,11 @@ class MultiSelectFieldType(FieldType):
                 choices=choices, required=field.required, initial=initial
             )
         else:
-            field_class = DynamicMultipleChoiceField
-            widget_class = APISelectMultiple
-            return field_class(
+            return _LazyAPIMultipleChoiceField(
                 choices=choices,
                 required=field.required,
                 initial=initial,
-                widget=widget_class(
+                widget=APISelectMultiple(
                     api_url=f"/api/extras/custom-field-choice-sets/{field.choice_set.pk}/choices/"
                 ),
             )


### PR DESCRIPTION
### Fixes: #538 

## Summary

- Add `_LazyAPIMultipleChoiceField` — a thin subclass of `DynamicMultipleChoiceField` that adds the missing `else: self.choices = []` branch to `get_bound_field()`, preventing the full choices list from being rendered as static `<option>` elements when no value is selected
- Use it in `MultiSelectFieldType.get_form_field` (non-CSV path)
- Pass `choices=[]` to both `get_filterform_field` methods (Select and MultiSelect) — filter-form fields have no server-side validation; the `APISelectMultiple` widget loads options via AJAX

## Root cause

`DynamicMultipleChoiceField` (NetBox core) is missing the `else: self.choices = []` branch that `DynamicChoiceField` has in `get_bound_field()`. When there is no current selection the full choices list is left intact, and the `APISelect` template (`{% include 'django/forms/widgets/select.html' %}`) renders every item as a static `<option>` element. For built-in choice sets such as IATA (~10 000 entries), two such fields (select + multiselect) generate ~20 000 DOM nodes, which is enough to OOM and kill the browser process (exit code 247).

`DynamicChoiceField` already handles this correctly — the fix brings `DynamicMultipleChoiceField`'s behaviour in line.

## Test plan

- [x] Existing field-type tests (62 tests) all pass
- [ ] Manual: create a COT with a select + multi-select field backed by the IATA base choice set; confirm the COT detail/list page and the custom object add form load in normal time without browser crash
- [ ] Confirm filter bar on the custom object list page works (AJAX-loads airports on demand)
- [ ] Confirm saving a new custom object with airport values selected validates and saves correctly

Closes #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)