### PR TITLE
Fixes #529: Render selection field colors and labels correctly

### DIFF
--- a/netbox_custom_objects/field_types.py
+++ b/netbox_custom_objects/field_types.py
@@ -480,12 +480,19 @@ class SelectFieldType(FieldType):
 
     def get_table_column_field(self, field, **kwargs):
         choices_dict = dict(field.choices)
+        choice_set = field.choice_set
 
         class _SelectLabelColumn(tables.Column):
             def render(self, value):
                 if value is None:
                     return self.default
-                return choices_dict.get(value, value)
+                label = choices_dict.get(value, value)
+                color = choice_set.get_choice_color(value) if choice_set else None
+                if color:
+                    return mark_safe(
+                        f'<span class="badge text-bg-{escape(color)}">{escape(label)}</span>'
+                    )
+                return label
 
         return _SelectLabelColumn()
 
@@ -606,12 +613,25 @@ class MultiSelectFieldType(FieldType):
 
     def get_table_column_field(self, field, **kwargs):
         choices_dict = dict(field.choices)
+        choice_set = field.choice_set
 
         class _MultiSelectLabelColumn(tables.Column):
             def render(self, value):
                 if not value:
                     return self.default
-                return ', '.join(choices_dict.get(v, v) for v in value)
+                pairs = [
+                    (choices_dict.get(v, v), choice_set.get_choice_color(v) if choice_set else None)
+                    for v in value
+                ]
+                if any(color for _, color in pairs):
+                    badges = ''.join(
+                        f'<span class="badge text-bg-{escape(color)}">{escape(label)}</span>'
+                        if color else
+                        f'<span class="badge">{escape(label)}</span>'
+                        for label, color in pairs
+                    )
+                    return mark_safe(f'<div class="d-flex flex-wrap gap-1">{badges}</div>')
+                return ', '.join(label for label, _ in pairs)
 
         return _MultiSelectLabelColumn()
 

--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -1396,6 +1396,16 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
             return self.choice_set.choices
         return []
 
+    def get_choice_label(self, value):
+        if not hasattr(self, '_choice_map'):
+            self._choice_map = dict(self.choices)
+        return self._choice_map.get(value, value)
+
+    def get_choice_color(self, value):
+        if self.choice_set:
+            return self.choice_set.get_choice_color(value)
+        return None
+
     @property
     def related_object_type_label(self):
         if self.is_polymorphic:

--- a/netbox_custom_objects/templates/netbox_custom_objects/customobject.html
+++ b/netbox_custom_objects/templates/netbox_custom_objects/customobject.html
@@ -123,9 +123,7 @@
                       {% endif %}
                     </th>
                     <td>
-                      {% with customfield=field value=object|get_field_value:field %}
-                        {% include "builtins/customfield_value.html" %}
-                      {% endwith %}
+                      {% customfield_value field object|get_field_value:field %}
                     </td>
                   </tr>
                 {% endif %}

--- a/netbox_custom_objects/templatetags/custom_object_utils.py
+++ b/netbox_custom_objects/templatetags/custom_object_utils.py
@@ -28,13 +28,7 @@ def get_field_type_verbose_name(field: CustomObjectTypeField) -> str:
 
 @register.filter(name="get_field_value")
 def get_field_value(obj, field: CustomObjectTypeField):
-    value = getattr(obj, field.name)
-    if field.type == CustomFieldTypeChoices.TYPE_SELECT and value:
-        return getattr(obj, f'get_{field.name}_display')() or value
-    if field.type == CustomFieldTypeChoices.TYPE_MULTISELECT and value:
-        choices_dict = dict(obj._meta.get_field(field.name).base_field.choices)
-        return [choices_dict.get(v, v) for v in value]
-    return value
+    return getattr(obj, field.name)
 
 
 @register.filter(name="get_field_is_ui_visible")

