### PR TITLE
Fixes #595: SET CONSTRAINTS before poly column removal on revert

### DIFF
--- a/netbox_custom_objects/field_types.py
+++ b/netbox_custom_objects/field_types.py
@@ -1000,6 +1000,10 @@ class ObjectFieldType(FieldType):
         ct_field_name = f"{field_instance.name}_content_type"
         oid_field_name = f"{field_instance.name}_object_id"
 
+        # Flush deferred FK trigger events before ALTER TABLE; PostgreSQL rejects
+        # column removal with "pending trigger events" when a row deletion (from
+        # the revert path) has queued events on a DEFERRABLE FK column.
+        schema_editor.execute('SET CONSTRAINTS ALL IMMEDIATE')
         try:
             oid_field = model._meta.get_field(oid_field_name)
             schema_editor.remove_field(model, oid_field)

--- a/netbox_custom_objects/field_types.py
+++ b/netbox_custom_objects/field_types.py
@@ -1000,10 +1000,6 @@ class ObjectFieldType(FieldType):
         ct_field_name = f"{field_instance.name}_content_type"
         oid_field_name = f"{field_instance.name}_object_id"
 
-        # Flush deferred FK trigger events before ALTER TABLE; PostgreSQL rejects
-        # column removal with "pending trigger events" when a row deletion (from
-        # the revert path) has queued events on a DEFERRABLE FK column.
-        schema_editor.execute('SET CONSTRAINTS ALL IMMEDIATE')
         try:
             oid_field = model._meta.get_field(oid_field_name)
             schema_editor.remove_field(model, oid_field)

--- a/netbox_custom_objects/field_types.py
+++ b/netbox_custom_objects/field_types.py
@@ -1000,6 +1000,12 @@ class ObjectFieldType(FieldType):
         ct_field_name = f"{field_instance.name}_content_type"
         oid_field_name = f"{field_instance.name}_object_id"
 
+        # Flush deferred FK trigger events before ALTER TABLE; PostgreSQL rejects
+        # column removal with "pending trigger events" when a row deletion (from
+        # the revert path) has queued events on a DEFERRABLE FK column.
+        # Also called by CustomObjectTypeField.delete() for the full removal block,
+        # but kept here so this method is self-contained when called directly.
+        schema_editor.execute('SET CONSTRAINTS ALL IMMEDIATE')
         try:
             oid_field = model._meta.get_field(oid_field_name)
             schema_editor.remove_field(model, oid_field)

--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -3636,6 +3636,11 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
             _unwire_polymorphic_reverse_descriptors(self)
 
         with schema_conn.schema_editor() as schema_editor:
+            # Flush deferred FK trigger events before any ALTER TABLE or DROP TABLE.
+            # PostgreSQL rejects DDL with "pending trigger events" when a row
+            # deletion (e.g. from the branching revert path) has queued events on
+            # a DEFERRABLE FK column.  Guards all removal paths below.
+            schema_editor.execute('SET CONSTRAINTS ALL IMMEDIATE')
             if self.type == CustomObjectFieldTypeChoices.TYPE_COORDINATES:
                 # Drop both backing columns (latitude/longitude).
                 for column_name, model_field in field_type.get_model_field(self).items():

--- a/netbox_custom_objects/tests/test_polymorphic_fields.py
+++ b/netbox_custom_objects/tests/test_polymorphic_fields.py
@@ -1148,6 +1148,65 @@ class ReferencedObjectDeletionTest(
             through_model_name.lower(), django_apps.all_models.get(APP_LABEL, {})
         )
 
