### PR TITLE
Fixes #535: Deregister through model from app registry on multiobject field delete

### DIFF
--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -2391,12 +2391,17 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
     def delete(self, *args, **kwargs):
         field_type = FIELD_TYPE_CLASS[self.type]()
         model = self.custom_object_type.get_model()
+        _dropped_through_model = None
 
         with connection.schema_editor() as schema_editor:
             if self.is_polymorphic:
                 if self.type == CustomFieldTypeChoices.TYPE_OBJECT:
                     field_type.remove_polymorphic_object_columns(self, model, schema_editor)
                 elif self.type == CustomFieldTypeChoices.TYPE_MULTIOBJECT:
+                    try:
+                        _dropped_through_model = model._meta.apps.get_model(APP_LABEL, self.through_model_name)
+                    except LookupError:
+                        pass
                     field_type.drop_polymorphic_m2m_table(self, model, schema_editor)
             else:
                 model_field = field_type.get_model_field(self)
@@ -2404,9 +2409,20 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
 
                 if self.type == CustomFieldTypeChoices.TYPE_MULTIOBJECT:
                     _apps = model._meta.apps
-                    through_model = _apps.get_model(APP_LABEL, self.through_model_name)
-                    schema_editor.delete_model(through_model)
+                    _dropped_through_model = _apps.get_model(APP_LABEL, self.through_model_name)
+                    schema_editor.delete_model(_dropped_through_model)
                 schema_editor.remove_field(model, model_field)
+
+        # The through table is now dropped, but its model class is still registered
+        # in Django's app registry. Without removing it, the cascade-delete collector
+        # finds the model, queries the missing table, and raises ProgrammingError.
+        # This mirrors the deregistration that CustomObjectType.delete() already
+        # performs for full COT teardown.
+        if _dropped_through_model is not None:
+            through_name = _dropped_through_model.__name__.lower()
+            if through_name in apps.all_models.get(APP_LABEL, {}):
+                del apps.all_models[APP_LABEL][through_name]
+            apps.clear_cache()
 
         # Clear the model cache for this CustomObjectType when a field is deleted
         self.custom_object_type.clear_model_cache(self.custom_object_type.id)

--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -2413,15 +2413,12 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
                     schema_editor.delete_model(_dropped_through_model)
                 schema_editor.remove_field(model, model_field)
 
-        # The through table is now dropped, but its model class is still registered
-        # in Django's app registry. Without removing it, the cascade-delete collector
-        # finds the model, queries the missing table, and raises ProgrammingError.
-        # This mirrors the deregistration that CustomObjectType.delete() already
-        # performs for full COT teardown.
+        # Deregister the dropped through model so the cascade-delete collector no longer queries the missing table.
         if _dropped_through_model is not None:
             through_name = _dropped_through_model.__name__.lower()
-            if through_name in apps.all_models.get(APP_LABEL, {}):
-                del apps.all_models[APP_LABEL][through_name]
+            with CustomObjectType._global_lock:
+                if through_name in apps.all_models.get(APP_LABEL, {}):
+                    del apps.all_models[APP_LABEL][through_name]
             apps.clear_cache()
 
         # Clear the model cache for this CustomObjectType when a field is deleted

--- a/netbox_custom_objects/tests/test_models.py
+++ b/netbox_custom_objects/tests/test_models.py
@@ -11,7 +11,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db import connection, transaction
 from django.db.utils import OperationalError, ProgrammingError
-from django.test import TestCase, override_settings
+from django.test import TestCase, override_settings, tag
 from django.urls import reverse
 from django.utils import timezone
 
@@ -1176,6 +1176,7 @@ class RelatedNameTestCase(CustomObjectsTestCase, TestCase):
             "MultiObject field without related_name should not create an auto-generated reverse accessor.",
         )
 