--- a/netbox_custom_objects/tests/test_field_types.py
+++ b/netbox_custom_objects/tests/test_field_types.py
@@ -598,7 +598,7 @@ class SelectFieldTypeTestCase(FieldTypeTestCase):
         field.choice_set.get_choice_color.return_value = 'green'
         column = SelectFieldType().get_table_column_field(field)
         result = column.render(value='choice1')
-        self.assertIn('badge', result)
+        self.assertIn('class="badge', result)
         self.assertIn('text-bg-green', result)
         self.assertIn('Choice 1', result)
 
@@ -782,6 +782,23 @@ class MultiSelectFieldTypeTestCase(FieldTypeTestCase):
         self.assertIn('text-bg-red', result)
         self.assertIn('Choice 1', result)
         self.assertIn('Choice 3', result)
+
+    def test_multiselect_column_render_mixed_colors(self):
+        """Colorless values get a plain badge when at least one sibling has a color."""
+        field = Mock()
+        field.choices = [('choice1', 'Choice 1'), ('choice2', 'Choice 2')]
+        field.choice_set = Mock()
+        # choice1 has a color; choice2 does not
+        field.choice_set.get_choice_color.side_effect = lambda v: 'blue' if v == 'choice1' else None
+        column = MultiSelectFieldType().get_table_column_field(field)
+        result = column.render(value=['choice1', 'choice2'])
+        self.assertIn('text-bg-blue', result)
+        self.assertIn('Choice 1', result)
+        # choice2 should still be a badge (no color class), not plain text
+        self.assertIn('class="badge"', result)
+        self.assertIn('Choice 2', result)
+        # result is HTML, not a comma-joined string
+        self.assertNotIn('Choice 1, Choice 2', result)
 
     def test_get_field_value_returns_raw_list_for_multiselect(self):
         """get_field_value template filter returns the raw stored list for multiselect fields."""

--- a/netbox_custom_objects/tests/test_field_types.py
+++ b/netbox_custom_objects/tests/test_field_types.py
@@ -577,6 +577,7 @@ class SelectFieldTypeTestCase(FieldTypeTestCase):
         """get_table_column_field() render() translates a raw key to its human-readable label."""
         field = Mock()
         field.choices = [('choice1', 'Choice 1'), ('choice2', 'Choice 2')]
+        field.choice_set = None
         column = SelectFieldType().get_table_column_field(field)
         self.assertEqual(column.render(value='choice1'), 'Choice 1')
         self.assertEqual(column.render(value='choice2'), 'Choice 2')
@@ -585,11 +586,24 @@ class SelectFieldTypeTestCase(FieldTypeTestCase):
         """get_table_column_field() render() returns the raw key when it is not in choices."""
         field = Mock()
         field.choices = [('choice1', 'Choice 1')]
+        field.choice_set = None
         column = SelectFieldType().get_table_column_field(field)
         self.assertEqual(column.render(value='unknown'), 'unknown')
 
-    def test_get_field_value_returns_label_for_select(self):
-        """get_field_value template filter returns the human-readable label for select fields."""
+    def test_select_column_render_returns_badge_when_color_present(self):
+        """get_table_column_field() render() returns an HTML badge when the choice has a color."""
+        field = Mock()
+        field.choices = [('choice1', 'Choice 1')]
+        field.choice_set = Mock()
+        field.choice_set.get_choice_color.return_value = 'green'
+        column = SelectFieldType().get_table_column_field(field)
+        result = column.render(value='choice1')
+        self.assertIn('badge', result)
+        self.assertIn('text-bg-green', result)
+        self.assertIn('Choice 1', result)
+
+    def test_get_field_value_returns_raw_value_for_select(self):
+        """get_field_value template filter returns the raw stored value for select fields."""
         from netbox_custom_objects.templatetags.custom_object_utils import get_field_value
         cotf = self.create_custom_object_type_field(
             self.custom_object_type,
@@ -600,7 +614,7 @@ class SelectFieldTypeTestCase(FieldTypeTestCase):
         )
         model = self.custom_object_type.get_model(no_cache=True)
         instance = model.objects.create(name="Test", status="choice1")
