### PR TITLE
Fixes #543: Render tag filter links in custom object list view

### DIFF
--- a/netbox_custom_objects/tables.py
+++ b/netbox_custom_objects/tables.py
@@ -50,6 +50,25 @@ OBJECTCHANGE_REQUEST_ID = """
 <a href="?request_id={{ value }}">{{ value }}</a>
 """
 
+# The {% url %} tag must stay on a single line: Django's template lexer does not parse a {% %}
+# tag whose delimiters span a newline. {% with %} shortens the slug accessor to keep it under 120.
+CUSTOM_OBJECT_TAGS = """
+{% load helpers %}
+{% with slug=record.custom_object_type.slug %}
+{% for tag in value.all %}
+    <a href="{% url 'plugins:netbox_custom_objects:customobject_list' custom_object_type=slug %}?tag={{ tag.slug }}">
+        <span {% if tag.description %}title="{{ tag.description }}"{% endif %}
+              class="badge"
+              style="color: {{ tag.color|fgcolor }}; background-color: #{{ tag.color }}">
+            {{ tag }}
+        </span>
+    </a>
+{% empty %}
+    <span class="text-muted">&mdash;</span>
+{% endfor %}
+{% endwith %}
+"""
+
 
 class CustomObjectTypeTable(NetBoxTable):
     comments = columns.MarkdownColumn(
@@ -91,21 +110,7 @@ class CustomObjectTagColumn(columns.TagColumn):
     """
     Custom TagColumn that generates tag filter URLs with the custom_object_type slug.
     """
-    template_code = """
-    {% load helpers %}
-    {% for tag in value.all %}
-        <a href="{% url 'plugins:netbox_custom_objects:customobject_list'
-                  custom_object_type=record.custom_object_type.slug %}?tag={{ tag.slug }}">
-            <span {% if tag.description %}title="{{ tag.description }}"{% endif %}
-                  class="badge"
-                  style="color: {{ tag.color|fgcolor }}; background-color: #{{ tag.color }}">
-                {{ tag }}
-            </span>
-        </a>
-    {% empty %}
-        <span class="text-muted">&mdash;</span>
-    {% endfor %}
-    """
+    template_code = CUSTOM_OBJECT_TAGS
 
     def __init__(self):
         # Override parent __init__ to use our custom template


### PR DESCRIPTION
### Fixes: #543

Tags in the custom object list view link to the filtered list (`?tag=<slug>`), but clicking one returned a 404.

The link's `{% url %}` template tag was split across two lines in `CustomObjectTagColumn`. Django's template lexer doesn't parse a `{% %}` tag whose delimiters span a newline, so the whole block was emitted verbatim into the `href` instead of being resolved. The browser then requested a path beginning with a literal `{% url ... %}`, which matched no route.

Keeping the `{% url %}` tag on a single line fixes the rendered link. The template is moved into a module-level `CUSTOM_OBJECT_TAGS` constant (matching the existing constants in this file and the convention in core NetBox tables), and the loop is wrapped in `{% with slug=... %}` so the shortened accessor keeps the line under the 120-char limit.

Verified through the list view: the rendered page now contains real `?tag=<slug>` hrefs with no leaked template tags, and following a tag link returns 200.
