### PR TITLE
Replace __getattr__ serializer fallback with serializer_resolver PluginConfig hook

### DIFF
--- a/netbox_custom_objects/__init__.py
+++ b/netbox_custom_objects/__init__.py
@@ -133,6 +133,7 @@ class CustomObjectsPluginConfig(PluginConfig):
     }
     required_settings = []
     template_extensions = "template_content.template_extensions"
+    serializer_resolver = "api.serializers.serializer_resolver"
 
     @staticmethod
     def should_skip_dynamic_model_creation():

--- a/netbox_custom_objects/api/serializers.py
+++ b/netbox_custom_objects/api/serializers.py
@@ -694,7 +694,8 @@ def get_serializer_class(model, skip_object_fields=False):
     )
 
     # Register the FULL serializer as a module attribute so NetBox's import_string()
-    # and the module-level __getattr__ fallback can find it.
+    # can find it (the serializer_resolver below generates on demand; this keeps
+    # any direct import-path lookups working too).
     # The partial variant (skip_object_fields=True) is used only as a nested field
     # descriptor inside another serializer class and must NOT be stored on the module
     # — doing so would silently replace the full serializer with an incomplete one
@@ -707,35 +708,26 @@ def get_serializer_class(model, skip_object_fields=False):
     return serializer
 
 
