### PR TITLE
Fixes #371: Persist tags on custom object create and update

### DIFF
--- a/netbox_custom_objects/api/serializers.py
+++ b/netbox_custom_objects/api/serializers.py
@@ -543,6 +543,13 @@ def get_serializer_class(model, skip_object_fields=False):
     def create(self, validated_data):
         ModelClass = self.Meta.model
 
+        # taggit's TaggableManager is not detected by model_meta.get_field_info() as a
+        # standard M2M relation.  If left in validated_data it gets passed to
+        # Model._default_manager.create(), where Django's __init__ sets it as a plain
+        # instance attribute (shadowing the manager), giving the illusion of success but
+        # never persisting to the DB.  Pop it here and save via taggit's own API.
+        tags = validated_data.pop('tags', None)
+
         info = model_meta.get_field_info(ModelClass)
         many_to_many = {}
         for field_name, relation_info in info.relations.items():
@@ -563,6 +570,12 @@ def get_serializer_class(model, skip_object_fields=False):
 
         instance = ModelClass._default_manager.create(**validated_data)
 
+        if tags is not None:
+            instance._tags = tags
+            instance.tags.set([t.name for t in tags])
+        else:
+            instance._tags = []
+
         if many_to_many:
             for field_name, value in many_to_many.items():
                 field = getattr(instance, field_name)
@@ -581,6 +594,11 @@ def get_serializer_class(model, skip_object_fields=False):
 
     # Stock DRF update() with custom field.set() for M2M
     def update(self, instance, validated_data):
+        # Pop tags before the setattr loop — taggit's manager has no __set__, so
+        # leaving tags in validated_data would shadow the manager with a plain list.
+        tags = validated_data.pop('tags', None)
+        instance._tags = tags or []
+
         info = model_meta.get_field_info(instance)
 
         # Pop polymorphic GFK fields
@@ -606,6 +624,10 @@ def get_serializer_class(model, skip_object_fields=False):
             setattr(instance, field_name, value)
 
         instance.save()
+
+        if tags is not None:
+            instance._tags = tags
+            instance.tags.set([t.name for t in tags])
 
         for attr, value in m2m_fields:
             field = getattr(instance, attr)

