### PR TITLE
Fixes #588: Guard get_choice_color() calls against NetBox <4.6

### DIFF
--- a/netbox_custom_objects/field_types.py
+++ b/netbox_custom_objects/field_types.py
@@ -534,12 +534,14 @@ class SelectFieldType(FieldType):
         choices_dict = dict(field.choices)
         choice_set = field.choice_set
 
+        _get_color = getattr(choice_set, 'get_choice_color', None) if choice_set else None
+
         class _SelectLabelColumn(tables.Column):
             def render(self, value):
                 if value is None:
                     return self.default
                 label = choices_dict.get(value, value)
-                color = getattr(choice_set, 'get_choice_color', lambda v: None)(value) if choice_set else None
+                color = _get_color(value) if _get_color else None
                 if color:
                     return mark_safe(
                         f'<span class="badge text-bg-{escape(color)}">{escape(label)}</span>'

--- a/netbox_custom_objects/field_types.py
+++ b/netbox_custom_objects/field_types.py
@@ -671,8 +671,9 @@ class MultiSelectFieldType(FieldType):
             def render(self, value):
                 if not value:
                     return self.default
+                _get_color = getattr(choice_set, 'get_choice_color', None) if choice_set else None
                 pairs = [
-                    (choices_dict.get(v, v), getattr(choice_set, 'get_choice_color', lambda v: None)(v) if choice_set else None)
+                    (choices_dict.get(v, v), _get_color(v) if _get_color else None)
                     for v in value
                 ]
                 if any(color for _, color in pairs):

--- a/netbox_custom_objects/field_types.py
+++ b/netbox_custom_objects/field_types.py
@@ -539,7 +539,7 @@ class SelectFieldType(FieldType):
                 if value is None:
                     return self.default
                 label = choices_dict.get(value, value)
-                color = choice_set.get_choice_color(value) if choice_set else None
+                color = getattr(choice_set, 'get_choice_color', lambda v: None)(value) if choice_set else None
                 if color:
                     return mark_safe(
                         f'<span class="badge text-bg-{escape(color)}">{escape(label)}</span>'
@@ -672,7 +672,7 @@ class MultiSelectFieldType(FieldType):
                 if not value:
                     return self.default
                 pairs = [
-                    (choices_dict.get(v, v), choice_set.get_choice_color(v) if choice_set else None)
+                    (choices_dict.get(v, v), getattr(choice_set, 'get_choice_color', lambda v: None)(v) if choice_set else None)
                     for v in value
                 ]
                 if any(color for _, color in pairs):

--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -1421,7 +1421,8 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
 
     def get_choice_color(self, value):
         if self.choice_set:
-            return self.choice_set.get_choice_color(value)
+            getter = getattr(self.choice_set, 'get_choice_color', None)
+            return getter(value) if getter else None
         return None
 
     @property


### PR DESCRIPTION
### Fixes: #588

## Summary

- `CustomFieldChoiceSet.get_choice_color()` was introduced in NetBox 4.6.0 and does not exist on NetBox 4.5.x, causing an `AttributeError` 500 on any list view that contains a Selection or MultiSelect field.
- Three call sites are guarded with `getattr(..., None)` fallbacks so that choice colors are silently skipped on NetBox 4.5, matching the pre-color behavior.

## Test plan

- [ ] Confirm list view with Selection/MultiSelect field no longer 500s on NetBox 4.5.x
- [ ] Confirm colored badges still render correctly on NetBox 4.6.x

No new unit tests are being added for the 4.5 compatibility path: support for NetBox 4.5.x is nearing end-of-life and the extra test surface is not warranted for a short-lived compat shim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