-def __getattr__(name):
-    """
-    Module-level lazy resolution for Table{N}ModelSerializer attributes (PEP 562).
+_TABLE_MODEL_PATTERN = re.compile(r'^table\d+model$', re.IGNORECASE)
 
-    NetBox's get_serializer_for_model() resolves serializers via
-    import_string("netbox_custom_objects.api.serializers.TableNModelSerializer"),
-    which ultimately calls getattr(module, name).  That lookup hits this hook
-    when the attribute has not yet been registered — for example in a worker
-    whose ready() ran against an empty database, or in any worker that started
-    before a given COT was created.
 
-    Generating on demand here means SerializerNotFound is never raised just
-    because startup-time registration was skipped or missed (issue #370).
-    The generated serializer is stored via setattr inside get_serializer_class(),
-    so subsequent lookups return it directly from __dict__ without re-entering
-    this hook.
+def serializer_resolver(model, prefix=''):
+    """Resolve dynamic CO models (``table{n}model``) to on-the-fly serializers.
+
+    Called by ``utilities.api.get_serializer_for_model`` before its default
+    import-path lookup.  Returns ``None`` for non-CO models so the default
+    lookup runs (including this plugin's static CustomObjectType serializer).
+
+    This supersedes the import-path/``__getattr__`` fallback approach: because
+    the resolver runs before any import path is built for a CO model, the
+    serializer is always generated on demand and ``SerializerNotFound`` is never
+    raised just because startup-time registration was skipped or missed
+    (issue #370).
     """
-    match = re.match(r'^Table(\d+)ModelSerializer$', name)
-    if match:
-        cot_id = int(match.group(1))
-        try:
-            obj = CustomObjectType.objects.get(pk=cot_id)
-            model = obj.get_model()
-            return get_serializer_class(model)
-        except (CustomObjectType.DoesNotExist, ProgrammingError, OperationalError, LookupError):
-            pass
-        except Exception:
-            logger.warning(
-                "Unexpected error generating serializer for %r; serializer will not be available",
-                name, exc_info=True,
-            )
-    raise AttributeError(f"module '{__name__}' has no attribute {name!r}")
+    if (
+        getattr(model, '_meta', None)
+        and model._meta.app_label == 'netbox_custom_objects'
+        and _TABLE_MODEL_PATTERN.match(model.__name__)
+    ):
+        return get_serializer_class(model)
+    return None

--- a/netbox_custom_objects/tests/test_models.py
+++ b/netbox_custom_objects/tests/test_models.py
@@ -2108,10 +2108,11 @@ class LazySerializerRegistrationTestCase(CustomObjectsTestCase, TestCase):
     1. get_serializer_class(model, skip_object_fields=True) used to overwrite the
        full module-level serializer with a partial one, causing subsequent requests
        to fail or return incomplete data.
-    2. import_string("netbox_custom_objects.api.serializers.Table{N}ModelSerializer")
-       raised SerializerNotFound in workers whose ready() ran before the COT existed.
-       The module-level __getattr__ hook (PEP 562) fixes this by generating the
-       serializer on demand.
+    2. get_serializer_for_model() raised SerializerNotFound for a Table{N}Model in
+       workers whose ready() ran before the COT existed.
+       The serializer_resolver() hook (registered via PluginConfig.serializer_resolver)
+       fixes this by generating the serializer on demand, ahead of any import-path
+       lookup.
     """
 
     @classmethod
@@ -2138,8 +2139,8 @@ class LazySerializerRegistrationTestCase(CustomObjectsTestCase, TestCase):
 
     def _clear_serializer_registrations(self):
         """Remove any previously registered serializers for parent and child COTs
-        from the module so that __getattr__ and get_serializer_class() behave as
-        they would in a fresh worker process."""
+        from the module so that serializer_resolver() and get_serializer_class()
+        behave as they would in a fresh worker process."""
         import netbox_custom_objects.api.serializers as ser_module
         parent_model = self.parent_cot.get_model()
         child_model = self.child_cot.get_model()
@@ -2147,10 +2148,14 @@ class LazySerializerRegistrationTestCase(CustomObjectsTestCase, TestCase):
             attr = f"{model._meta.object_name}Serializer"
             ser_module.__dict__.pop(attr, None)
 
-    def test_module_getattr_generates_serializer_on_demand(self):
-        """__getattr__ must generate and return a serializer for any Table{N}Model
-        whose serializer was never pre-registered (simulates a worker that started
-        before the COT was created — issue #370 Scenario A)."""
+    def test_resolver_generates_serializer_on_demand(self):
+        """serializer_resolver() must generate and return a serializer for any
+        Table{N}Model whose serializer was never pre-registered (simulates a worker
+        that started before the COT was created — issue #370 Scenario A).
+
+        NetBox calls this resolver from get_serializer_for_model() before falling
+        back to an import-path lookup, so a missing startup-time registration can
+        never raise SerializerNotFound."""
         import netbox_custom_objects.api.serializers as ser_module
         self._clear_serializer_registrations()
 
@@ -2161,14 +2166,15 @@ class LazySerializerRegistrationTestCase(CustomObjectsTestCase, TestCase):
         self.assertNotIn(serializer_name, ser_module.__dict__,
                          "precondition: serializer must not be pre-registered")
 
-        # getattr() must trigger __getattr__ and return a valid class
-        serializer_cls = getattr(ser_module, serializer_name)
+        # The resolver must generate and return a valid serializer class on demand
+        serializer_cls = ser_module.serializer_resolver(parent_model)
         self.assertIsNotNone(serializer_cls)
         self.assertIn("title", serializer_cls.Meta.fields)
 
-        # After __getattr__ fires, the serializer is cached in __dict__
+        # After the resolver fires, the full serializer is cached in __dict__
+        # (get_serializer_class registers it via setattr)
         self.assertIn(serializer_name, ser_module.__dict__,
-                      "serializer must be cached in module __dict__ after first access")
+                      "serializer must be cached in module __dict__ after first resolution")
 
     def test_skip_object_fields_does_not_overwrite_full_serializer(self):
         """get_serializer_class(model, skip_object_fields=True) must not overwrite


### PR DESCRIPTION
## Summary

- Replaces the module-level `__getattr__` (PEP 562) added in PR #542 with `PluginConfig.serializer_resolver` — the purpose-built NetBox extension point for dynamically-generated model serializers
- Adds `serializer_resolver = "api.serializers.serializer_resolver"` to `CustomObjectsPluginConfig`
- Adds `serializer_resolver(model, prefix='')` in `api/serializers.py`; removes `__getattr__`
- Updates `LazySerializerRegistrationTestCase` to exercise `serializer_resolver()` directly

The `skip_object_fields` guard on `setattr()` (the other fix from PR #542) is unchanged.

## Why

`__getattr__` fires only after normal attribute lookup fails — it is a Python module fallback that NetBox has no visibility into. `serializer_resolver` is called by `get_serializer_for_model()` *before* any import-path lookup is attempted, making it strictly more reliable: a CO serializer is always generated on demand and `SerializerNotFound` can never be raised due to a missed startup-time registration.

Using the official hook also makes the integration explicit and discoverable rather than relying on an opaque Python protocol.

## Pre-empts a merge conflict

The `feature` branch (PR #476) already uses `serializer_resolver` and omits `__getattr__`. Aligning `main` now means the eventual `main`->`feature` merge produces no conflict in `api/serializers.py`.

## Test plan

- [ ] `LazySerializerRegistrationTestCase.test_resolver_generates_serializer_on_demand`
- [ ] `LazySerializerRegistrationTestCase.test_skip_object_fields_does_not_overwrite_full_serializer`
- [ ] `LazySerializerRegistrationTestCase.test_child_serializer_does_not_clobber_parent_serializer`
- [ ] Existing test suite passes

Closes: #546
Ref: #370