### PR TITLE
Fixes #370: lazy serializer registration via module __getattr__ and skip_object_fields guard

### DIFF
--- a/netbox_custom_objects/api/serializers.py
+++ b/netbox_custom_objects/api/serializers.py
@@ -692,8 +692,44 @@ def get_serializer_class(model, skip_object_fields=False):
         attrs,
     )
 
-    # Register the serializer in the current module so NetBox can find it
-    current_module = sys.modules[__name__]
-    setattr(current_module, serializer_name, serializer)
+    # Register the FULL serializer as a module attribute so NetBox's import_string()
+    # and the module-level __getattr__ fallback can find it.
+    # The partial variant (skip_object_fields=True) is used only as a nested field
+    # descriptor inside another serializer class and must NOT be stored on the module
+    # — doing so would silently replace the full serializer with an incomplete one
+    # that drops FK fields, causing SerializerNotFound or data loss on the next
+    # request that expects those fields (issue #370).
+    if not skip_object_fields:
+        current_module = sys.modules[__name__]
+        setattr(current_module, serializer_name, serializer)
 
     return serializer
+
+
+def __getattr__(name):
+    """
+    Module-level lazy resolution for Table{N}ModelSerializer attributes (PEP 562).
+
+    NetBox's get_serializer_for_model() resolves serializers via
+    import_string("netbox_custom_objects.api.serializers.TableNModelSerializer"),
+    which ultimately calls getattr(module, name).  That lookup hits this hook
+    when the attribute has not yet been registered — for example in a worker
+    whose ready() ran against an empty database, or in any worker that started
+    before a given COT was created.
+
+    Generating on demand here means SerializerNotFound is never raised just
+    because startup-time registration was skipped or missed (issue #370).
+    The generated serializer is stored via setattr inside get_serializer_class(),
+    so subsequent lookups return it directly from __dict__ without re-entering
+    this hook.
+    """
+    match = re.match(r'^Table(\d+)ModelSerializer$', name)
+    if match:
+        cot_id = int(match.group(1))
+        try:
+            obj = CustomObjectType.objects.get(pk=cot_id)
+            model = obj.get_model()
+            return get_serializer_class(model)
+        except Exception:
+            pass
+    raise AttributeError(f"module '{__name__}' has no attribute {name!r}")

--- a/netbox_custom_objects/api/serializers.py
+++ b/netbox_custom_objects/api/serializers.py
@@ -5,6 +5,7 @@ import sys
 from core.models import ObjectType
 from django.contrib.contenttypes.models import ContentType
 from django.db import transaction
+from django.db.utils import OperationalError, ProgrammingError
 from django.urls import NoReverseMatch
 from django.utils.translation import gettext_lazy as _
 from extras.choices import CustomFieldTypeChoices
@@ -730,6 +731,11 @@ def __getattr__(name):
             obj = CustomObjectType.objects.get(pk=cot_id)
             model = obj.get_model()
             return get_serializer_class(model)
-        except Exception:
+        except (CustomObjectType.DoesNotExist, ProgrammingError, OperationalError, LookupError):
             pass
+        except Exception:
+            logger.warning(
+                "Unexpected error generating serializer for %r; serializer will not be available",
+                name, exc_info=True,
+            )
     raise AttributeError(f"module '{__name__}' has no attribute {name!r}")

--- a/netbox_custom_objects/tests/test_models.py
+++ b/netbox_custom_objects/tests/test_models.py
@@ -2057,3 +2057,125 @@ class StaleFKReferenceRegressionTest(CustomObjectsTestCase, TestCase):
             "B's FK field must be patched to the newly generated A class; "
             "a stale reference would cause ValueError on FK assignment",
         )