-        self.assertEqual(get_field_value(instance, cotf), "Choice 1")
+        self.assertEqual(get_field_value(instance, cotf), "choice1")
 
     def test_get_field_value_returns_raw_value_when_select_is_none(self):
         """get_field_value returns None (falsy) when the select field is unset."""
@@ -615,6 +629,57 @@ class SelectFieldTypeTestCase(FieldTypeTestCase):
         model = self.custom_object_type.get_model(no_cache=True)
         instance = model.objects.create(name="Test")
         self.assertIsNone(get_field_value(instance, cotf))
+
+    def test_get_choice_label_returns_label_for_known_value(self):
+        """get_choice_label() returns the human-readable label for a stored choice value."""
+        cotf = self.create_custom_object_type_field(
+            self.custom_object_type,
+            name="status",
+            label="Status",
+            type="select",
+            choice_set=self.choice_set,
+        )
+        self.assertEqual(cotf.get_choice_label("choice1"), "Choice 1")
+
+    def test_get_choice_label_falls_back_to_value_when_unknown(self):
+        """get_choice_label() returns the raw value when it is not in the choice set."""
+        cotf = self.create_custom_object_type_field(
+            self.custom_object_type,
+            name="status",
+            label="Status",
+            type="select",
+            choice_set=self.choice_set,
+        )
+        self.assertEqual(cotf.get_choice_label("unknown"), "unknown")
+
+    def test_get_choice_color_returns_color_when_set(self):
+        """get_choice_color() returns the color configured for a choice value."""
+        from extras.models import CustomFieldChoiceSet
+        choice_set = CustomFieldChoiceSet.objects.create(
+            name="Colored Choices",
+            extra_choices=[["active", "Active"], ["inactive", "Inactive"]],
+            choice_colors={"active": "green", "inactive": "red"},
+        )
+        cotf = self.create_custom_object_type_field(
+            self.custom_object_type,
+            name="state",
+            label="State",
+            type="select",
+            choice_set=choice_set,
+        )
+        self.assertEqual(cotf.get_choice_color("active"), "green")
+        self.assertEqual(cotf.get_choice_color("inactive"), "red")
+
+    def test_get_choice_color_returns_none_when_no_color(self):
+        """get_choice_color() returns None for a value with no configured color."""
+        cotf = self.create_custom_object_type_field(
+            self.custom_object_type,
+            name="status",
+            label="Status",
+            type="select",
+            choice_set=self.choice_set,
+        )
+        self.assertIsNone(cotf.get_choice_color("choice1"))
 
 
 class MultiSelectFieldTypeTestCase(FieldTypeTestCase):
@@ -693,6 +758,7 @@ class MultiSelectFieldTypeTestCase(FieldTypeTestCase):
         """get_table_column_field() render() translates raw keys to comma-joined labels."""
         field = Mock()
         field.choices = [('choice1', 'Choice 1'), ('choice2', 'Choice 2'), ('choice3', 'Choice 3')]
+        field.choice_set = None
         column = MultiSelectFieldType().get_table_column_field(field)
         self.assertEqual(column.render(value=['choice1', 'choice3']), 'Choice 1, Choice 3')
 
@@ -700,11 +766,25 @@ class MultiSelectFieldTypeTestCase(FieldTypeTestCase):
         """get_table_column_field() render() preserves unknown keys in the joined output."""
         field = Mock()
         field.choices = [('choice1', 'Choice 1')]
+        field.choice_set = None
         column = MultiSelectFieldType().get_table_column_field(field)
         self.assertEqual(column.render(value=['choice1', 'unknown']), 'Choice 1, unknown')
 
