### PR TITLE
Fixes #550: Allow explicit null for optional object/multiobject fields in API

### DIFF
--- a/netbox_custom_objects/api/serializers.py
+++ b/netbox_custom_objects/api/serializers.py
@@ -566,7 +566,7 @@ def get_serializer_class(model, skip_object_fields=False):
         if many_to_many:
             for field_name, value in many_to_many.items():
                 field = getattr(instance, field_name)
-                field.set(value)
+                field.set(value if value is not None else [])
 
         for field_name, value in poly_gfk.items():
             setattr(instance, field_name, value)
@@ -609,7 +609,7 @@ def get_serializer_class(model, skip_object_fields=False):
 
         for attr, value in m2m_fields:
             field = getattr(instance, attr)
-            field.set(value, clear=True)
+            field.set(value if value is not None else [], clear=True)
 
         for field_name, value in poly_m2m.items():
             mgr = getattr(instance, field_name)

--- a/netbox_custom_objects/field_types.py
+++ b/netbox_custom_objects/field_types.py
@@ -804,7 +804,7 @@ class ObjectFieldType(FieldType):
             serializer = get_serializer_class(related_model_class, skip_object_fields=True)
         else:
             serializer = get_serializer_for_model(related_model_class)
-        return serializer(required=field.required, nested=True)
+        return serializer(required=field.required, allow_null=not field.required, nested=True)
 
     def after_model_generation(self, instance, model, field_name):
         """
@@ -1286,7 +1286,7 @@ class MultiObjectFieldType(FieldType):
             serializer = get_serializer_class(related_model_class, skip_object_fields=True)
         else:
             serializer = get_serializer_for_model(related_model_class)
-        return serializer(required=field.required, nested=True, many=True)
+        return serializer(required=field.required, allow_null=not field.required, nested=True, many=True)
 
     def get_filterform_field(self, field, **kwargs):
         if field.is_polymorphic:

--- a/netbox_custom_objects/field_types.py
+++ b/netbox_custom_objects/field_types.py
@@ -1286,7 +1286,21 @@ class MultiObjectFieldType(FieldType):
             serializer = get_serializer_class(related_model_class, skip_object_fields=True)
         else:
             serializer = get_serializer_for_model(related_model_class)
-        return serializer(required=field.required, allow_null=not field.required, nested=True, many=True)
+        # Construct the ListSerializer explicitly so that allow_null is set only on
+        # the outer list (permitting null to clear the whole field) and NOT on the
+        # child (preventing individual null items like [null, 3] from slipping
+        # through).  Using many=True would forward allow_null to the child via
+        # many_init(), widening null acceptance unintentionally.
+        from rest_framework import serializers as drf_serializers
+        child = serializer(required=False, nested=True)
+        meta = getattr(serializer, 'Meta', None)
+        list_serializer_class = getattr(meta, 'list_serializer_class', drf_serializers.ListSerializer)
+        return list_serializer_class(
+            child=child,
+            required=field.required,
+            allow_null=not field.required,
+            allow_empty=True,
+        )
 
     def get_filterform_field(self, field, **kwargs):
         if field.is_polymorphic:

--- a/netbox_custom_objects/tests/test_api.py
+++ b/netbox_custom_objects/tests/test_api.py
@@ -1615,3 +1615,128 @@ class CrossCOTMultiObjectAPITest(CustomObjectsTestCase, TestCase):
         self.assertIn('refs', response.data, 'Response must include the refs M2M field.')
         ref_ids = [r['id'] for r in response.data['refs']]
         self.assertIn(self.obj_target1.pk, ref_ids)
+
+
+# ---------------------------------------------------------------------------
+# Regression: explicit null on optional object/multiobject fields (#550)
+# ---------------------------------------------------------------------------
+
+
+class NullOptionalObjectFieldTest(CustomObjectsTestCase, TestCase):
+    """
+    POST/PATCH with explicit null on a non-required object or multiobject field
+    must succeed (201/200).  Before the fix, the serializer lacked allow_null=True
+    so null was rejected with 400 'This field may not be null.'
+    """
+
+    def setUp(self):
+        self.user = create_test_user('nullobjuser')
+        token_key = create_token(self.user)
+        self.header = {'HTTP_AUTHORIZATION': f'Token {token_key}'}
+        self.client = APIClient()
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {token_key}')
+
+        self.cot = CustomObjectsTestCase.create_custom_object_type(
+            name='NullObjTest', slug='null-obj-test'
+        )
+        CustomObjectsTestCase.create_custom_object_type_field(
+            self.cot, name='name', type='text', primary=True, required=True,
+        )
+        device_ct = CustomObjectsTestCase.get_device_object_type()
+        CustomObjectsTestCase.create_custom_object_type_field(
+            self.cot, name='device', type='object',
+            related_object_type=device_ct, required=False,
+        )
+        CustomObjectsTestCase.create_custom_object_type_field(
+            self.cot, name='devices', type='multiobject',
+            related_object_type=device_ct, required=False,
+        )
+        self.model = self.cot.get_model()
+
+        for action in ('add', 'change', 'view'):
+            perm = ObjectPermission(name=f'null-obj-{action}', actions=[action])
+            perm.save()
+            perm.users.add(self.user)
+            perm.object_types.add(ObjectType.objects.get_for_model(self.model))
+
+    def tearDown(self):
+        CustomObjectType.clear_model_cache()
+        super().tearDown()
+
+    def _list_url(self):
+        return reverse(
+            'plugins-api:netbox_custom_objects-api:customobject-list',
+            kwargs={'custom_object_type': self.cot.slug},
+        )
+
+    def _detail_url(self, pk):
+        return reverse(
+            'plugins-api:netbox_custom_objects-api:customobject-detail',
+            kwargs={'pk': pk, 'custom_object_type': self.cot.slug},
+        )
+
+    def test_post_null_object_field_accepted(self):
+        """POST with explicit null on an optional object field must return 201."""
+        response = self.client.post(
+            self._list_url(),
+            {'name': 'obj-null-post', 'device': None},
+            format='json',
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+        self.assertIsNone(response.data['device'])
+
+    def test_post_null_multiobject_field_accepted(self):
+        """POST with explicit null on an optional multiobject field must return 201."""
+        response = self.client.post(
+            self._list_url(),
+            {'name': 'multiobj-null-post', 'devices': None},
+            format='json',
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+
+    def test_patch_null_object_field_clears_value(self):
+        """PATCH with null on an optional object field must clear it and return 200."""
+        site = Site.objects.create(name='null-test-site', slug='null-test-site')
+        manufacturer = Manufacturer.objects.create(name='null-mfr', slug='null-mfr')
+        device_type = DeviceType.objects.create(
+            manufacturer=manufacturer, model='null-dt', slug='null-dt'
+        )
+        device_role = DeviceRole.objects.create(name='null-role', slug='null-role')
+        device = Device.objects.create(
+            name='null-dev', site=site, device_type=device_type, role=device_role
+        )
+        obj = self.model.objects.create(name='patch-null-obj', device=device)
+        self.assertIsNotNone(obj.device)
+
+        response = self.client.patch(
+            self._detail_url(obj.pk),
+            {'device': None},
+            format='json',
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        obj.refresh_from_db()
+        self.assertIsNone(obj.device)
+
+    def test_patch_null_multiobject_field_clears_value(self):
+        """PATCH with null on an optional multiobject field must clear it and return 200."""
+        site = Site.objects.create(name='null-multi-site', slug='null-multi-site')
+        manufacturer = Manufacturer.objects.create(name='null-multi-mfr', slug='null-multi-mfr')
+        device_type = DeviceType.objects.create(
+            manufacturer=manufacturer, model='null-multi-dt', slug='null-multi-dt'
+        )
+        device_role = DeviceRole.objects.create(name='null-multi-role', slug='null-multi-role')
+        device = Device.objects.create(
+            name='null-multi-dev', site=site, device_type=device_type, role=device_role
+        )
+        obj = self.model.objects.create(name='patch-null-multi-obj')
+        obj.devices.add(device)
+        self.assertEqual(obj.devices.count(), 1)
+
+        response = self.client.patch(
+            self._detail_url(obj.pk),
+            {'devices': None},
+            format='json',
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        obj.refresh_from_db()
+        self.assertEqual(obj.devices.count(), 0)

--- a/netbox_custom_objects/tests/test_api.py
+++ b/netbox_custom_objects/tests/test_api.py
@@ -1693,6 +1693,7 @@ class NullOptionalObjectFieldTest(CustomObjectsTestCase, TestCase):
             format='json',
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+        self.assertEqual(response.data['devices'], [])
 
     def test_patch_null_object_field_clears_value(self):
         """PATCH with null on an optional object field must clear it and return 200."""

--- a/netbox_custom_objects/tests/test_api.py
+++ b/netbox_custom_objects/tests/test_api.py
@@ -1,6 +1,8 @@
 """
 Tests for API code paths.
 """
+import uuid
+
 from django.test import TestCase, RequestFactory
 from django.urls import reverse
 
@@ -1653,8 +1655,9 @@ class NullOptionalObjectFieldTest(CustomObjectsTestCase, TestCase):
         )
         self.model = self.cot.get_model()
 
+        uid = uuid.uuid4().hex[:8]
         for action in ('add', 'change', 'view'):
-            perm = ObjectPermission(name=f'null-obj-{action}', actions=[action])
+            perm = ObjectPermission(name=f'null-obj-{action}-{uid}', actions=[action])
             perm.save()
             perm.users.add(self.user)
             perm.object_types.add(ObjectType.objects.get_for_model(self.model))
@@ -1741,3 +1744,35 @@ class NullOptionalObjectFieldTest(CustomObjectsTestCase, TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
         obj.refresh_from_db()
         self.assertEqual(obj.devices.count(), 0)
+
+    def test_post_null_required_object_field_rejected(self):
+        """POST with null on a required object field must still return 400."""
+        device_ct = CustomObjectsTestCase.get_device_object_type()
+        uid = uuid.uuid4().hex[:8]
+        cot = CustomObjectsTestCase.create_custom_object_type(
+            name=f'NullReqTest-{uid}', slug=f'null-req-test-{uid}'
+        )
+        CustomObjectsTestCase.create_custom_object_type_field(
+            cot, name='name', type='text', primary=True, required=True,
+        )
+        CustomObjectsTestCase.create_custom_object_type_field(
+            cot, name='req_device', type='object',
+            related_object_type=device_ct, required=True,
+        )
+        model = cot.get_model()
+        for action in ('add', 'view'):
+            perm = ObjectPermission(name=f'null-req-{action}-{uid}', actions=[action])
+            perm.save()
+            perm.users.add(self.user)
+            perm.object_types.add(ObjectType.objects.get_for_model(model))
+
+        list_url = reverse(
+            'plugins-api:netbox_custom_objects-api:customobject-list',
+            kwargs={'custom_object_type': cot.slug},
+        )
+        response = self.client.post(
+            list_url,
+            {'name': 'req-null-post', 'req_device': None},
+            format='json',
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.data)


### PR DESCRIPTION
### Fixes: #550

## Summary

- `ObjectFieldType.get_serializer_field()` and `MultiObjectFieldType.get_serializer_field()` now pass `allow_null=not field.required` to their DRF serializer constructors
- Without this, passing `null` for an optional object or multiobject field returned HTTP 400 even though the field is marked `required=False`
- Regression tests added in `NullOptionalObjectFieldTest` covering POST and PATCH with null for both field types

## Test plan

- [ ] `python manage.py test netbox_custom_objects.tests.test_api.NullOptionalObjectFieldTest`
- [ ] Verify POST with `{"name": "x", "device": null}` returns 201 for a COT with an optional device field
- [ ] Verify PATCH with `{"device": null}` returns 200 and clears the field

🤖 Generated with [Claude Code](https://claude.com/claude-code)