### PR TITLE
Fixes #561: Register <field>_id filter for non-polymorphic FK Object fields

### DIFF
--- a/netbox_custom_objects/filtersets.py
+++ b/netbox_custom_objects/filtersets.py
@@ -19,6 +19,7 @@ __all__ = (
     "CustomObjectTypeFilterSet",
     "NonPolymorphicMultiObjectFilter",
     "NonPolymorphicObjectFilter",
+    "NonPolymorphicObjectIdFilter",
     "PolymorphicMultiObjectFilter",
     "PolymorphicObjectFilter",
     "get_filterset_class",
@@ -167,6 +168,35 @@ class NonPolymorphicObjectFilter(django_filters.Filter):
         if value is None:
             return qs
         return qs.filter(**{f"{self.field_name}_id": value.pk})
+
+
+class NonPolymorphicObjectIdFilter(django_filters.Filter):
+    """
+    Accepts a raw integer PK for a non-polymorphic FK Object field.
+
+    Registered as ``<field_name>_id`` alongside ``NonPolymorphicObjectFilter``
+    (which accepts a model-instance input under ``<field_name>``).  NetBox's
+    Related Objects panel links use the ``_id`` suffix form (e.g.
+    ``?tenant_id=5``), so without this entry those links would silently return
+    unfiltered results (issue #561).
+
+    Uses IntegerField (not ModelChoiceField) so the filter is applied even when
+    the submitted PK doesn't correspond to an existing object.  Inherits from
+    django_filters.Filter (not NumberFilter / ModelChoiceFilter) for the same
+    reason as NonPolymorphicObjectFilter: avoids get_additional_lookups()
+    introspecting _meta after apps.clear_cache().
+    """
+
+    field_class = django_forms.IntegerField
+
+    def __init__(self, **kwargs):
+        kwargs.setdefault("required", False)
+        super().__init__(**kwargs)
+
+    def filter(self, qs, value):
+        if value is None:
+            return qs
+        return qs.filter(**{f"{self.field_name}": value})
 
 
 class NonPolymorphicMultiObjectFilter(django_filters.Filter):
@@ -334,7 +364,7 @@ def build_filter_for_field(field) -> dict:
         for key, value in spec.extra_kwargs.items():
             extra_kwargs[key] = value(field) if callable(value) else value
 
-    return {
+    filters = {
         field.name: spec.build(
             field_name=field.name,
             label=field.label or field.name,
@@ -342,6 +372,18 @@ def build_filter_for_field(field) -> dict:
             **extra_kwargs,
         )
     }
+
+    # For FK Object fields, also register a <field_name>_id filter that accepts
+    # a raw integer PK.  NetBox's Related Objects panel links use the _id suffix
+    # form (e.g. ?tenant_id=5), so without this the links return unfiltered
+    # results even though the filter name is present in the URL (issue #561).
+    if field.type == CustomFieldTypeChoices.TYPE_OBJECT and not field.is_polymorphic:
+        filters[f"{field.name}_id"] = NonPolymorphicObjectIdFilter(
+            field_name=f"{field.name}_id",
+            label=field.label or field.name,
+        )
+
+    return filters
 
 
 def get_filterset_class(model):

--- a/netbox_custom_objects/tests/test_filtersets.py
+++ b/netbox_custom_objects/tests/test_filtersets.py
@@ -132,6 +132,19 @@ class ObjectFieldFiltersetTestCase(CustomObjectsTestCase, TestCase):
     def test_no_filter_returns_all(self):
         self.assertEqual(self._filterset({}).qs.count(), 3)
 
+    def test_filter_by_id_suffix_returns_matching_object(self):
+        # Regression for #561: NetBox's Related Objects panel generates
+        # ?<field>_id=N links; the filterset must honour the _id suffix form.
+        pks = list(self._filterset({"device_id": self.device1.pk}).qs.values_list("pk", flat=True))
+        self.assertIn(self.obj_d1.pk, pks)
+        self.assertNotIn(self.obj_d2.pk, pks)
+        self.assertNotIn(self.obj_none.pk, pks)
+
+    def test_filter_by_id_suffix_different_value(self):
+        pks = list(self._filterset({"device_id": self.device2.pk}).qs.values_list("pk", flat=True))
+        self.assertIn(self.obj_d2.pk, pks)
+        self.assertNotIn(self.obj_d1.pk, pks)
+
 
 # ---------------------------------------------------------------------------
 # MultiObjectFieldType.get_filterform_field — form field shape


### PR DESCRIPTION
### Fixes: #561

## Summary

NetBox's Related Objects panel generates links with `?<field>_id=N` (e.g. `?tenant_id=5`), but the dynamic filterset for custom objects only registered the `?<field>=N` form (which takes a model instance). Clicking through from a tenant's Related Objects panel to the custom object list would silently return all objects unfiltered, despite the correct filter being present in the URL.

## Root cause

`build_filter_for_field()` returned only `{field.name: NonPolymorphicObjectFilter(...)}` for non-polymorphic `TYPE_OBJECT` fields. `NonPolymorphicObjectFilter` uses a `ModelChoiceField` which expects a PK and resolves it to an instance — the right input for the filter form — but the `_id` URL param produces a raw integer that the instance-based filter never sees.

## Fix

A new `NonPolymorphicObjectIdFilter` accepts a raw integer PK and filters directly by `<field_name>_id=`. `build_filter_for_field()` now emits it alongside the existing instance-based filter for every non-polymorphic `TYPE_OBJECT` field.

The `_id` suffix is the standard NetBox convention (per AGENTS.md: "FK filters must declare an explicit `<field>_id` variant").

## Tests

Two regression tests added to `ObjectFieldFiltersetTestCase`:
- `test_filter_by_id_suffix_returns_matching_object`
- `test_filter_by_id_suffix_different_value`

🤖 Generated with [Claude Code](https://claude.com/claude-code)