-    def test_get_field_value_returns_label_list_for_multiselect(self):
-        """get_field_value template filter returns a list of labels for multiselect fields."""
+    def test_multiselect_column_render_returns_badges_when_colors_present(self):
+        """get_table_column_field() render() returns HTML badges when choices have colors."""
+        field = Mock()
+        field.choices = [('choice1', 'Choice 1'), ('choice3', 'Choice 3')]
+        field.choice_set = Mock()
+        field.choice_set.get_choice_color.side_effect = lambda v: 'green' if v == 'choice1' else 'red'
+        column = MultiSelectFieldType().get_table_column_field(field)
+        result = column.render(value=['choice1', 'choice3'])
+        self.assertIn('text-bg-green', result)
+        self.assertIn('text-bg-red', result)
+        self.assertIn('Choice 1', result)
+        self.assertIn('Choice 3', result)
+
+    def test_get_field_value_returns_raw_list_for_multiselect(self):
+        """get_field_value template filter returns the raw stored list for multiselect fields."""
         from netbox_custom_objects.templatetags.custom_object_utils import get_field_value
         cotf = self.create_custom_object_type_field(
             self.custom_object_type,
@@ -715,7 +795,7 @@ class MultiSelectFieldTypeTestCase(FieldTypeTestCase):
         )
         model = self.custom_object_type.get_model(no_cache=True)
         instance = model.objects.create(name="Test", tags=["choice1", "choice3"])
-        self.assertEqual(get_field_value(instance, cotf), ["Choice 1", "Choice 3"])
+        self.assertEqual(get_field_value(instance, cotf), ["choice1", "choice3"])
 
     def test_get_field_value_returns_empty_list_when_multiselect_is_none(self):
         """get_field_value returns None (falsy) when the multiselect field is unset."""

