### PR TITLE
Fixes #406: Resolve correct to_field_name for CSV/YAML/JSON bulk import

### DIFF
--- a/netbox_custom_objects/field_types.py
+++ b/netbox_custom_objects/field_types.py
@@ -44,6 +44,30 @@ logger = logging.getLogger(__name__)
 # PostgreSQL's hard limit for identifier names is 63 bytes.
 _PG_MAX_IDENTIFIER_LEN = 63
 
+# Ordered list of field names tried when resolving the natural text identifier for a
+# model during CSV/YAML/JSON bulk import.  The first name that exists on the model
+# wins.  This handles models like ModuleType that use 'model' rather than 'name'.
+_CSV_IDENTIFIER_FIELD_PRECEDENCE = ('name', 'slug', 'model', 'identifier')
+
+
+def _csv_import_to_field_name(model_class, explicit=None):
+    """Return the field name to use as ``to_field_name`` for CSV import lookups.
+
+    If *explicit* is provided (e.g. from a stored field configuration), it is
+    returned directly.  Otherwise the target model's fields are probed in
+    ``_CSV_IDENTIFIER_FIELD_PRECEDENCE`` order and the first match is used.
+    Falls back to ``'pk'`` when none of the candidates exist.
+    """
+    if explicit:
+        return explicit
+    for candidate in _CSV_IDENTIFIER_FIELD_PRECEDENCE:
+        try:
+            model_class._meta.get_field(candidate)
+            return candidate
+        except Exception:
+            pass
+    return 'pk'
+
 
 def _safe_pg_identifier(full_name: str) -> str:
     """
@@ -721,12 +745,10 @@ class ObjectFieldType(FieldType):
 
         if for_csv_import:
             field_class = CSVModelChoiceField
-            # For CSV import, determine to_field_name from the field configuration
-            to_field_name = getattr(field, 'to_field_name', None) or 'name'
+            to_field_name = _csv_import_to_field_name(model, explicit=getattr(field, 'to_field_name', None))
             return field_class(
                 queryset=model.objects.all(),
                 required=field.required,
-                # Remove initial=field.default to allow Django to handle instance data properly
                 to_field_name=to_field_name,
             )
         else:
@@ -1239,8 +1261,7 @@ class MultiObjectFieldType(FieldType):
 
         if for_csv_import:
             field_class = CSVModelMultipleChoiceField
-            # For CSV import, determine to_field_name from the field configuration
-            to_field_name = getattr(field, 'to_field_name', None) or 'name'
+            to_field_name = _csv_import_to_field_name(model, explicit=getattr(field, 'to_field_name', None))
             return field_class(
                 queryset=model.objects.all(),
                 required=field.required,

--- a/netbox_custom_objects/field_types.py
+++ b/netbox_custom_objects/field_types.py
@@ -56,16 +56,23 @@ def _csv_import_to_field_name(model_class, explicit=None):
     If *explicit* is provided (e.g. from a stored field configuration), it is
     returned directly.  Otherwise the target model's fields are probed in
     ``_CSV_IDENTIFIER_FIELD_PRECEDENCE`` order and the first match is used.
-    Falls back to ``'pk'`` when none of the candidates exist.
+    Falls back to ``'pk'`` when none of the candidates exist (rare; emits a
+    warning because importing by PK is user-unfriendly).
     """
-    if explicit:
+    if explicit is not None:
         return explicit
     for candidate in _CSV_IDENTIFIER_FIELD_PRECEDENCE:
         try:
             model_class._meta.get_field(candidate)
             return candidate
-        except Exception:
+        except FieldDoesNotExist:
             pass
+    logger.warning(
+        'No natural identifier field found on %s for CSV import '
+        '(tried %s); falling back to pk.',
+        model_class.__name__,
+        ', '.join(_CSV_IDENTIFIER_FIELD_PRECEDENCE),
+    )
     return 'pk'
 
 