+    @tag('regression')  # #535
     def test_deleting_multiobject_field_deregisters_through_model(self):
         """
         After a multiobject field is deleted its through model must be removed

--- a/netbox_custom_objects/tests/test_models.py
+++ b/netbox_custom_objects/tests/test_models.py
@@ -1198,12 +1198,17 @@ class RelatedNameTestCase(CustomObjectsTestCase, TestCase):
 
         field.delete()
 
-        self.assertNotIn(through_model_name, django_apps.all_models.get(APP_LABEL, {}))
-
+        # Primary assertion: deleting a relation target must not raise ProgrammingError.
+        # Without the fix this line raises:
+        #   ProgrammingError: relation "custom_objects_<id>_related_slbs" does not exist
+        # because the stale through model is still in apps.all_models and the
+        # cascade-delete collector queries the already-dropped table.
         try:
             slb_instance.delete()
         except ProgrammingError as exc:
             self.fail(f"Deleting a related object raised ProgrammingError after field deletion: {exc}")
+
+        self.assertNotIn(through_model_name, django_apps.all_models.get(APP_LABEL, {}))
 
 
 class SearchReindexTestCase(CustomObjectsTestCase, TestCase):

--- a/netbox_custom_objects/tests/test_models.py
+++ b/netbox_custom_objects/tests/test_models.py
@@ -1176,6 +1176,35 @@ class RelatedNameTestCase(CustomObjectsTestCase, TestCase):
             "MultiObject field without related_name should not create an auto-generated reverse accessor.",
         )
 
+    def test_deleting_multiobject_field_deregisters_through_model(self):
+        """
+        After a multiobject field is deleted its through model must be removed
+        from Django's app registry. Without the fix the cascade-delete collector
+        still finds the model, queries the dropped table, and raises
+        ProgrammingError when deleting any object that was a relation target
+        of the field (issue #535).
+        """
+        field = self.create_custom_object_type_field(
+            self.cert_cot,
+            name="related_slbs",
+            type="multiobject",
+            related_object_type=self.slb_object_type,
+        )
+        through_model_name = field.through_model_name.lower()
+        self.assertIn(through_model_name, django_apps.all_models.get(APP_LABEL, {}))
+
+        slb_model = self.slb_cot.get_model()
+        slb_instance = slb_model.objects.create(name="SLB-To-Delete")
+
+        field.delete()
+
+        self.assertNotIn(through_model_name, django_apps.all_models.get(APP_LABEL, {}))
+
+        try:
+            slb_instance.delete()
+        except ProgrammingError as exc:
+            self.fail(f"Deleting a related object raised ProgrammingError after field deletion: {exc}")
+
 
 class SearchReindexTestCase(CustomObjectsTestCase, TestCase):
     """Test that ReindexCustomObjectTypeJob is triggered when field search weights change."""


### PR DESCRIPTION
### Fixes: #535

## Summary

When a `multiobject` field is deleted, `CustomObjectTypeField.delete()` was correctly dropping the through table via `schema_editor.delete_model()`, but the through model class remained registered in Django's `apps.all_models`. Django's cascade-delete collector walks `apps.all_models` when computing what to clean up before deleting an object. Because it still found the through model (with its FK to the relation target), it generated a query against the already-dropped table, producing:

```
django.db.utils.ProgrammingError: relation "custom_objects_2_ssl_service2" does not exist
```

**Fix:** After dropping the through table — in both the non-polymorphic and polymorphic code paths — remove the through model from `apps.all_models` and call `apps.clear_cache()` to flush Django's internal relation caches. This mirrors the deregistration already performed in `CustomObjectType.delete()` for full COT teardown.

## Test plan

- [x] New regression test `RelatedNameTestCase.test_deleting_multiobject_field_deregisters_through_model`: creates a multiobject field, deletes it, then deletes a related object and asserts no `ProgrammingError` is raised. A secondary assertion confirms the through model is no longer in `apps.all_models`.
- [x] Full `test_models` suite (98 tests + 1 skip) passes.

**Verified pre-fix failure:** The regression test was confirmed to catch the bug by temporarily disabling the deregistration block and running the test against the pre-fix code path. Without the fix, `slb_instance.delete()` raises the exact error from the issue report:

```
ProgrammingError: relation "custom_objects_285_related_slbs" does not exist
LINE 1: ...custom_objects_285_related_slbs"."target_id" FROM "custom_ob...
```

The test is ordered so this `ProgrammingError` is the first and most visible failure — a later reviewer or CI run sees the user-facing error directly, not an opaque registry state assertion.