### PR TITLE
Fixes #587: Use actual FK target column in migration 0011

### DIFF
--- a/netbox_custom_objects/migrations/0011_non_deferrable_fk_constraints.py
+++ b/netbox_custom_objects/migrations/0011_non_deferrable_fk_constraints.py
@@ -42,7 +42,8 @@ def fix_deferrable_fk_constraints(apps, schema_editor):
                 tc.table_name,
                 tc.constraint_name,
                 kcu.column_name,
-                ccu.table_name AS foreign_table_name
+                ccu.table_name AS foreign_table_name,
+                ccu.column_name AS foreign_column_name
             FROM information_schema.table_constraints AS tc
             JOIN information_schema.key_column_usage AS kcu
                 ON tc.constraint_name = kcu.constraint_name
@@ -60,7 +61,7 @@ def fix_deferrable_fk_constraints(apps, schema_editor):
         """)
         rows = cursor.fetchall()
 
-        for table_name, constraint_name, column_name, foreign_table in rows:
+        for table_name, constraint_name, column_name, foreign_table, foreign_column in rows:
             new_constraint_name = _safe_constraint_name(table_name, column_name)
             # IF EXISTS on the old name handles partial re-runs where the old constraint
             # was already dropped in a previous (failed) attempt.
@@ -77,7 +78,7 @@ def fix_deferrable_fk_constraints(apps, schema_editor):
                 ALTER TABLE "{table_name}"
                 ADD CONSTRAINT "{new_constraint_name}"
                 FOREIGN KEY ("{column_name}")
-                REFERENCES "{foreign_table}" ("id")
+                REFERENCES "{foreign_table}" ("{foreign_column}")
                 ON DELETE CASCADE
             """)
 


### PR DESCRIPTION
### Fixes: #587

## Summary

Migration `0011_non_deferrable_fk_constraints` reconstructs DEFERRABLE FK constraints as non-DEFERRABLE. The `REFERENCES` clause hardcoded `"id"` as the target column, but COTs created under multi-table inheritance use `customobject_ptr_id` as their primary key. PostgreSQL rejects the constraint because the column `id` literally does not exist on those tables.

The fix: the query already joins `information_schema.constraint_column_usage`, which records the actual referenced column name. Adding `ccu.column_name AS foreign_column_name` to the SELECT and using it in the `REFERENCES` clause makes the migration correct for both standard (`id`) and MTI (`customobject_ptr_id`) COTs.

## Local verification

Verified with a direct DB script that:
1. Creates an MTI-style `custom_objects_test_*` table (PK=`customobject_ptr_id`) and a through table with a DEFERRABLE FK pointing at it
2. Runs the **original** migration logic → **confirmed** `ProgrammingError: column "id" referenced in foreign key constraint does not exist`
3. Restores the DEFERRABLE constraint, runs the **fixed** migration logic → **succeeds**, constraint rebuilt as non-DEFERRABLE referencing `customobject_ptr_id`

## Test plan

- [x] Bug reproduced and fix verified locally via DB-level script
- [ ] Confirm on a real pre-0.5.x install with an MTI COT that has M2M fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)