### PR TITLE
Fixes: #428 - Use module-based warning filters for Python 3.13 compatibility

### DIFF
--- a/netbox_custom_objects/__init__.py
+++ b/netbox_custom_objects/__init__.py
@@ -234,13 +234,21 @@ class CustomObjectsPluginConfig(PluginConfig):
         # Patch ObjectSelectorView to support dynamically-generated custom object models
         _patch_object_selector_view()
 
-        # Suppress warnings about database calls during app initialization
+        # Suppress warnings about database calls during app initialization.
+        # Filter by source module rather than message content — message-pattern
+        # matching proved unreliable on Python 3.13 (the filter silently failed
+        # to suppress the warning in some environments).  Module-based filtering
+        # is stable across Python versions: the branching warning always comes
+        # from netbox_branching.database and Django's own warning from
+        # django.db.backends.utils.
         with warnings.catch_warnings():
             warnings.filterwarnings(
-                "ignore", category=RuntimeWarning, message=".*database.*"
+                "ignore", category=RuntimeWarning,
+                module=r"django\.db\.backends\..*",
             )
             warnings.filterwarnings(
-                "ignore", category=UserWarning, message=".*database.*"
+                "ignore", category=UserWarning,
+                module=r"netbox_branching\..*",
             )
 
             # Skip database calls if dynamic models can't be created yet
@@ -344,13 +352,17 @@ class CustomObjectsPluginConfig(PluginConfig):
         for model in super().get_models(include_auto_created, include_swapped):
             yield model
 
-        # Suppress warnings about database calls during model loading
+        # Suppress warnings about database calls during model loading.
+        # See the corresponding block in ready() for the rationale for using
+        # module-based filtering instead of message-content matching.
         with warnings.catch_warnings():
             warnings.filterwarnings(
-                "ignore", category=RuntimeWarning, message=".*database.*"
+                "ignore", category=RuntimeWarning,
+                module=r"django\.db\.backends\..*",
             )
             warnings.filterwarnings(
-                "ignore", category=UserWarning, message=".*database.*"
+                "ignore", category=UserWarning,
+                module=r"netbox_branching\..*",
             )
 
             # Skip dynamic model generation until ready() has completed.


### PR DESCRIPTION
### Fixes: #428

## Summary

The `warnings.catch_warnings()` suppression for startup DB-access warnings silently failed on Python 3.13, causing both `UserWarning: Routing database query for {model} before branching support is initialized.` (from `netbox_branching`) and `RuntimeWarning: Accessing the database during app initialization` (from Django) to appear in logs even on v0.5.1.

## Root Cause

The previous filters matched on message content:

```python
warnings.filterwarnings("ignore", category=UserWarning, message=".*database.*")
warnings.filterwarnings("ignore", category=RuntimeWarning, message=".*database.*")
```

Message-pattern matching via `warnings.filterwarnings(message=...)` uses `re.compile(..., re.I).match()` internally. This approach proved unreliable on Python 3.13 — the pattern matched correctly in unit tests but failed to suppress warnings in a real startup environment. The exact root cause in 3.13 is unclear (likely related to how the C extension `_warnings` module resolves filters when called from a DB router callback during app initialization), but the fix is straightforward.

## Fix

Replace message-content matching with module-origin matching in both `ready()` and `get_models()`:

```python
warnings.filterwarnings("ignore", category=RuntimeWarning, module=r"django\.db\.backends\..*")
warnings.filterwarnings("ignore", category=UserWarning,    module=r"netbox_branching\..*")
```

Module-based filtering is more robust: it matches the stable `__name__` of the module that calls `warnings.warn()`, which doesn't change across Python versions. The branching warning always originates from `netbox_branching.database` and Django's DB warning from `django.db.backends.utils`.

## Verification

Confirmed with `django.setup()` under a custom `showwarning` hook that no branching or DB initialization warnings leak through the new filters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