+
+
+class LazySerializerRegistrationTestCase(CustomObjectsTestCase, TestCase):
+    """Regression tests for issue #370: SerializerNotFound when a COT is
+    created after startup and a worker never served a custom-objects API request.
+
+    Two related bugs:
+    1. get_serializer_class(model, skip_object_fields=True) used to overwrite the
+       full module-level serializer with a partial one, causing subsequent requests
+       to fail or return incomplete data.
+    2. import_string("netbox_custom_objects.api.serializers.Table{N}ModelSerializer")
+       raised SerializerNotFound in workers whose ready() ran before the COT existed.
+       The module-level __getattr__ hook (PEP 562) fixes this by generating the
+       serializer on demand.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.parent_cot = CustomObjectType.objects.create(
+            name="lazy_parent", slug="lazy-parent", verbose_name_plural="lazy_parents",
+        )
+        CustomObjectTypeField.objects.create(
+            custom_object_type=cls.parent_cot, name="title", label="Title",
+            type="text", primary=True, required=True,
+        )
+
+        cls.child_cot = CustomObjectType.objects.create(
+            name="lazy_child", slug="lazy-child", verbose_name_plural="lazy_children",
+        )
+        CustomObjectTypeField.objects.create(
+            custom_object_type=cls.child_cot, name="title", label="Title",
+            type="text", primary=True, required=True,
+        )
+        CustomObjectTypeField.objects.create(
+            custom_object_type=cls.child_cot, name="parent", label="Parent",
+            type="object", related_object_type=cls.parent_cot.object_type,
+        )
+
+    def _clear_serializer_registrations(self):
+        """Remove any previously registered serializers for parent and child COTs
+        from the module so that __getattr__ and get_serializer_class() behave as
+        they would in a fresh worker process."""
+        import netbox_custom_objects.api.serializers as ser_module
+        parent_model = self.parent_cot.get_model()
+        child_model = self.child_cot.get_model()
+        for model in (parent_model, child_model):
+            attr = f"{model._meta.object_name}Serializer"
+            ser_module.__dict__.pop(attr, None)
+
+    def test_module_getattr_generates_serializer_on_demand(self):
+        """__getattr__ must generate and return a serializer for any Table{N}Model
+        whose serializer was never pre-registered (simulates a worker that started
+        before the COT was created — issue #370 Scenario A)."""
+        import netbox_custom_objects.api.serializers as ser_module
+        self._clear_serializer_registrations()
+
+        parent_model = self.parent_cot.get_model()
+        serializer_name = f"{parent_model._meta.object_name}Serializer"
+
+        # Attribute must not be in __dict__ after clearing
+        self.assertNotIn(serializer_name, ser_module.__dict__,
+                         "precondition: serializer must not be pre-registered")
+
+        # getattr() must trigger __getattr__ and return a valid class
+        serializer_cls = getattr(ser_module, serializer_name)
+        self.assertIsNotNone(serializer_cls)
+        self.assertIn("title", serializer_cls.Meta.fields)
+
+        # After __getattr__ fires, the serializer is cached in __dict__
+        self.assertIn(serializer_name, ser_module.__dict__,
+                      "serializer must be cached in module __dict__ after first access")
+
+    def test_skip_object_fields_does_not_overwrite_full_serializer(self):
+        """get_serializer_class(model, skip_object_fields=True) must not overwrite
+        the full module-level serializer for that model.  The full serializer
+        (registered via skip_object_fields=False) must remain accessible after
+        a partial serializer is built for the same model (issue #370 Bug 2)."""
+        import netbox_custom_objects.api.serializers as ser_module
+        self._clear_serializer_registrations()
+
+        parent_model = self.parent_cot.get_model()
+        serializer_name = f"{parent_model._meta.object_name}Serializer"
+
+        # Register the full serializer first
+        full_serializer = get_serializer_class(parent_model, skip_object_fields=False)
+        self.assertIn(serializer_name, ser_module.__dict__)
+
+        # Now call with skip_object_fields=True (simulates the nested-serializer path
+        # triggered when building the child serializer's FK field)
+        partial_serializer = get_serializer_class(parent_model, skip_object_fields=True)
+
+        # Module must still hold the FULL serializer, not the partial one
+        registered = getattr(ser_module, serializer_name)
+        self.assertIs(registered, full_serializer,
+                      "full serializer must not be overwritten by the partial variant")
+        self.assertIsNot(registered, partial_serializer,
+                         "partial serializer must be a distinct object, not stored on module")
+
+    def test_child_serializer_does_not_clobber_parent_serializer(self):
+        """Building child's serializer (which creates a nested partial for parent)
+        must leave the parent's full module-level serializer intact (issue #370)."""
+        import netbox_custom_objects.api.serializers as ser_module
+        self._clear_serializer_registrations()
+
+        parent_model = self.parent_cot.get_model()
+        child_model = self.child_cot.get_model()
+        parent_serializer_name = f"{parent_model._meta.object_name}Serializer"
+        child_serializer_name = f"{child_model._meta.object_name}Serializer"
+
+        # Register parent's full serializer first
+        full_parent_serializer = get_serializer_class(parent_model)
+        self.assertIn("title", full_parent_serializer.Meta.fields)
+
+        # Build child serializer — internally calls get_serializer_class(parent, skip_object_fields=True)
+        get_serializer_class(child_model)
+
+        # Parent's full serializer must be unchanged
+        registered_parent = getattr(ser_module, parent_serializer_name)
+        self.assertIs(registered_parent, full_parent_serializer,
+                      "building child serializer must not clobber parent's full serializer")
+        self.assertIn("title", registered_parent.Meta.fields,
+                      "parent's full field set must be intact after child serializer is built")

--- a/netbox_custom_objects/tests/test_models.py
+++ b/netbox_custom_objects/tests/test_models.py
@@ -2164,7 +2164,7 @@ class LazySerializerRegistrationTestCase(CustomObjectsTestCase, TestCase):
         parent_model = self.parent_cot.get_model()
         child_model = self.child_cot.get_model()
         parent_serializer_name = f"{parent_model._meta.object_name}Serializer"
-        child_serializer_name = f"{child_model._meta.object_name}Serializer"
+        # child_serializer_name = f"{child_model._meta.object_name}Serializer"
 
         # Register parent's full serializer first
         full_parent_serializer = get_serializer_class(parent_model)

--- a/netbox_custom_objects/tests/test_models.py
+++ b/netbox_custom_objects/tests/test_models.py
@@ -2164,7 +2164,6 @@ class LazySerializerRegistrationTestCase(CustomObjectsTestCase, TestCase):
         parent_model = self.parent_cot.get_model()
         child_model = self.child_cot.get_model()
         parent_serializer_name = f"{parent_model._meta.object_name}Serializer"
-        # child_serializer_name = f"{child_model._meta.object_name}Serializer"
 
         # Register parent's full serializer first
         full_parent_serializer = get_serializer_class(parent_model)


### PR DESCRIPTION
## Summary

Two interlocking bugs caused `SerializerNotFound` in workers that started before a COT was created (or whose `ready()` ran against an empty DB / hit a transient connection error):

**Bug 1 — partial serializer clobbered the full one**

`get_serializer_class(model, skip_object_fields=True)` unconditionally called `setattr()` on the module, silently replacing the registered full serializer with a partial one that drops FK fields. This partial variant is built recursively when constructing nested field descriptors for FK-to-COT fields; it was never intended to be the module-level export. Fix: only call `setattr()` when `skip_object_fields=False`.

**Bug 2 — no fallback when serializer was never registered**

`import_string("netbox_custom_objects.api.serializers.Table{N}ModelSerializer")` raised `SerializerNotFound` in any worker whose `ready()` completed without finding that COT (Scenario A/B from the issue). `AppConfig.get_model()` generated the model on demand but never registered its serializer. Adding `get_serializer_class()` to `get_model()`'s fallback path (Options 1 & 2 reported in the issue) caused a `ValueError: Cannot assign` because the partial-variant registration bug (Bug 1) would overwrite the full serializer mid-request. Fix: add a module-level `__getattr__` (PEP 562) that generates and caches the serializer the first time `import_string()` asks for it. Now that Bug 1 is fixed, the `__getattr__` path can call `get_serializer_class(model)` safely without risk of clobbering related models' serializers.

## Changes

- `netbox_custom_objects/api/serializers.py`: guard the `setattr()` with `if not skip_object_fields`; add module-level `__getattr__`
- `netbox_custom_objects/tests/test_models.py`: `LazySerializerRegistrationTestCase` — 3 regression tests

## Test plan

- [ ] `LazySerializerRegistrationTestCase.test_module_getattr_generates_serializer_on_demand` — `__getattr__` generates and caches serializer for a COT whose serializer was never pre-registered
- [ ] `LazySerializerRegistrationTestCase.test_skip_object_fields_does_not_overwrite_full_serializer` — calling `get_serializer_class(model, skip_object_fields=True)` does not replace the registered full serializer
- [ ] `LazySerializerRegistrationTestCase.test_child_serializer_does_not_clobber_parent_serializer` — building child's serializer (which creates a nested partial for parent) leaves parent's full serializer intact
- [ ] Existing `StaleFKReferenceRegressionTest`, `NestedCOTStartupOrderingTestCase`, `NullRelatedObjectTypeTestCase` all still pass

Closes: #370