--- a/netbox_custom_objects/field_types.py
+++ b/netbox_custom_objects/field_types.py
@@ -54,19 +54,40 @@ def _csv_import_to_field_name(model_class, explicit=None):
     """Return the field name to use as ``to_field_name`` for CSV import lookups.
 
     If *explicit* is provided (e.g. from a stored field configuration), it is
-    returned directly.  Otherwise the target model's fields are probed in
-    ``_CSV_IDENTIFIER_FIELD_PRECEDENCE`` order and the first match is used.
-    Falls back to ``'pk'`` when none of the candidates exist (rare; emits a
-    warning because importing by PK is user-unfriendly).
+    validated against the model and returned if the field exists.  If the stored
+    value is stale (field was renamed on the target model), a warning is logged
+    and the function falls through to the probe loop.
+
+    The probe loop iterates ``_CSV_IDENTIFIER_FIELD_PRECEDENCE`` and returns the
+    first candidate that exists **and is unique** on the model, guaranteeing that
+    ``CSVModelChoiceField`` can resolve a single record.  If no unique match is
+    found the first existing candidate (unique or not) is used as a fallback.
+    Falls back to ``'pk'`` when none of the candidates exist at all.
     """
     if explicit is not None:
-        return explicit
+        try:
+            model_class._meta.get_field(explicit)
+            return explicit
+        except FieldDoesNotExist:
+            logger.warning(
+                'Stored to_field_name %r not found on %s; probing for a natural identifier.',
+                explicit, model_class.__name__,
+            )
+
+    first_match = None  # best non-unique candidate, used only if no unique field found
     for candidate in _CSV_IDENTIFIER_FIELD_PRECEDENCE:
         try:
-            model_class._meta.get_field(candidate)
-            return candidate
+            field_obj = model_class._meta.get_field(candidate)
+            if getattr(field_obj, 'unique', False):
+                return candidate
+            if first_match is None:
+                first_match = candidate
         except FieldDoesNotExist:
             pass