+    def test_remove_poly_obj_columns_succeeds_with_pending_deferred_triggers(self):
+        """
+        remove_polymorphic_object_columns() must not raise
+        "cannot ALTER TABLE because it has pending trigger events" when the
+        source row was deleted inside the same transaction (issue #595 regression).
+
+        The through-table created by the MULTIOBJECT field has a source_id FK:
+            custom_objects_<id>_poly_multi.source_id → custom_objects_<id>.id
+            DEFERRABLE INITIALLY DEFERRED (Django's PostgreSQL backend default)
+
+        When a row in custom_objects_<id> is deleted inside a transaction,
+        PostgreSQL queues a deferred trigger event associated with the REFERENCED
+        table (custom_objects_<id>), not the referencing through-table.  A
+        subsequent ALTER TABLE on that same table then fails with:
+            "cannot ALTER TABLE … because it has pending trigger events"
+        unless SET CONSTRAINTS ALL IMMEDIATE is issued first to flush the queue.
+
+        The fix in remove_polymorphic_object_columns() issues SET CONSTRAINTS ALL
+        IMMEDIATE before the first ALTER TABLE, firing the deferred check against
+        the through-table.  If the through-table rows were already deleted (as the
+        branching revert path does before removing the COT instance), the check
+        finds no FK violation and clears the pending event, allowing the ALTER
+        TABLE to proceed.
+        """
+        from django.db import connection, transaction as db_transaction
+        from netbox_custom_objects.field_types import FIELD_TYPE_CLASS
+
+        # Create an instance with the MULTIOBJECT populated so the through-table
+        # has a row referencing the source.
+        obj = self.model.objects.create(name="revert-repro")
+        obj.poly_multi.add(self.site)
+
+        main_table = self.model._meta.db_table
+        through_table = self.m2m_field.through_table_name
+
+        with db_transaction.atomic():
+            with connection.cursor() as cursor:
+                # Step 1: delete through-table rows first (mirrors the branching
+                # revert path, which cascades child rows before removing the COT
+                # instance).
+                cursor.execute(
+                    f'DELETE FROM "{through_table}" WHERE source_id = %s', [obj.pk]
+                )
+                # Step 2: delete the COT instance via raw SQL.  Django's FK
+                # constraints are DEFERRABLE INITIALLY DEFERRED, so PostgreSQL
+                # queues a deferred trigger on custom_objects_X (the referenced
+                # table) instead of checking the constraint immediately.
+                cursor.execute(f'DELETE FROM "{main_table}" WHERE id = %s', [obj.pk])
+            # Step 3: remove the polymorphic OBJECT field columns.  Without the
+            # fix, the ALTER TABLE inside remove_polymorphic_object_columns()
+            # fails with "cannot ALTER TABLE … because it has pending trigger
+            # events".  The fix calls SET CONSTRAINTS ALL IMMEDIATE first, which
+            # fires the deferred check (no FK violation since step 1 already
+            # deleted the through-table row) and clears the pending event.
+            with connection.schema_editor() as editor:
+                field_type = FIELD_TYPE_CLASS[self.gfk_field.type]()
+                field_type.remove_polymorphic_object_columns(self.gfk_field, self.model, editor)
+        # Reaching here without a database exception confirms the fix is effective.
+
 
 # ---------------------------------------------------------------------------
 # Cycle-detection: multi-hop polymorphic cycles


### PR DESCRIPTION
### Fixes: #595

## Summary

- `remove_polymorphic_object_columns()` dropped the `_content_type` and `_object_id` columns with `ALTER TABLE` but did not flush deferred FK trigger events first.
- On branch revert, the preceding row deletion queues deferred FK trigger events from the `DEFERRABLE INITIALLY DEFERRED` through-table FK (created by any `MULTIOBJECT` field on the same COT). PostgreSQL then rejects the `ALTER TABLE` with `ObjectInUse: cannot ALTER TABLE "custom_objects_<id>" because it has pending trigger events`.
- Fix: issue `SET CONSTRAINTS ALL IMMEDIATE` before the first `ALTER TABLE`, mirroring what `_schema_remove_field()` already does for scalar fields.

## Test plan

- [ ] Run the repro script from issue #595 — revert should complete without error.
- [ ] Existing poly field tests pass.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)