### PR TITLE
Fixes #572: Use apps.is_installed() to guard netbox-branching import in live.py

### DIFF
--- a/netbox_custom_objects/graphql/live.py
+++ b/netbox_custom_objects/graphql/live.py
@@ -206,11 +206,11 @@ def connect_signature_invalidation():
             )
 
     # Evict a branch's cached schema when the branch itself is deleted.  No-op when
-    # netbox-branching is not installed (there are then no branch-keyed entries).
-    try:
-        from netbox_branching.models import Branch
-    except ImportError:
+    # netbox-branching is not installed or not in INSTALLED_APPS.
+    from django.apps import apps as django_apps
+    if not django_apps.is_installed('netbox_branching'):
         return
+    from netbox_branching.models import Branch
     post_delete.connect(
         _evict_branch_schema,
         sender=Branch,

--- a/netbox_custom_objects/graphql/live.py
+++ b/netbox_custom_objects/graphql/live.py
@@ -36,6 +36,8 @@ assigns the result to the view before it executes the operation.
 import logging
 import threading
 
+from django.apps import apps as django_apps
+
 logger = logging.getLogger("netbox_custom_objects.graphql")
 
 # Single-flight rebuild lock.  Two roles:
@@ -207,7 +209,6 @@ def connect_signature_invalidation():
 
     # Evict a branch's cached schema when the branch itself is deleted.  No-op when
     # netbox-branching is not installed or not in INSTALLED_APPS.
-    from django.apps import apps as django_apps
     if not django_apps.is_installed('netbox_branching'):
         return
     from netbox_branching.models import Branch

--- a/netbox_custom_objects/tests/test_graphql.py
+++ b/netbox_custom_objects/tests/test_graphql.py
@@ -300,6 +300,49 @@ class GraphQLLiveSchemaTestCase(CustomObjectsTestCase, TestCase):
         self.assertNotIn("custom_objects_temp_type", str(live_module.get_live_schema()))
 
 
+class GraphQLSignalRegistrationTestCase(TestCase):
+    """
+    Regression tests for connect_signature_invalidation() guard logic.
+
+    The function must not crash when netbox-branching is installed in the Python
+    environment but absent from INSTALLED_APPS (which raises RuntimeError, not
+    ImportError, when Django model classes are imported).
+    """
+
+    def test_branching_installed_but_not_enabled_does_not_crash(self):
+        # Simulate netbox-branching installed but not in INSTALLED_APPS by
+        # patching apps.is_installed to return False for it, then verify that
+        # connect_signature_invalidation() returns without attempting the import.
+        from django.db.models.signals import post_delete
+
+        from netbox_custom_objects.graphql.live import connect_signature_invalidation
+
+        with mock.patch(
+            "netbox_custom_objects.graphql.live.django_apps.is_installed",
+            side_effect=lambda app: app != "netbox_branching",
+        ):
+            # Must not raise — previously raised RuntimeError here.
+            connect_signature_invalidation()
+            # receivers items: ((dispatch_uid, sender_id), receiver, sender_ref, is_async)
+            registered_uids = [r[0][0] for r in post_delete.receivers]
+        self.assertNotIn(
+            "nco_graphql_evict_branch",
+            registered_uids,
+            "Branch eviction handler must not be registered when branching is not enabled",
+        )
+
+    def test_branching_not_installed_does_not_crash(self):
+        # When netbox-branching is entirely absent, is_installed returns False
+        # and the function must also return cleanly.
+        from netbox_custom_objects.graphql.live import connect_signature_invalidation
+
+        with mock.patch(
+            "netbox_custom_objects.graphql.live.django_apps.is_installed",
+            return_value=False,
+        ):
+            connect_signature_invalidation()  # must not raise
+
+
 @override_settings(LOGIN_REQUIRED=True)
 class GraphQLEndpointTestCase(CustomObjectsTestCase, TestCase):
     """

--- a/netbox_custom_objects/tests/test_graphql.py
+++ b/netbox_custom_objects/tests/test_graphql.py
@@ -309,13 +309,35 @@ class GraphQLSignalRegistrationTestCase(TestCase):
     ImportError, when Django model classes are imported).
     """
 
+    def _assert_evict_handler_not_registered(self):
+        """
+        Assert that the branch-eviction handler is not registered, using
+        Signal.disconnect() rather than inspecting the undocumented receivers
+        list.  disconnect() is the public API and returns True only when it
+        actually removed something — so if it returns False the handler was
+        never connected (which is the desired outcome).  Calling disconnect()
+        also serves as cleanup: if a prior test or ready() left a stale
+        registration, this removes it without affecting the assertion.
+        """
+        from django.db.models.signals import post_delete
+        was_registered = post_delete.disconnect(dispatch_uid="nco_graphql_evict_branch")
+        self.assertFalse(
+            was_registered,
+            "Branch eviction handler must not be registered when branching is not enabled",
+        )
+
     def test_branching_installed_but_not_enabled_does_not_crash(self):
         # Simulate netbox-branching installed but not in INSTALLED_APPS by
         # patching apps.is_installed to return False for it, then verify that
-        # connect_signature_invalidation() returns without attempting the import.
+        # connect_signature_invalidation() returns without registering the
+        # branch-eviction handler.
         from django.db.models.signals import post_delete
 
         from netbox_custom_objects.graphql.live import connect_signature_invalidation
+
+        # Remove any pre-existing registration (e.g. from ready()) so the test
+        # is self-contained regardless of the environment.
+        post_delete.disconnect(dispatch_uid="nco_graphql_evict_branch")
 
         with mock.patch(
             "netbox_custom_objects.graphql.live.django_apps.is_installed",
@@ -323,24 +345,26 @@ class GraphQLSignalRegistrationTestCase(TestCase):
         ):
             # Must not raise — previously raised RuntimeError here.
             connect_signature_invalidation()
-            # receivers items: ((dispatch_uid, sender_id), receiver, sender_ref, is_async)
-            registered_uids = [r[0][0] for r in post_delete.receivers]
-        self.assertNotIn(
-            "nco_graphql_evict_branch",
-            registered_uids,
-            "Branch eviction handler must not be registered when branching is not enabled",
-        )
+
+        self._assert_evict_handler_not_registered()
 
     def test_branching_not_installed_does_not_crash(self):
         # When netbox-branching is entirely absent, is_installed returns False
-        # and the function must also return cleanly.
+        # for all apps and the function must return cleanly without registering
+        # the branch-eviction handler.
+        from django.db.models.signals import post_delete
+
         from netbox_custom_objects.graphql.live import connect_signature_invalidation
+
+        post_delete.disconnect(dispatch_uid="nco_graphql_evict_branch")
 
         with mock.patch(
             "netbox_custom_objects.graphql.live.django_apps.is_installed",
-            return_value=False,
+            side_effect=lambda app: app != "netbox_branching",
         ):
             connect_signature_invalidation()  # must not raise
+
+        self._assert_evict_handler_not_registered()
 
 
 @override_settings(LOGIN_REQUIRED=True)


### PR DESCRIPTION
### Fixes: #572

## Summary

`connect_signature_invalidation()` guarded the `from netbox_branching.models import Branch` import with `except ImportError`. When netbox-branching is installed in the Python environment but absent from `PLUGINS`/`INSTALLED_APPS`, Django raises `RuntimeError` (not `ImportError`) during model class creation because the app registry is unpopulated for that package — causing a startup crash.

**Fix:** replace the `ImportError` guard with `apps.is_installed('netbox_branching')`, which correctly handles both "package not installed" and "package installed but not enabled" without attempting to import Django models for a non-registered app.

## Test plan

- [ ] Install netbox-branching into the venv but omit it from `PLUGINS` — server starts cleanly
- [ ] With netbox-branching in `PLUGINS` — branch schema eviction still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)