+
+    if first_match is not None:
+        return first_match
+
     logger.warning(
         'No natural identifier field found on %s for CSV import '
         '(tried %s); falling back to pk.',

--- a/netbox_custom_objects/tests/test_field_types.py
+++ b/netbox_custom_objects/tests/test_field_types.py
@@ -802,6 +802,37 @@ class ObjectFieldTypeTestCase(FieldTypeTestCase):
         instance = model.objects.create(name="Test", device=device)
         self.assertEqual(instance.device, device)
 
+    def test_csv_import_field_uses_name_for_models_with_name(self):
+        """get_form_field(for_csv_import=True) uses 'name' as to_field_name for models
+        that have a name field (e.g. Device)."""
+        from dcim.models import Device
+        from netbox_custom_objects.field_types import ObjectFieldType, _csv_import_to_field_name
+        self.assertEqual(_csv_import_to_field_name(Device), 'name')
+
+    def test_csv_import_field_uses_model_for_module_type(self):
+        """get_form_field(for_csv_import=True) uses 'model' as to_field_name for
+        ModuleType, which has no 'name' field — regression for issue #406."""
+        from dcim.models import ModuleType
+        from netbox_custom_objects.field_types import ObjectFieldType, _csv_import_to_field_name
+        self.assertEqual(_csv_import_to_field_name(ModuleType), 'model')
+
+    def test_csv_import_form_field_for_module_type_uses_model_field(self):
+        """get_form_field(for_csv_import=True) on an Object field referencing ModuleType
+        produces a CSVModelChoiceField with to_field_name='model', not 'name'."""
+        from core.models import ObjectType
+        from netbox_custom_objects.field_types import ObjectFieldType
+        module_type_ot = ObjectType.objects.get(app_label='dcim', model='moduletype')
+        cotf = self.create_custom_object_type_field(
+            self.custom_object_type,
+            name="module_type",
+            label="Module Type",
+            type="object",
+            related_object_type=module_type_ot,
+        )
+        form_field = ObjectFieldType().get_form_field(cotf, for_csv_import=True)
+        self.assertEqual(form_field.to_field_name, 'model',
+                         "ModuleType CSV import must use 'model', not 'name'")
+
 
 class MultiObjectFieldTypeTestCase(FieldTypeTestCase):
     """Test cases for multiobject field type."""

--- a/netbox_custom_objects/tests/test_field_types.py
+++ b/netbox_custom_objects/tests/test_field_types.py
@@ -5,7 +5,7 @@ from unittest import skip
 from unittest.mock import Mock
 from datetime import date, datetime
 from decimal import Decimal
-from django.core.exceptions import ValidationError
+from django.core.exceptions import FieldDoesNotExist, ValidationError
 from django.test import TestCase
 
 from core.models import ObjectType
@@ -833,6 +833,31 @@ class ObjectFieldTypeTestCase(FieldTypeTestCase):
         form_field = ObjectFieldType().get_form_field(cotf, for_csv_import=True)
         self.assertEqual(form_field.to_field_name, 'model',
                          "ModuleType CSV import must use 'model', not 'name'")
+
+    def test_csv_import_to_field_name_explicit_returned_when_valid(self):
+        """An explicit to_field_name that exists on the model is returned directly."""
+        self.assertEqual(_csv_import_to_field_name(Device, explicit='id'), 'id')
+
+    def test_csv_import_to_field_name_explicit_falls_through_when_stale(self):
+        """A stale explicit to_field_name (field no longer exists) triggers a warning
+        and falls through to the probe loop."""
+        import logging
+        with self.assertLogs('netbox_custom_objects.field_types', level=logging.WARNING):
+            result = _csv_import_to_field_name(Device, explicit='nonexistent_field_xyz')
+        # Falls through to probe loop — Device has 'name'
+        self.assertEqual(result, 'name')
+
+    def test_csv_import_to_field_name_pk_fallback_when_no_candidate_exists(self):
+        """Falls back to 'pk' and emits a warning when none of the candidate fields
+        exist on the model."""
+        import logging
+        from unittest.mock import MagicMock
+        mock_model = MagicMock()
+        mock_model.__name__ = 'FakeModel'
+        mock_model._meta.get_field.side_effect = FieldDoesNotExist
+        with self.assertLogs('netbox_custom_objects.field_types', level=logging.WARNING):
+            result = _csv_import_to_field_name(mock_model)
+        self.assertEqual(result, 'pk')
 
 
 class MultiObjectFieldTypeTestCase(FieldTypeTestCase):

--- a/netbox_custom_objects/tests/test_field_types.py
+++ b/netbox_custom_objects/tests/test_field_types.py
@@ -9,11 +9,13 @@ from django.core.exceptions import ValidationError
 from django.test import TestCase
 
 from core.models import ObjectType
+from dcim.models import Device, DeviceType, ModuleType
 from netbox_custom_objects.field_types import (
     MultiObjectFieldType,
     MultiSelectFieldType,
     ObjectFieldType,
     SelectFieldType,
+    _csv_import_to_field_name,
 )
 from netbox_custom_objects.models import CustomObjectType, CustomObjectTypeField
 from .base import CustomObjectsTestCase
@@ -805,22 +807,21 @@ class ObjectFieldTypeTestCase(FieldTypeTestCase):
     def test_csv_import_field_uses_name_for_models_with_name(self):
         """get_form_field(for_csv_import=True) uses 'name' as to_field_name for models
         that have a name field (e.g. Device)."""
-        from dcim.models import Device
-        from netbox_custom_objects.field_types import ObjectFieldType, _csv_import_to_field_name
         self.assertEqual(_csv_import_to_field_name(Device), 'name')
 
     def test_csv_import_field_uses_model_for_module_type(self):
         """get_form_field(for_csv_import=True) uses 'model' as to_field_name for
         ModuleType, which has no 'name' field — regression for issue #406."""
-        from dcim.models import ModuleType
-        from netbox_custom_objects.field_types import ObjectFieldType, _csv_import_to_field_name
         self.assertEqual(_csv_import_to_field_name(ModuleType), 'model')
+
+    def test_csv_import_field_uses_slug_before_model_for_device_type(self):
+        """DeviceType has both 'slug' and 'model'; slug takes precedence per the
+        _CSV_IDENTIFIER_FIELD_PRECEDENCE ordering, matching NetBox core behaviour."""
+        self.assertEqual(_csv_import_to_field_name(DeviceType), 'slug')
 
     def test_csv_import_form_field_for_module_type_uses_model_field(self):
         """get_form_field(for_csv_import=True) on an Object field referencing ModuleType
         produces a CSVModelChoiceField with to_field_name='model', not 'name'."""
-        from core.models import ObjectType
-        from netbox_custom_objects.field_types import ObjectFieldType
         module_type_ot = ObjectType.objects.get(app_label='dcim', model='moduletype')
         cotf = self.create_custom_object_type_field(
             self.custom_object_type,
@@ -911,6 +912,21 @@ class MultiObjectFieldTypeTestCase(FieldTypeTestCase):
         self.assertEqual(instance.devices.count(), 2)
         self.assertIn(device1, instance.devices.all())
         self.assertIn(device2, instance.devices.all())
+
+    def test_csv_import_form_field_for_module_type_uses_model_field(self):
+        """MultiObjectFieldType.get_form_field(for_csv_import=True) on a field
+        referencing ModuleType produces to_field_name='model', not 'name'."""
+        module_type_ot = ObjectType.objects.get(app_label='dcim', model='moduletype')
+        cotf = self.create_custom_object_type_field(
+            self.custom_object_type,
+            name="module_types",
+            label="Module Types",
+            type="multiobject",
+            related_object_type=module_type_ot,
+        )
+        form_field = MultiObjectFieldType().get_form_field(cotf, for_csv_import=True)
+        self.assertEqual(form_field.to_field_name, 'model',
+                         "ModuleType multi-object CSV import must use 'model', not 'name'")
 
 
 class SelfReferentialFieldTestCase(FieldTypeTestCase):


### PR DESCRIPTION
### Fixes: #406

## Summary

Bulk import of Object and MultiObject fields referencing models without a `name` field (e.g. `dcim.ModuleType`, which uses `model` as its identifier) failed with `"invalid accessor field name"` because `to_field_name` was hardcoded to fall back to `'name'`.

## Root Cause

In `ObjectFieldType.get_form_field()` and `MultiObjectFieldType.get_form_field()`, the CSV import path used:

```python
to_field_name = getattr(field, 'to_field_name', None) or 'name'
```

`ModuleType` has no `name` field — it uses `model` — so `CSVModelChoiceField` received an invalid accessor and raised `FieldError`, surfaced to the user as `"invalid accessor field name"`.

NetBox core's own bulk import form for `ModuleType` explicitly sets `to_field_name='model'`, confirming `'name'` is not a universal default.

## Fix

Add `_csv_import_to_field_name(model_class, explicit=None)` which probes the target model's fields in priority order `('name', 'slug', 'model', 'identifier')` and returns the first match, falling back to `'pk'`. Both `get_form_field()` call sites now use this helper.

With this fix, importing a CO instance that references a `ModuleType` works as expected:

```yaml
---
testname: my-component
module_type: CPU567
```

## Tests

- `test_csv_import_field_uses_name_for_models_with_name` — `Device` (has `name`) → `'name'`
- `test_csv_import_field_uses_model_for_module_type` — `ModuleType` (no `name`) → `'model'`
- `test_csv_import_form_field_for_module_type_uses_model_field` — end-to-end: `get_form_field(for_csv_import=True)` on a `ModuleType` COTF produces `to_field_name='model'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