--- a/netbox_custom_objects/tests/test_api.py
+++ b/netbox_custom_objects/tests/test_api.py
@@ -481,7 +481,11 @@ class CustomObjectTest(CustomObjectsTestCase, CustomObjectAPITestCaseMixin, Test
         self.assertHttpStatus(response, status.HTTP_200_OK)
 
         instance.refresh_from_db()
-        self.assertIn(tag.name, list(instance.tags.names()), 'Existing tags must be preserved when tags not in PATCH payload')
+        self.assertIn(
+            tag.name,
+            list(instance.tags.names()),
+            'Existing tags must be preserved when tags not in PATCH payload',
+        )
 
 
 class LinkedObjectsAPITest(CustomObjectsTestCase, TestCase):

--- a/netbox_custom_objects/tests/test_api.py
+++ b/netbox_custom_objects/tests/test_api.py
@@ -15,6 +15,7 @@ from netbox_custom_objects.template_content import CustomObjectLink, LinkedCusto
 from .base import CustomObjectsTestCase
 from core.models import ObjectType
 from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Rack, Site
+from extras.models import Tag
 from users.models import ObjectPermission, Token
 from virtualization.models import Cluster, ClusterType
 
@@ -413,6 +414,40 @@ class CustomObjectTest(CustomObjectsTestCase, CustomObjectAPITestCaseMixin, Test
             set(instance.devices.values_list('id', flat=True)),
             set(data['devices']),
         )
+
+    def test_create_with_tags_persists_to_db(self):
+        """Regression #371: tags submitted on POST must be saved to the DB, not just echoed."""
+        self._add_permission('add', 'Create with tags perm')
+        tag = Tag.objects.get_or_create(name='api-create-tag', slug='api-create-tag')[0]
+
+        data = {
+            'test_field': 'Tagged Object',
+            'tags': [{'id': tag.id, 'name': tag.name, 'slug': tag.slug, 'color': tag.color}],
+        }
+        response = self.client.post(self._get_list_url(), data, format='json', **self.header)
+        self.assertHttpStatus(response, status.HTTP_201_CREATED)
+        self.assertIn('tags', response.data)
+        self.assertTrue(len(response.data['tags']) > 0, 'Response should include the submitted tag')
+
+        # Fetch fresh from the DB — the critical assertion that caught #371
+        instance = self._get_queryset().get(pk=response.data['id'])
+        self.assertIn(tag.name, list(instance.tags.names()), 'Tag must be persisted to the DB')
+
+    def test_patch_with_tags_persists_to_db(self):
+        """Regression #371: tags submitted on PATCH must be saved to the DB, not just echoed."""
+        self._add_permission('view', 'View perm')
+        self._add_permission('change', 'Patch with tags perm')
+        tag = Tag.objects.get_or_create(name='api-patch-tag', slug='api-patch-tag')[0]
+
+        instance = self._get_queryset().first()
+        self.assertEqual(list(instance.tags.names()), [], 'Instance should start with no tags')
+
+        data = {'tags': [{'id': tag.id, 'name': tag.name, 'slug': tag.slug, 'color': tag.color}]}
+        response = self.client.patch(self._get_detail_url(instance), data, format='json', **self.header)
+        self.assertHttpStatus(response, status.HTTP_200_OK)
+
+        instance.refresh_from_db()
+        self.assertIn(tag.name, list(instance.tags.names()), 'Tag must be persisted to the DB after PATCH')
 
 
 class LinkedObjectsAPITest(CustomObjectsTestCase, TestCase):

--- a/netbox_custom_objects/tests/test_api.py
+++ b/netbox_custom_objects/tests/test_api.py
@@ -449,6 +449,40 @@ class CustomObjectTest(CustomObjectsTestCase, CustomObjectAPITestCaseMixin, Test
         instance.refresh_from_db()
         self.assertIn(tag.name, list(instance.tags.names()), 'Tag must be persisted to the DB after PATCH')
 
+    def test_patch_with_empty_tags_clears_existing(self):
+        """PATCH with tags=[] must remove all existing tags from the DB."""
+        self._add_permission('view', 'View perm')
+        self._add_permission('change', 'Patch clear tags perm')
+        tag = Tag.objects.get_or_create(name='api-clear-tag', slug='api-clear-tag')[0]
+
+        instance = self._get_queryset().first()
+        instance.tags.add(tag.name)
+        self.assertIn(tag.name, list(instance.tags.names()), 'Pre-condition: tag should be set')
+
+        response = self.client.patch(self._get_detail_url(instance), {'tags': []}, format='json', **self.header)
+        self.assertHttpStatus(response, status.HTTP_200_OK)
+
+        instance.refresh_from_db()
+        self.assertEqual(list(instance.tags.names()), [], 'All tags must be cleared after PATCH with tags=[]')
+
+    def test_patch_without_tags_preserves_existing(self):
+        """PATCH that omits the tags key entirely must leave existing tags unchanged."""
+        self._add_permission('view', 'View perm')
+        self._add_permission('change', 'Patch preserve tags perm')
+        tag = Tag.objects.get_or_create(name='api-preserve-tag', slug='api-preserve-tag')[0]
+
+        instance = self._get_queryset().first()
+        instance.tags.add(tag.name)
+        self.assertIn(tag.name, list(instance.tags.names()), 'Pre-condition: tag should be set')
+
+        response = self.client.patch(
+            self._get_detail_url(instance), {'test_field': 'updated'}, format='json', **self.header
+        )
+        self.assertHttpStatus(response, status.HTTP_200_OK)
+
+        instance.refresh_from_db()
+        self.assertIn(tag.name, list(instance.tags.names()), 'Existing tags must be preserved when tags not in PATCH payload')
+
 
 class LinkedObjectsAPITest(CustomObjectsTestCase, TestCase):
     """


### PR DESCRIPTION
### Fixes: #371

## Summary

Tags submitted via POST or PATCH to custom object endpoints were silently discarded. The response appeared to include the tags (giving the illusion of success), but a subsequent GET returned an empty `tags` list.

## Root Cause

`taggit`'s `TaggableManager` is not detected by DRF's `model_meta.get_field_info()` as a standard M2M relation. Without explicit handling, `tags` remained in `validated_data` and was passed directly to `Model._default_manager.create()`. Django's `Model.__init__` then called `setattr(obj, 'tags', [...])` which, since `TaggableManager` defines no `__set__`, shadowed the manager with a plain list on the instance dict. The serializer read this back for the response, making it look correct — but `TaggableManager`'s DB-backed storage was never touched.

The same issue applied to `update()`, where `tags` fell through to the `setattr` branch of the field-setting loop.

## Fix

Mirrors `TaggableModelSerializer._save_tags()`: explicitly pop `tags` from `validated_data` before model creation/update, then persist via `instance.tags.set([t.name for t in tags])` after the instance exists. `instance._tags` is also set for NetBox's change-logging machinery.

## Tests

Two regression tests added to `CustomObjectTest`:

- `test_create_with_tags_persists_to_db` — POSTs with tags, then asserts `instance.tags.names()` on a fresh DB fetch contains the submitted tag.
- `test_patch_with_tags_persists_to_db` — PATCHes with tags, then asserts the same after `refresh_from_db()`.

Both tests fail against the unfixed code and pass with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)