--- a/netbox_custom_objects/tests/test_views.py
+++ b/netbox_custom_objects/tests/test_views.py
@@ -658,6 +658,87 @@ class ComplexCustomObjectViewTestCase(CustomObjectsTestCase, ViewTestCases.Prima
         ...
 
 
+class SelectFieldColorDetailViewTestCase(CustomObjectsTestCase, TestCase):
+    """Regression tests for #529: selection field colors render correctly in the detail view."""
+
+    def setUp(self):
+        super().setUp()
+        self.colored_choice_set = CustomFieldChoiceSet.objects.create(
+            name='Colored Status Choices',
+            extra_choices=[['active', 'Active'], ['planned', 'Planned'], ['retired', 'Retired']],
+            choice_colors={'active': 'green', 'planned': 'blue', 'retired': 'red'},
+        )
+        self.cot = CustomObjectType.objects.create(
+            name='ColorTestObject',
+            verbose_name_plural='Color Test Objects',
+            slug='color-test-objects',
+        )
+        CustomObjectTypeField.objects.create(
+            custom_object_type=self.cot,
+            name='name', label='Name', type='text', primary=True, required=True,
+        )
+        CustomObjectTypeField.objects.create(
+            custom_object_type=self.cot,
+            name='status', label='Status', type='select',
+            choice_set=self.colored_choice_set,
+        )
+        CustomObjectTypeField.objects.create(
+            custom_object_type=self.cot,
+            name='phases', label='Phases', type='multiselect',
+            choice_set=self.colored_choice_set,
+        )
+        self.model = self.cot.get_model()
+        self.instance = self.model.objects.create(
+            name='Test Instance', status='active', phases=['planned', 'retired'],
+        )
+        content_type = ContentType.objects.get_for_model(self.model)
+        perm = ObjectPermission(name='color-test-view', actions=['view'])
+        perm.save()
+        perm.users.add(self.user)
+        perm.object_types.add(content_type)
+
+    def _detail_url(self, instance=None):
+        return reverse(
+            'plugins:netbox_custom_objects:customobject',
+            kwargs={'pk': (instance or self.instance).pk, 'custom_object_type': self.cot.slug},
+        )
+
+    def test_detail_view_renders_select_color_badge(self):
+        """Regression #529: select field with a color renders a colored badge in the detail view."""
+        response = self.client.get(self._detail_url())
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertIn('text-bg-green', content)
+        self.assertIn('Active', content)
+
+    def test_detail_view_renders_multiselect_color_badges(self):
+        """Regression #529: multiselect field with colors renders colored badges in the detail view."""
+        response = self.client.get(self._detail_url())
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertIn('text-bg-blue', content)
+        self.assertIn('text-bg-red', content)
+        self.assertIn('Planned', content)
+        self.assertIn('Retired', content)
+
+    def test_detail_view_renders_label_for_uncolored_select_field(self):
+        """A select field with no colors configured renders the human-readable label without error."""
+        uncolored_choice_set = CustomFieldChoiceSet.objects.create(
+            name='Uncolored Choices',
+            extra_choices=[['yes', 'Yes'], ['no', 'No']],
+        )
+        CustomObjectTypeField.objects.create(
+            custom_object_type=self.cot,
+            name='flag', label='Flag', type='select', choice_set=uncolored_choice_set,
+        )
+        model = self.cot.get_model(no_cache=True)
+        instance = model.objects.create(name='Uncolored Test', status='active', flag='yes')
+        response = self.client.get(self._detail_url(instance))
+        self.assertEqual(response.status_code, 200)
+        # The human-readable label "Yes" must appear, not the raw stored value "yes"
+        self.assertIn('Yes', response.content.decode())
+
+
 class ObjectFieldViewTestCase(CustomObjectsTestCase, ViewTestCases.PrimaryObjectViewTestCase):
     """Test cases for custom objects with object and multi-object fields."""
 


### PR DESCRIPTION
### Fixes: #529

## Summary

- Selection (`select`) and multi-selection (`multiselect`) fields backed by a `CustomFieldChoiceSet` with colors now render colored Bootstrap badges in both the list table and the object detail view.
- The detail view was broken because the template directly `{% include %}`d `builtins/customfield_value.html` without computing `color`, so the badge branch was never reached. It now uses `{% customfield_value field value %}` which resolves label and color correctly.
- The table columns previously returned a plain label string. They now emit `<span class="badge text-bg-{color}">` markup when a color is configured; fields without colors fall back to the previous plain text / comma-joined behaviour.

## Changes

- `models.py` — Added `get_choice_label()` and `get_choice_color()` to `CustomObjectTypeField`, delegating to `choice_set`, to match the `CustomField` API expected by the `customfield_value` inclusion tag.
- `field_types.py` — `SelectFieldType` and `MultiSelectFieldType` table columns capture `field.choice_set` and render colored badges when a color is present.
- `custom_object_utils.py` — `get_field_value` template filter simplified to return the raw stored value; label/color resolution is now handled downstream by `customfield_value`.
- `customobject.html` — Replaced `{% with %}{% include %}` pattern with `{% customfield_value field value %}`.
- `test_field_types.py` — Updated existing column/filter tests; added tests for badge rendering and the new `get_choice_label`/`get_choice_color` methods.

## Screenshots

**List view** — colored badges in the `VALUE` (select) and `VALUES` (multiselect) columns:

<img width="1174" height="491" alt="Screenshot 2026-06-03 at 3 01 37 PM" src="https://github.com/user-attachments/assets/21c148f6-a8e9-4239-a0ce-4a5b69531e4d" />

**Detail view** — colored badges on the object detail panel:

<img width="616" height="595" alt="Screenshot 2026-06-03 at 3 01 46 PM" src="https://github.com/user-attachments/assets/16c28b10-bcbc-461d-9c81-e0abc3ffa98a" />

## Test plan

- [ ] Create a `CustomFieldChoiceSet` with `choice_colors` configured
- [ ] Create a Custom Object Type with both a `select` and a `multiselect` field using that choice set
- [ ] Create instances with different values; verify colored badges appear in the list table
- [ ] Open an instance detail view; verify colored badges appear for both field types
- [ ] Verify fields with no colors configured still render as plain text / comma-joined labels
- [ ] `python manage.py test netbox_custom_objects.tests.test_field_types` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)