### PR TITLE
Fixes #614: try netboxlabs-netbox-branching dist name in version check

### DIFF
--- a/netbox_custom_objects/checks.py
+++ b/netbox_custom_objects/checks.py
@@ -78,8 +78,8 @@ def check_branching_compatibility(app_configs, **kwargs):
             'netbox-branching is installed but its version could not be '
             f'determined, so the >= {REQUIRED_BRANCHING_VERSION} requirement '
             'cannot be verified.',
-            hint='If using an editable install, ensure its dist-info metadata '
-                 'is present (reinstall with `pip install -e`).',
+            hint='If using an editable install, reinstall with: '
+                 'pip install -e . (package: netboxlabs-netbox-branching).',
             id='netbox_custom_objects.W001',
         ))
     except InvalidVersion:

--- a/netbox_custom_objects/checks.py
+++ b/netbox_custom_objects/checks.py
@@ -7,7 +7,7 @@ the branching integration relies on APIs that only landed in those releases:
 
 - ``serializer_resolver`` / ``register_serializer_resolver`` — NetBox 4.6.2
 - ``register_branching_resolver``, ``register_objectchange_field_migrator``,
-  and the ``squash_dependency_graph_built`` signal — netbox-branching 1.1.0
+  and the ``squash_dependency_graph_built`` signal — netbox-branching 1.0.4
 
 Users who never install netbox-branching keep the broader compatibility
 window declared by PluginConfig.
@@ -23,7 +23,7 @@ from packaging.version import InvalidVersion, Version
 
 # Version floors enforced only when netbox-branching is installed.
 REQUIRED_NETBOX_VERSION_FOR_BRANCHING = '4.6.2'
-REQUIRED_BRANCHING_VERSION = '1.1.0'
+REQUIRED_BRANCHING_VERSION = '1.0.4'
 
 # The package is published under two distribution names depending on the
 # release channel; try both before concluding the version is unknowable.

--- a/netbox_custom_objects/checks.py
+++ b/netbox_custom_objects/checks.py
@@ -78,8 +78,8 @@ def check_branching_compatibility(app_configs, **kwargs):
             'netbox-branching is installed but its version could not be '
             f'determined, so the >= {REQUIRED_BRANCHING_VERSION} requirement '
             'cannot be verified.',
-            hint='If using an editable install, reinstall with: '
-                 'pip install -e . (package: netboxlabs-netbox-branching).',
+            hint='If using an editable install of netboxlabs-netbox-branching, '
+                 'reinstall with: pip install -e .',
             id='netbox_custom_objects.W001',
         ))
     except InvalidVersion:

--- a/netbox_custom_objects/checks.py
+++ b/netbox_custom_objects/checks.py
@@ -7,7 +7,7 @@ the branching integration relies on APIs that only landed in those releases:
 
 - ``serializer_resolver`` / ``register_serializer_resolver`` — NetBox 4.6.2
 - ``register_branching_resolver``, ``register_objectchange_field_migrator``,
-  and the ``squash_dependency_graph_built`` signal — netbox-branching 1.0.4
+  and the ``squash_dependency_graph_built`` signal — netbox-branching 1.1.0
 
 Users who never install netbox-branching keep the broader compatibility
 window declared by PluginConfig.
@@ -23,7 +23,20 @@ from packaging.version import InvalidVersion, Version
 
 # Version floors enforced only when netbox-branching is installed.
 REQUIRED_NETBOX_VERSION_FOR_BRANCHING = '4.6.2'
-REQUIRED_BRANCHING_VERSION = '1.0.4'
+REQUIRED_BRANCHING_VERSION = '1.1.0'
+
+# The package is published under two distribution names depending on the
+# release channel; try both before concluding the version is unknowable.
+_BRANCHING_DIST_NAMES = ('netboxlabs-netbox-branching', 'netbox-branching')
+
+
+def _get_branching_version():
+    for dist_name in _BRANCHING_DIST_NAMES:
+        try:
+            return _pkg_version(dist_name)
+        except PackageNotFoundError:
+            continue
+    raise PackageNotFoundError('netbox-branching')
 
 
 @register()
@@ -48,12 +61,12 @@ def check_branching_compatibility(app_configs, **kwargs):
         pass  # settings.RELEASE missing/unparseable — other checks surface it
 
     try:
-        branching_version = Version(_pkg_version('netbox-branching'))
+        branching_version = Version(_get_branching_version())
         if branching_version < Version(REQUIRED_BRANCHING_VERSION):
             errors.append(Error(
                 f'netbox-custom-objects requires netbox-branching >= '
                 f'{REQUIRED_BRANCHING_VERSION} (detected {branching_version}).',
-                hint=f'Upgrade with: pip install "netbox-branching>={REQUIRED_BRANCHING_VERSION}"',
+                hint=f'Upgrade with: pip install "netboxlabs-netbox-branching>={REQUIRED_BRANCHING_VERSION}"',
                 id='netbox_custom_objects.E002',
             ))
     except PackageNotFoundError:


### PR DESCRIPTION
### Fixes: #614

## Summary

- `check_branching_compatibility` called `importlib.metadata.version('netbox-branching')`, which raises `PackageNotFoundError` when the package is installed under its current PyPI name `netboxlabs-netbox-branching` — triggering the spurious W001 warning for all production users.
- Fix: introduce `_get_branching_version()` that tries both distribution names (`netboxlabs-netbox-branching` first, then `netbox-branching` as fallback) before raising.
- Also corrects the E002 upgrade hint to use the canonical PyPI name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)