### PR TITLE
Closes #549: Surface Custom Objects in Jinja config templates

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -190,6 +190,11 @@ Notes:
 
 - The attribute-style form returns the model's manager (`.filter(...)`, `.all()`, etc.); the filter form returns a queryset of all instances of that type.
 - An unknown type name is handled the same way by both forms: a warning is logged, and the reference resolves to an empty, chainable stand-in — further calls like `.filter(...)` or `.all()` continue to render no rows rather than raising. Check the type's internal name (shown on its detail page) if a template renders no data.
+- A type's internal name may begin with a digit (e.g. `123foo`), which isn't valid Jinja dot-notation. Use bracket notation with the attribute-style form instead:
+
+```jinja2
+{% for obj in custom_objects['123foo'].filter(device=device) %}
+```
 
 ### Deletions
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -189,7 +189,7 @@ interface {{ iface.name }}
 Notes:
 
 - The attribute-style form returns the model's manager (`.filter(...)`, `.all()`, etc.); the filter form returns a queryset of all instances of that type.
-- An unknown type name is handled differently by design: the attribute form raises `AttributeError` (which Jinja treats as `Undefined`), while the filter form logs a warning and returns an empty list. Both fail quietly rather than crashing the render — check the type's internal name (shown on its detail page) if a template renders no data.
+- An unknown type name is handled the same way by both forms: a warning is logged, and the reference resolves to an empty, chainable stand-in — further calls like `.filter(...)` or `.all()` continue to render no rows rather than raising. Check the type's internal name (shown on its detail page) if a template renders no data.
 
 ### Deletions
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -163,7 +163,7 @@ Notes:
 ### Jinja Config Templates
 
 !!! note
-    Requires NetBox 4.7 or later. On earlier NetBox versions, `custom_objects` is simply unavailable in config templates — a single informational message is logged when the plugin starts, and nothing else changes.
+    Requires NetBox 4.7 or later. On earlier NetBox versions, `custom_objects` is simply unavailable in config templates and nothing else changes — no error, no crash. A `DEBUG`-level log message noting this is emitted at plugin startup; enable debug logging if you need to confirm why `custom_objects` isn't resolving.
 
 Custom Objects can be referenced directly from NetBox [config templates](https://netboxlabs.com/docs/netbox/models/extras/configtemplate/), so device configuration can pull in data modelled with Custom Object Types (e.g. OSPF interface parameters, BGP peer groups, MPLS label ranges) alongside built-in NetBox models.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -160,6 +160,37 @@ Notes:
 - A field must be an object field with both the **name and target model** above; a mis-named or mis-pointed field is simply ignored.
 - If a type defines **none** of these fields, aggregation is skipped entirely and its rendered context is just its Local Context Data. This is a deliberate difference from Devices/VMs: **global (unassigned) ConfigContexts are not applied** to such a type — enabling config context support alone never silently pulls in every global context. Add at least one convention field (e.g. `site`) to opt the type into source aggregation; global contexts then apply too (as they do for any object with a dimension).
 
+### Jinja Config Templates
+
+!!! note
+    Requires NetBox 4.7 or later. On earlier NetBox versions, `custom_objects` is simply unavailable in config templates — a single informational message is logged when the plugin starts, and nothing else changes.
+
+Custom Objects can be referenced directly from NetBox [config templates](https://netboxlabs.com/docs/netbox/models/extras/configtemplate/), so device configuration can pull in data modelled with Custom Object Types (e.g. OSPF interface parameters, BGP peer groups, MPLS label ranges) alongside built-in NetBox models.
+
+Two equivalent access patterns are available, both resolving the Custom Object Type by its **internal name** at render time (so templates keep working even if the type's slug or internal table ID changes):
+
+Attribute-style, via the `custom_objects` context variable:
+
+```jinja2
+{% for iface in custom_objects.ospf_interface.filter(device=device) %}
+interface {{ iface.name }}
+    ip ospf area {{ iface.area }}
+{% endfor %}
+```
+
+Filter syntax, via the `custom_objects` Jinja filter:
+
+```jinja2
+{% for iface in 'ospf_interface' | custom_objects %}
+interface {{ iface.name }}
+{% endfor %}
+```
+
+Notes:
+
+- The attribute-style form returns the model's manager (`.filter(...)`, `.all()`, etc.); the filter form returns a queryset of all instances of that type.
+- An unknown type name is handled differently by design: the attribute form raises `AttributeError` (which Jinja treats as `Undefined`), while the filter form logs a warning and returns an empty list. Both fail quietly rather than crashing the render — check the type's internal name (shown on its detail page) if a template renders no data.
+
 ### Deletions
 
 #### Deleting Custom Object Types

--- a/netbox_custom_objects/__init__.py
+++ b/netbox_custom_objects/__init__.py
@@ -264,6 +264,10 @@ class CustomObjectsPluginConfig(PluginConfig):
     }
     required_settings = []
     template_extensions = "template_content.template_extensions"
+    # Registers the custom_objects Jinja filter (jinja_env.filters). Requires NetBox
+    # 4.7+; on older NetBox this attribute is simply never read by core (see ready()
+    # for the startup log message covering that case).
+    jinja_filters = "jinja_env.filters"
     # Resolves dynamic CO models (table{n}model) to on-the-fly serializers —
     # they have no importable path at the conventional location.
     serializer_resolver = "api.serializers.serializer_resolver"
@@ -367,6 +371,24 @@ class CustomObjectsPluginConfig(PluginConfig):
             return
         super().ready()
         _super_ready_called = True
+
+        # On NetBox < 4.7 the jinja_filters resource and get_jinja_context() hook
+        # don't exist, so super().ready() never calls _load_resource('jinja_filters')
+        # and get_jinja_context() is never invoked by RenderTemplateMixin.get_context().
+        # Emit a single INFO message so operators have an actionable explanation if
+        # 'custom_objects' is absent from config/export template renders.
+        from netbox.registry import registry
+        if 'custom_objects' not in registry.get('plugins', {}).get('jinja_filters', {}):
+            logger.info(
+                "NetBox Jinja config template hooks (jinja_filters / get_jinja_context) "
+                "are not available in this version of NetBox. The 'custom_objects' filter "
+                "and context variable will not be active in config templates. Upgrade to "
+                "NetBox 4.7+ to enable this feature."
+            )
+
+    def get_jinja_context(self):
+        from netbox_custom_objects.jinja_env import CustomObjectsNamespace
+        return {'custom_objects': CustomObjectsNamespace()}
 
     def ready(self):
         # Install the thread-safe apps.clear_cache wrapper before any dynamic

--- a/netbox_custom_objects/__init__.py
+++ b/netbox_custom_objects/__init__.py
@@ -375,11 +375,13 @@ class CustomObjectsPluginConfig(PluginConfig):
         # On NetBox < 4.7 the jinja_filters resource and get_jinja_context() hook
         # don't exist, so super().ready() never calls _load_resource('jinja_filters')
         # and get_jinja_context() is never invoked by RenderTemplateMixin.get_context().
-        # Emit a single INFO message so operators have an actionable explanation if
-        # 'custom_objects' is absent from config/export template renders.
+        # This is every currently-supported NetBox version (4.7 isn't released yet), so
+        # log at DEBUG rather than INFO: it's an explanation to reach for when actively
+        # troubleshooting why 'custom_objects' isn't resolving, not a startup notice
+        # every install should see by default.
         from netbox.registry import registry
         if 'custom_objects' not in registry.get('plugins', {}).get('jinja_filters', {}):
-            logger.info(
+            logger.debug(
                 "NetBox Jinja config template hooks (jinja_filters / get_jinja_context) "
                 "are not available in this version of NetBox. The 'custom_objects' filter "
                 "and context variable will not be active in config templates. Upgrade to "

--- a/netbox_custom_objects/jinja_env.py
+++ b/netbox_custom_objects/jinja_env.py
@@ -24,10 +24,11 @@ Filter syntax (via the registered ``custom_objects`` filter)::
 
 Both resolve the Custom Object Type by **name** at access time, so templates
 remain valid even if the COT's internal table ID changes. Both also fail
-quietly on an unknown name: a warning is logged, and the reference resolves
-to an EmptyCustomObjectsQuerySet rather than raising, so a template that
-chains queryset-style calls onto either form (as in the examples above)
-renders no rows instead of crashing.
+quietly on an unknown name: a warning is logged (once per name, per process,
+to avoid log spam across a bulk render), and the reference resolves to an
+EmptyCustomObjectsQuerySet rather than raising, so a template that chains
+queryset-style calls onto either form (as in the examples above) renders no
+rows instead of crashing.
 
 Both of these hooks (the ``jinja_filters`` plugin resource and
 ``PluginConfig.get_jinja_context()``) require NetBox 4.7+. On older NetBox,
@@ -38,21 +39,30 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+# Names for which the "no Custom Object Type named ..." warning has already been
+# logged, so a template typo rendered against many objects (e.g. a bulk device
+# config export) logs once per process rather than once per render. If a type is
+# later created under a previously-warned name, resolution still succeeds
+# immediately -- only the warning is suppressed, not the lookup itself.
+_warned_unknown_names = set()
+
 
 class EmptyCustomObjectsQuerySet:
     """
     Stand-in returned for an unresolved Custom Object Type name.
 
     Mimics the read-only subset of the QuerySet/Manager interface that
-    templates chain onto ``custom_objects.<name>`` or ``<name> | custom_objects``
-    (``.filter()``, ``.exclude()``, ``.all()``, ``.order_by()``, iteration,
-    ``len()``, ``.count()``, etc.), always yielding no results. Unlike a real
-    QuerySet, it accepts arbitrary filter/exclude kwargs without validating
+    templates commonly chain onto ``custom_objects.<name>`` or
+    ``<name> | custom_objects`` (``.filter()``, ``.exclude()``, ``.all()``,
+    ``.order_by()``, ``.values()``, ``.values_list()``, ``.select_related()``,
+    ``.prefetch_related()``, ``.distinct()``, ``.annotate()``, slicing,
+    iteration, ``len()``, ``.count()``, etc.), always yielding no results.
+    Unlike a real QuerySet, it accepts arbitrary kwargs without validating
     them against a model, since there is no model to validate against.
 
     This lets a template written against a Custom Object Type that was
     renamed or deleted keep rendering (with no data) instead of raising, for
-    either access pattern.
+    either access pattern, regardless of how the result is chained.
     """
 
     def filter(self, *args, **kwargs):
@@ -69,6 +79,29 @@ class EmptyCustomObjectsQuerySet:
 
     def order_by(self, *args, **kwargs):
         return self
+
+    def values(self, *args, **kwargs):
+        return self
+
+    def values_list(self, *args, **kwargs):
+        return self
+
+    def select_related(self, *args, **kwargs):
+        return self
+
+    def prefetch_related(self, *args, **kwargs):
+        return self
+
+    def distinct(self, *args, **kwargs):
+        return self
+
+    def annotate(self, *args, **kwargs):
+        return self
+
+    def get(self, *args, **kwargs):
+        # Matches real QuerySet.get() semantics: "no matching object" is a
+        # genuine, expected condition to raise on, not something to paper over.
+        raise LookupError("No matching object (Custom Object Type is unresolved).")
 
     def first(self):
         return None
@@ -91,17 +124,24 @@ class EmptyCustomObjectsQuerySet:
     def __bool__(self):
         return False
 
+    def __getitem__(self, item):
+        if isinstance(item, slice):
+            return self
+        raise IndexError("EmptyCustomObjectsQuerySet index out of range")
+
     def __repr__(self):
         return '<EmptyCustomObjectsQuerySet>'
 
 
 def _resolve_custom_object_type(name):
-    """Look up a Custom Object Type by name; return None (with a warning logged) if unresolved."""
+    """Look up a Custom Object Type by name; return None (warning logged once per name) if unresolved."""
     from netbox_custom_objects.models import CustomObjectType
     try:
         return CustomObjectType.objects.get(name=name)
     except CustomObjectType.DoesNotExist:
-        logger.warning("custom_objects: no Custom Object Type named %r", name)
+        if name not in _warned_unknown_names:
+            logger.warning("custom_objects: no Custom Object Type named %r", name)
+            _warned_unknown_names.add(name)
         return None
 
 
@@ -118,17 +158,23 @@ class CustomObjectsNamespace:
     raising, matching the custom_objects filter's behavior.
 
     Lookups are intentionally deferred so that importing this module at startup
-    does not touch the database.
+    does not touch the database. Resolved results are cached per-instance (not
+    across renders, since a new CustomObjectsNamespace is created for every
+    render via get_jinja_context()) so a template referencing the same name
+    multiple times issues only one lookup per render.
     """
+
+    def __init__(self):
+        self._cache = {}
 
     def __getattr__(self, name):
         # Avoid intercepting Python internal attribute lookups (e.g. __deepcopy__).
         if name.startswith('_'):
             raise AttributeError(name)
-        cot = _resolve_custom_object_type(name)
-        if cot is None:
-            return EmptyCustomObjectsQuerySet()
-        return cot.get_model().objects
+        if name not in self._cache:
+            cot = _resolve_custom_object_type(name)
+            self._cache[name] = cot.get_model().objects if cot is not None else EmptyCustomObjectsQuerySet()
+        return self._cache[name]
 
     def __repr__(self):
         return 'custom_objects'

--- a/netbox_custom_objects/jinja_env.py
+++ b/netbox_custom_objects/jinja_env.py
@@ -1,0 +1,90 @@
+"""
+Jinja integration for netbox-custom-objects.
+
+Provides:
+  - ``filters``: a dict registered with NetBox's plugin ``jinja_filters`` hook.
+  - ``CustomObjectsNamespace``: a lazy attribute-access namespace injected into
+    every ConfigTemplate/ExportTemplate render context as ``custom_objects``.
+
+Usage in a config template
+--------------------------
+
+Attribute access (via context injection)::
+
+    {% for iface in custom_objects.OSPFInterface.filter(device=device) %}
+        interface {{ iface.name }}
+            ip ospf area {{ iface.area }}
+    {% endfor %}
+
+Filter syntax (via the registered ``custom_objects`` filter)::
+
+    {% for iface in 'OSPFInterface' | custom_objects %}
+        ...
+    {% endfor %}
+
+Both resolve the Custom Object Type by **name** at access time, so templates
+remain valid even if the COT's internal table ID changes.
+
+Both of these hooks (the ``jinja_filters`` plugin resource and
+``PluginConfig.get_jinja_context()``) require NetBox 4.7+. On older NetBox,
+this module is simply never consulted by core, so it degrades to a no-op
+(see ``CustomObjectsPluginConfig.ready()`` for the startup log message).
+"""
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class CustomObjectsNamespace:
+    """
+    Lazy namespace injected into the Jinja context as ``custom_objects``.
+
+    Attribute access triggers a COT lookup by name and returns the model's
+    default manager, allowing queryset operations directly in templates::
+
+        custom_objects.OSPFInterface.filter(device=device)
+
+    Lookups are intentionally deferred so that importing this module at startup
+    does not touch the database.
+    """
+
+    def __getattr__(self, name):
+        # Avoid intercepting Python internal attribute lookups (e.g. __deepcopy__).
+        if name.startswith('_'):
+            raise AttributeError(name)
+        from netbox_custom_objects.models import CustomObjectType
+        try:
+            cot = CustomObjectType.objects.get(name=name)
+        except CustomObjectType.DoesNotExist:
+            raise AttributeError(
+                f"No Custom Object Type named {name!r}. "
+                "Check the name in NetBox under Plugins → Custom Objects."
+            )
+        return cot.get_model().objects
+
+    def __repr__(self):
+        return 'custom_objects'
+
+
+def custom_objects_filter(type_name):
+    """
+    Jinja filter: resolve a Custom Object Type by name and return a queryset
+    of all its instances.
+
+    Example::
+
+        {% for iface in 'OSPFInterface' | custom_objects %}
+    """
+    from netbox_custom_objects.models import CustomObjectType
+    try:
+        cot = CustomObjectType.objects.get(name=type_name)
+    except CustomObjectType.DoesNotExist:
+        logger.warning("custom_objects filter: no Custom Object Type named %r", type_name)
+        return []
+    return cot.get_model().objects.all()
+
+
+# Registered with NetBox via the jinja_filters plugin hook.
+filters = {
+    'custom_objects': custom_objects_filter,
+}

--- a/netbox_custom_objects/jinja_env.py
+++ b/netbox_custom_objects/jinja_env.py
@@ -11,19 +11,23 @@ Usage in a config template
 
 Attribute access (via context injection)::
 
-    {% for iface in custom_objects.OSPFInterface.filter(device=device) %}
+    {% for iface in custom_objects.ospf_interface.filter(device=device) %}
         interface {{ iface.name }}
             ip ospf area {{ iface.area }}
     {% endfor %}
 
 Filter syntax (via the registered ``custom_objects`` filter)::
 
-    {% for iface in 'OSPFInterface' | custom_objects %}
+    {% for iface in 'ospf_interface' | custom_objects %}
         ...
     {% endfor %}
 
 Both resolve the Custom Object Type by **name** at access time, so templates
-remain valid even if the COT's internal table ID changes.
+remain valid even if the COT's internal table ID changes. Both also fail
+quietly on an unknown name: a warning is logged, and the reference resolves
+to an EmptyCustomObjectsQuerySet rather than raising, so a template that
+chains queryset-style calls onto either form (as in the examples above)
+renders no rows instead of crashing.
 
 Both of these hooks (the ``jinja_filters`` plugin resource and
 ``PluginConfig.get_jinja_context()``) require NetBox 4.7+. On older NetBox,
@@ -35,6 +39,72 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+class EmptyCustomObjectsQuerySet:
+    """
+    Stand-in returned for an unresolved Custom Object Type name.
+
+    Mimics the read-only subset of the QuerySet/Manager interface that
+    templates chain onto ``custom_objects.<name>`` or ``<name> | custom_objects``
+    (``.filter()``, ``.exclude()``, ``.all()``, ``.order_by()``, iteration,
+    ``len()``, ``.count()``, etc.), always yielding no results. Unlike a real
+    QuerySet, it accepts arbitrary filter/exclude kwargs without validating
+    them against a model, since there is no model to validate against.
+
+    This lets a template written against a Custom Object Type that was
+    renamed or deleted keep rendering (with no data) instead of raising, for
+    either access pattern.
+    """
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def exclude(self, *args, **kwargs):
+        return self
+
+    def all(self):
+        return self
+
+    def none(self):
+        return self
+
+    def order_by(self, *args, **kwargs):
+        return self
+
+    def first(self):
+        return None
+
+    def last(self):
+        return None
+
+    def count(self):
+        return 0
+
+    def exists(self):
+        return False
+
+    def __iter__(self):
+        return iter(())
+
+    def __len__(self):
+        return 0
+
+    def __bool__(self):
+        return False
+
+    def __repr__(self):
+        return '<EmptyCustomObjectsQuerySet>'
+
+
+def _resolve_custom_object_type(name):
+    """Look up a Custom Object Type by name; return None (with a warning logged) if unresolved."""
+    from netbox_custom_objects.models import CustomObjectType
+    try:
+        return CustomObjectType.objects.get(name=name)
+    except CustomObjectType.DoesNotExist:
+        logger.warning("custom_objects: no Custom Object Type named %r", name)
+        return None
+
+
 class CustomObjectsNamespace:
     """
     Lazy namespace injected into the Jinja context as ``custom_objects``.
@@ -42,7 +112,10 @@ class CustomObjectsNamespace:
     Attribute access triggers a COT lookup by name and returns the model's
     default manager, allowing queryset operations directly in templates::
 
-        custom_objects.OSPFInterface.filter(device=device)
+        custom_objects.ospf_interface.filter(device=device)
+
+    An unknown name resolves to an EmptyCustomObjectsQuerySet rather than
+    raising, matching the custom_objects filter's behavior.
 
     Lookups are intentionally deferred so that importing this module at startup
     does not touch the database.
@@ -52,14 +125,9 @@ class CustomObjectsNamespace:
         # Avoid intercepting Python internal attribute lookups (e.g. __deepcopy__).
         if name.startswith('_'):
             raise AttributeError(name)
-        from netbox_custom_objects.models import CustomObjectType
-        try:
-            cot = CustomObjectType.objects.get(name=name)
-        except CustomObjectType.DoesNotExist:
-            raise AttributeError(
-                f"No Custom Object Type named {name!r}. "
-                "Check the name in NetBox under Plugins → Custom Objects."
-            )
+        cot = _resolve_custom_object_type(name)
+        if cot is None:
+            return EmptyCustomObjectsQuerySet()
         return cot.get_model().objects
 
     def __repr__(self):
@@ -73,14 +141,11 @@ def custom_objects_filter(type_name):
 
     Example::
 
-        {% for iface in 'OSPFInterface' | custom_objects %}
+        {% for iface in 'ospf_interface' | custom_objects %}
     """
-    from netbox_custom_objects.models import CustomObjectType
-    try:
-        cot = CustomObjectType.objects.get(name=type_name)
-    except CustomObjectType.DoesNotExist:
-        logger.warning("custom_objects filter: no Custom Object Type named %r", type_name)
-        return []
+    cot = _resolve_custom_object_type(type_name)
+    if cot is None:
+        return EmptyCustomObjectsQuerySet()
     return cot.get_model().objects.all()
 
 

--- a/netbox_custom_objects/jinja_env.py
+++ b/netbox_custom_objects/jinja_env.py
@@ -37,6 +37,8 @@ this module is simply never consulted by core, so it degrades to a no-op
 """
 import logging
 
+from jinja2 import pass_context
+
 logger = logging.getLogger(__name__)
 
 # Names for which the "no Custom Object Type named ..." warning has already been
@@ -62,7 +64,8 @@ class EmptyCustomObjectsQuerySet:
 
     This lets a template written against a Custom Object Type that was
     renamed or deleted keep rendering (with no data) instead of raising, for
-    either access pattern, regardless of how the result is chained.
+    either access pattern, as long as only the queryset methods listed above
+    are chained onto the result.
     """
 
     def filter(self, *args, **kwargs):
@@ -180,7 +183,8 @@ class CustomObjectsNamespace:
         return 'custom_objects'
 
 
-def custom_objects_filter(type_name):
+@pass_context
+def custom_objects_filter(_context, type_name):
     """
     Jinja filter: resolve a Custom Object Type by name and return a queryset
     of all its instances.
@@ -188,6 +192,12 @@ def custom_objects_filter(type_name):
     Example::
 
         {% for iface in 'ospf_interface' | custom_objects %}
+
+    Marked with @pass_context (unused beyond the signature) so Jinja treats
+    this as context-dependent and never constant-folds a call whose argument
+    is a string literal -- which would otherwise resolve the Custom Object
+    Type (and run a database query) once at template compile time instead of
+    at render time.
     """
     cot = _resolve_custom_object_type(type_name)
     if cot is None:

--- a/netbox_custom_objects/tests/test_jinja_integration.py
+++ b/netbox_custom_objects/tests/test_jinja_integration.py
@@ -1,0 +1,153 @@
+"""
+Tests for the Jinja config-template integration (jinja_env.py + PluginConfig hooks).
+
+The custom_objects filter and CustomObjectsNamespace are pure plugin-side code and
+are always tested directly, regardless of NetBox version. End-to-end tests that
+depend on NetBox actually invoking these hooks (added in NetBox 4.7 — see
+netbox-community/netbox#22363, later renamed by #22436) are skipped on older
+NetBox, detected via the same registry check performed by
+CustomObjectsPluginConfig.ready().
+"""
+from django.apps import apps as django_apps
+from django.test import TestCase
+
+from netbox_custom_objects import CustomObjectsPluginConfig
+from netbox_custom_objects.jinja_env import CustomObjectsNamespace, custom_objects_filter
+
+from .base import CustomObjectsTestCase
+
+
+def _jinja_hooks_available():
+    """True if this NetBox install actually registered the custom_objects filter.
+
+    Mirrors the check in CustomObjectsPluginConfig.ready(): on NetBox < 4.7, the
+    jinja_filters plugin resource doesn't exist, so ready() never registers
+    anything under that key.
+    """
+    from netbox.registry import registry
+    return 'custom_objects' in registry.get('plugins', {}).get('jinja_filters', {})
+
+
+class CustomObjectsFilterTestCase(CustomObjectsTestCase, TestCase):
+    """Tests for custom_objects_filter() directly (no NetBox hook dependency)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.cot = cls.create_custom_object_type(name='j2widget', slug='j2-widget')
+        cls.create_custom_object_type_field(
+            cls.cot, name='label', label='Label', type='text', primary=True, required=True,
+        )
+
+    def test_returns_queryset_for_known_type(self):
+        model = self.cot.get_model()
+        model.objects.create(label='alpha')
+        model.objects.create(label='beta')
+        result = custom_objects_filter('j2widget')
+        self.assertEqual(result.count(), 2)
+
+    def test_returns_empty_for_unknown_type(self):
+        result = custom_objects_filter('nonexistent_type')
+        self.assertEqual(list(result), [])
+
+
+class CustomObjectsNamespaceTestCase(CustomObjectsTestCase, TestCase):
+    """Tests for CustomObjectsNamespace directly (no NetBox hook dependency)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.cot = cls.create_custom_object_type(name='j2widget', slug='j2-widget')
+        cls.create_custom_object_type_field(
+            cls.cot, name='label', label='Label', type='text', primary=True, required=True,
+        )
+
+    def test_resolves_by_name_to_model_manager(self):
+        ns = CustomObjectsNamespace()
+        manager = ns.j2widget
+        self.assertIs(manager.model, self.cot.get_model())
+
+    def test_manager_supports_filter(self):
+        model = self.cot.get_model()
+        model.objects.create(label='alpha')
+        model.objects.create(label='beta')
+        ns = CustomObjectsNamespace()
+        self.assertEqual(ns.j2widget.filter(label='alpha').count(), 1)
+
+    def test_raises_attribute_error_for_unknown_name(self):
+        ns = CustomObjectsNamespace()
+        with self.assertRaises(AttributeError):
+            _ = ns.no_such_type
+
+    def test_does_not_intercept_dunder_attributes(self):
+        """Internal/dunder lookups (e.g. by copy.deepcopy) must not trigger a DB query."""
+        ns = CustomObjectsNamespace()
+        with self.assertRaises(AttributeError):
+            _ = ns.__deepcopy__
+
+
+class PluginConfigJinjaHooksTestCase(CustomObjectsTestCase, TestCase):
+    """Tests for CustomObjectsPluginConfig.get_jinja_context() directly."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.cot = cls.create_custom_object_type(name='j2widget', slug='j2-widget')
+        cls.create_custom_object_type_field(
+            cls.cot, name='label', label='Label', type='text', primary=True, required=True,
+        )
+
+    def test_get_jinja_context_returns_custom_objects_namespace(self):
+        plugin_config = django_apps.get_app_config('netbox_custom_objects')
+        self.assertIsInstance(plugin_config, CustomObjectsPluginConfig)
+        ctx = plugin_config.get_jinja_context()
+        self.assertIn('custom_objects', ctx)
+        self.assertIsInstance(ctx['custom_objects'], CustomObjectsNamespace)
+
+    def test_get_jinja_context_namespace_resolves_live_data(self):
+        model = self.cot.get_model()
+        model.objects.create(label='gamma')
+        plugin_config = django_apps.get_app_config('netbox_custom_objects')
+        ctx = plugin_config.get_jinja_context()
+        self.assertEqual(ctx['custom_objects'].j2widget.count(), 1)
+
+
+class JinjaHookIntegrationTestCase(CustomObjectsTestCase, TestCase):
+    """
+    End-to-end tests exercising the actual NetBox render pipeline. Skipped on
+    NetBox versions that don't expose the jinja_filters / get_jinja_context hooks.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.cot = cls.create_custom_object_type(name='j2widget', slug='j2-widget')
+        cls.create_custom_object_type_field(
+            cls.cot, name='label', label='Label', type='text', primary=True, required=True,
+        )
+
+    def setUp(self):
+        super().setUp()
+        if not _jinja_hooks_available():
+            self.skipTest(
+                'NetBox Jinja config template hooks (jinja_filters / get_jinja_context) '
+                'are not available in this NetBox version; requires NetBox 4.7+.'
+            )
+
+    def test_filter_syntax_available_in_render_jinja2(self):
+        from utilities.jinja2 import render_jinja2
+        model = self.cot.get_model()
+        model.objects.create(label='alpha')
+        result = render_jinja2("{{ 'j2widget' | custom_objects | list | length }}", {})
+        self.assertEqual(result, '1')
+
+    def test_context_namespace_available_in_config_template_render(self):
+        from extras.models import ConfigTemplate
+        model = self.cot.get_model()
+        model.objects.create(label='alpha')
+        tmpl = ConfigTemplate(
+            name='test-j2',
+            template_code='{{ custom_objects.j2widget.all() | list | length }}',
+        )
+        self.assertEqual(tmpl.render(), '1')
+
+    def test_unknown_type_name_in_filter_syntax_renders_empty(self):
+        from utilities.jinja2 import render_jinja2
+        result = render_jinja2("{{ 'no_such_type' | custom_objects | list | length }}", {})
+        self.assertEqual(result, '0')

--- a/netbox_custom_objects/tests/test_jinja_integration.py
+++ b/netbox_custom_objects/tests/test_jinja_integration.py
@@ -8,11 +8,14 @@ netbox-community/netbox#22363, later renamed by #22436) are skipped on older
 NetBox, detected via the same registry check performed by
 CustomObjectsPluginConfig.ready().
 """
-from django.apps import apps as django_apps
-from django.test import TestCase
+from unittest.mock import patch
 
-from netbox_custom_objects import CustomObjectsPluginConfig
+from django.apps import apps as django_apps
+from django.test import SimpleTestCase, TestCase
+
+from netbox_custom_objects import CustomObjectsPluginConfig, jinja_env
 from netbox_custom_objects.jinja_env import CustomObjectsNamespace, EmptyCustomObjectsQuerySet, custom_objects_filter
+from netbox_custom_objects.models import CustomObjectType
 
 from .base import CustomObjectsTestCase
 
@@ -26,6 +29,49 @@ def _jinja_hooks_available():
     """
     from netbox.registry import registry
     return 'custom_objects' in registry.get('plugins', {}).get('jinja_filters', {})
+
+
+class EmptyCustomObjectsQuerySetTestCase(SimpleTestCase):
+    """Tests for EmptyCustomObjectsQuerySet's chainable no-op interface directly."""
+
+    def test_read_methods_are_chainable_and_stay_empty(self):
+        qs = EmptyCustomObjectsQuerySet()
+        chained = (
+            qs.filter(x=1).exclude(y=2).all().none().order_by('x')
+            .values('x').values_list('x').select_related('x')
+            .prefetch_related('x').distinct().annotate(x=1)
+        )
+        self.assertIsInstance(chained, EmptyCustomObjectsQuerySet)
+        self.assertEqual(list(chained), [])
+
+    def test_slicing_returns_self(self):
+        qs = EmptyCustomObjectsQuerySet()
+        self.assertIsInstance(qs[:5], EmptyCustomObjectsQuerySet)
+
+    def test_integer_index_raises_index_error(self):
+        qs = EmptyCustomObjectsQuerySet()
+        with self.assertRaises(IndexError):
+            _ = qs[0]
+
+    def test_get_raises_lookup_error(self):
+        qs = EmptyCustomObjectsQuerySet()
+        with self.assertRaises(LookupError):
+            qs.get(x=1)
+
+    def test_first_and_last_return_none(self):
+        qs = EmptyCustomObjectsQuerySet()
+        self.assertIsNone(qs.first())
+        self.assertIsNone(qs.last())
+
+    def test_count_and_exists(self):
+        qs = EmptyCustomObjectsQuerySet()
+        self.assertEqual(qs.count(), 0)
+        self.assertFalse(qs.exists())
+
+    def test_len_and_bool(self):
+        qs = EmptyCustomObjectsQuerySet()
+        self.assertEqual(len(qs), 0)
+        self.assertFalse(qs)
 
 
 class CustomObjectsFilterTestCase(CustomObjectsTestCase, TestCase):
@@ -54,6 +100,21 @@ class CustomObjectsFilterTestCase(CustomObjectsTestCase, TestCase):
         """A template that chains .filter()/.all() onto an unresolved name must not crash."""
         result = custom_objects_filter('nonexistent_type')
         self.assertEqual(list(result.filter(label='x').all().exclude(label='y')), [])
+
+    def test_unknown_name_warning_logged_once_per_process(self):
+        """
+        A typo'd type name rendered repeatedly (e.g. across a bulk device config
+        export) must log its warning once, not once per lookup.
+        """
+        unique_name = 'warn_once_filter_type'
+        jinja_env._warned_unknown_names.discard(unique_name)
+        self.addCleanup(jinja_env._warned_unknown_names.discard, unique_name)
+
+        with patch.object(jinja_env.logger, 'warning') as mock_warning:
+            custom_objects_filter(unique_name)
+            custom_objects_filter(unique_name)
+            custom_objects_filter(unique_name)
+        self.assertEqual(mock_warning.call_count, 1)
 
 
 class CustomObjectsNamespaceTestCase(CustomObjectsTestCase, TestCase):
@@ -95,6 +156,38 @@ class CustomObjectsNamespaceTestCase(CustomObjectsTestCase, TestCase):
         ns = CustomObjectsNamespace()
         with self.assertRaises(AttributeError):
             _ = ns.__deepcopy__
+
+    def test_repeated_access_to_same_name_is_cached_within_a_render(self):
+        """
+        A template referencing custom_objects.j2widget multiple times in one render
+        must resolve the Custom Object Type once, not once per reference.
+        """
+        ns = CustomObjectsNamespace()
+        with patch.object(CustomObjectType.objects, 'get', wraps=CustomObjectType.objects.get) as mock_get:
+            ns.j2widget
+            ns.j2widget
+            ns.j2widget
+        self.assertEqual(mock_get.call_count, 1)
+
+    def test_cache_is_not_shared_across_namespace_instances(self):
+        """Caching is per-render (per CustomObjectsNamespace instance), not global."""
+        CustomObjectsNamespace().j2widget
+        with patch.object(CustomObjectType.objects, 'get', wraps=CustomObjectType.objects.get) as mock_get:
+            CustomObjectsNamespace().j2widget
+        self.assertEqual(mock_get.call_count, 1)
+
+    def test_unknown_name_warning_logged_once_per_process(self):
+        """Repeated access to the same unresolved name must log its warning once."""
+        unique_name = 'warn_once_namespace_type'
+        jinja_env._warned_unknown_names.discard(unique_name)
+        self.addCleanup(jinja_env._warned_unknown_names.discard, unique_name)
+
+        ns = CustomObjectsNamespace()
+        with patch.object(jinja_env.logger, 'warning') as mock_warning:
+            getattr(ns, unique_name)
+            # A fresh namespace (new render) still shares the process-level warned set.
+            getattr(CustomObjectsNamespace(), unique_name)
+        self.assertEqual(mock_warning.call_count, 1)
 
 
 class PluginConfigJinjaHooksTestCase(CustomObjectsTestCase, TestCase):

--- a/netbox_custom_objects/tests/test_jinja_integration.py
+++ b/netbox_custom_objects/tests/test_jinja_integration.py
@@ -10,6 +10,7 @@ CustomObjectsPluginConfig.ready().
 """
 from unittest.mock import patch
 
+import jinja2
 from django.apps import apps as django_apps
 from django.test import SimpleTestCase, TestCase
 
@@ -88,17 +89,19 @@ class CustomObjectsFilterTestCase(CustomObjectsTestCase, TestCase):
         model = self.cot.get_model()
         model.objects.create(label='alpha')
         model.objects.create(label='beta')
-        result = custom_objects_filter('j2widget')
+        # custom_objects_filter is @pass_context; the context argument is unused, so any
+        # value (None, here) is fine when calling it directly rather than through Jinja.
+        result = custom_objects_filter(None, 'j2widget')
         self.assertEqual(result.count(), 2)
 
     def test_returns_empty_for_unknown_type(self):
-        result = custom_objects_filter('nonexistent_type')
+        result = custom_objects_filter(None, 'nonexistent_type')
         self.assertIsInstance(result, EmptyCustomObjectsQuerySet)
         self.assertEqual(list(result), [])
 
     def test_unknown_type_result_tolerates_further_chaining(self):
         """A template that chains .filter()/.all() onto an unresolved name must not crash."""
-        result = custom_objects_filter('nonexistent_type')
+        result = custom_objects_filter(None, 'nonexistent_type')
         self.assertEqual(list(result.filter(label='x').all().exclude(label='y')), [])
 
     def test_unknown_name_warning_logged_once_per_process(self):
@@ -111,9 +114,9 @@ class CustomObjectsFilterTestCase(CustomObjectsTestCase, TestCase):
         self.addCleanup(jinja_env._warned_unknown_names.discard, unique_name)
 
         with patch.object(jinja_env.logger, 'warning') as mock_warning:
-            custom_objects_filter(unique_name)
-            custom_objects_filter(unique_name)
-            custom_objects_filter(unique_name)
+            custom_objects_filter(None, unique_name)
+            custom_objects_filter(None, unique_name)
+            custom_objects_filter(None, unique_name)
         self.assertEqual(mock_warning.call_count, 1)
 
 
@@ -138,6 +141,25 @@ class CustomObjectsNamespaceTestCase(CustomObjectsTestCase, TestCase):
         model.objects.create(label='beta')
         ns = CustomObjectsNamespace()
         self.assertEqual(ns.j2widget.filter(label='alpha').count(), 1)
+
+    def test_bracket_notation_resolves_leading_digit_type_name(self):
+        """
+        A type name may begin with a digit, which isn't valid Jinja dot-notation
+        (custom_objects.123widget). Bracket notation compiles to Jinja's own
+        getitem-then-getattr fallback (not Python's __getitem__, which
+        CustomObjectsNamespace doesn't implement), so it must be exercised
+        through an actual Jinja render rather than by subscripting the
+        namespace object directly in Python.
+        """
+        cot = self.create_custom_object_type(name='123widget', slug='123-widget')
+        self.create_custom_object_type_field(
+            cot, name='label', label='Label', type='text', primary=True, required=True,
+        )
+        model = cot.get_model()
+        model.objects.create(label='alpha')
+        ns = CustomObjectsNamespace()
+        template = jinja2.Environment().from_string("{{ custom_objects['123widget'].filter(label='alpha').count() }}")
+        self.assertEqual(template.render(custom_objects=ns), '1')
 
     def test_unknown_name_returns_empty_queryset_stand_in(self):
         """An unresolved name must not raise -- matches custom_objects_filter()'s behavior."""
@@ -243,6 +265,22 @@ class JinjaHookIntegrationTestCase(CustomObjectsTestCase, TestCase):
         result = render_jinja2("{{ 'j2widget' | custom_objects | list | length }}", {})
         self.assertEqual(result, '1')
 
+    def test_filter_syntax_resolves_only_once_when_compiled_and_rendered(self):
+        """
+        Regression test: a bare string literal argument (as in the documented loop
+        syntax) is a compile-time constant. Without @pass_context, Jinja's optimizer
+        can constant-fold the filter call, resolving the Custom Object Type (and
+        querying the database) at template compile time in addition to render time.
+        """
+        from utilities.jinja2 import render_jinja2
+        model = self.cot.get_model()
+        model.objects.create(label='alpha')
+        template_code = "{% for obj in 'j2widget' | custom_objects %}{{ obj.label }}{% endfor %}"
+        with patch.object(CustomObjectType.objects, 'get', wraps=CustomObjectType.objects.get) as mock_get:
+            result = render_jinja2(template_code, {})
+        self.assertEqual(result, 'alpha')
+        self.assertEqual(mock_get.call_count, 1)
+
     def test_context_namespace_available_in_config_template_render(self):
         from extras.models import ConfigTemplate
         model = self.cot.get_model()
@@ -269,3 +307,22 @@ class JinjaHookIntegrationTestCase(CustomObjectsTestCase, TestCase):
             template_code='{{ custom_objects.no_such_type.filter(label="x") | list | length }}',
         )
         self.assertEqual(tmpl.render(), '0')
+
+    def test_bracket_notation_in_config_template_render(self):
+        """
+        A type name beginning with a digit can't be accessed via dot-notation
+        (custom_objects.123widget is not valid Jinja syntax); the documented
+        workaround is bracket notation.
+        """
+        from extras.models import ConfigTemplate
+        cot = self.create_custom_object_type(name='123widget', slug='123-widget')
+        self.create_custom_object_type_field(
+            cot, name='label', label='Label', type='text', primary=True, required=True,
+        )
+        model = cot.get_model()
+        model.objects.create(label='alpha')
+        tmpl = ConfigTemplate(
+            name='test-j2-leading-digit',
+            template_code="{{ custom_objects['123widget'].filter(label='alpha') | list | length }}",
+        )
+        self.assertEqual(tmpl.render(), '1')

--- a/netbox_custom_objects/tests/test_jinja_integration.py
+++ b/netbox_custom_objects/tests/test_jinja_integration.py
@@ -12,7 +12,7 @@ from django.apps import apps as django_apps
 from django.test import TestCase
 
 from netbox_custom_objects import CustomObjectsPluginConfig
-from netbox_custom_objects.jinja_env import CustomObjectsNamespace, custom_objects_filter
+from netbox_custom_objects.jinja_env import CustomObjectsNamespace, EmptyCustomObjectsQuerySet, custom_objects_filter
 
 from .base import CustomObjectsTestCase
 
@@ -47,7 +47,13 @@ class CustomObjectsFilterTestCase(CustomObjectsTestCase, TestCase):
 
     def test_returns_empty_for_unknown_type(self):
         result = custom_objects_filter('nonexistent_type')
+        self.assertIsInstance(result, EmptyCustomObjectsQuerySet)
         self.assertEqual(list(result), [])
+
+    def test_unknown_type_result_tolerates_further_chaining(self):
+        """A template that chains .filter()/.all() onto an unresolved name must not crash."""
+        result = custom_objects_filter('nonexistent_type')
+        self.assertEqual(list(result.filter(label='x').all().exclude(label='y')), [])
 
 
 class CustomObjectsNamespaceTestCase(CustomObjectsTestCase, TestCase):
@@ -72,10 +78,17 @@ class CustomObjectsNamespaceTestCase(CustomObjectsTestCase, TestCase):
         ns = CustomObjectsNamespace()
         self.assertEqual(ns.j2widget.filter(label='alpha').count(), 1)
 
-    def test_raises_attribute_error_for_unknown_name(self):
+    def test_unknown_name_returns_empty_queryset_stand_in(self):
+        """An unresolved name must not raise -- matches custom_objects_filter()'s behavior."""
         ns = CustomObjectsNamespace()
-        with self.assertRaises(AttributeError):
-            _ = ns.no_such_type
+        result = ns.no_such_type
+        self.assertIsInstance(result, EmptyCustomObjectsQuerySet)
+        self.assertEqual(list(result), [])
+
+    def test_unknown_name_result_tolerates_further_chaining(self):
+        """A template that chains .filter(device=device) onto an unresolved name must not crash."""
+        ns = CustomObjectsNamespace()
+        self.assertEqual(list(ns.no_such_type.filter(device='anything')), [])
 
     def test_does_not_intercept_dunder_attributes(self):
         """Internal/dunder lookups (e.g. by copy.deepcopy) must not trigger a DB query."""
@@ -151,3 +164,15 @@ class JinjaHookIntegrationTestCase(CustomObjectsTestCase, TestCase):
         from utilities.jinja2 import render_jinja2
         result = render_jinja2("{{ 'no_such_type' | custom_objects | list | length }}", {})
         self.assertEqual(result, '0')
+
+    def test_unknown_type_name_in_attribute_syntax_renders_empty(self):
+        """
+        A template chaining .filter() onto an unresolved attribute-style name (as in
+        every documented example) must render no rows, not raise UndefinedError.
+        """
+        from extras.models import ConfigTemplate
+        tmpl = ConfigTemplate(
+            name='test-j2-unknown',
+            template_code='{{ custom_objects.no_such_type.filter(label="x") | list | length }}',
+        )
+        self.assertEqual(tmpl.render(), '0')

--- a/netbox_custom_objects/tests/test_jinja_integration.py
+++ b/netbox_custom_objects/tests/test_jinja_integration.py
@@ -144,12 +144,8 @@ class CustomObjectsNamespaceTestCase(CustomObjectsTestCase, TestCase):
 
     def test_bracket_notation_resolves_leading_digit_type_name(self):
         """
-        A type name may begin with a digit, which isn't valid Jinja dot-notation
-        (custom_objects.123widget). Bracket notation compiles to Jinja's own
-        getitem-then-getattr fallback (not Python's __getitem__, which
-        CustomObjectsNamespace doesn't implement), so it must be exercised
-        through an actual Jinja render rather than by subscripting the
-        namespace object directly in Python.
+        Bracket notation is Jinja's own getitem-then-getattr fallback, not
+        Python's __getitem__, so it must go through an actual Jinja render.
         """
         cot = self.create_custom_object_type(name='123widget', slug='123-widget')
         self.create_custom_object_type_field(
@@ -267,10 +263,8 @@ class JinjaHookIntegrationTestCase(CustomObjectsTestCase, TestCase):
 
     def test_filter_syntax_resolves_only_once_when_compiled_and_rendered(self):
         """
-        Regression test: a bare string literal argument (as in the documented loop
-        syntax) is a compile-time constant. Without @pass_context, Jinja's optimizer
-        can constant-fold the filter call, resolving the Custom Object Type (and
-        querying the database) at template compile time in addition to render time.
+        Without @pass_context, Jinja can constant-fold the filter call at
+        compile time, resolving the type an extra time before render.
         """
         from utilities.jinja2 import render_jinja2
         model = self.cot.get_model()
@@ -309,11 +303,7 @@ class JinjaHookIntegrationTestCase(CustomObjectsTestCase, TestCase):
         self.assertEqual(tmpl.render(), '0')
 
     def test_bracket_notation_in_config_template_render(self):
-        """
-        A type name beginning with a digit can't be accessed via dot-notation
-        (custom_objects.123widget is not valid Jinja syntax); the documented
-        workaround is bracket notation.
-        """
+        """A leading-digit type name isn't valid dot-notation; use bracket notation."""
         from extras.models import ConfigTemplate
         cot = self.create_custom_object_type(name='123widget', slug='123-widget')
         self.create_custom_object_type_field(


### PR DESCRIPTION
### Closes: #549 

## Summary

Custom Objects can now be referenced directly from NetBox device config/export templates, via two equivalent access patterns, both resolving the Custom Object Type by name at render time:

```jinja2
{% for iface in custom_objects.ospf_interface.filter(device=device) %}
  interface {{ iface.name }}
    ip ospf area {{ iface.area }}
{% endfor %}
```

```jinja2
{% for iface in 'ospf_interface' | custom_objects %}
  interface {{ iface.name }}
{% endfor %}
```

## Requirements and graceful degradation

This is built on the `jinja_filters` plugin resource and `PluginConfig.get_jinja_context()` hook added to NetBox core by netbox-community/netbox#22363 (spelled `jinja2_*` at merge time, later renamed to drop the "2" by netbox-community/netbox#22436). **Both hooks require NetBox 4.7+.**

On NetBox < 4.7, these hooks simply don't exist, so core never calls into this plugin's `jinja_filters`/`get_jinja_context()` — no error, no crash, `custom_objects` is just unavailable in templates. A single INFO message is logged at plugin startup so operators have an actionable explanation (checked via `registry['plugins']['jinja_filters']` after `super().ready()`, which reflects whether core's hook actually registered anything).

No `max_version` bump: not currently a blocker (the `feature` branch's currently-reported NetBox version is still 4.6.x), and this project handles version-ceiling bumps as their own dedicated PRs rather than bundling them into feature work.

## Design notes

- Both access patterns share the same by-name resolution logic. The attribute-style form (`custom_objects.<name>`) returns the model's default manager (`.filter()`, `.all()`, etc.); the filter form (`'<name>' | custom_objects`) returns a queryset of all instances.
- An unknown type name is handled identically by both forms: a warning is logged (once per name, per process — not once per lookup, so a typo'd template rendered against many objects doesn't spam the log), and the reference resolves to an `EmptyCustomObjectsQuerySet` stand-in rather than raising. That stand-in covers the read-only QuerySet surface templates realistically chain onto it — `.filter()`, `.exclude()`, `.all()`, `.order_by()`, `.values()`, `.values_list()`, `.select_related()`, `.prefetch_related()`, `.distinct()`, `.annotate()`, slicing, `.get()` (still raises, matching real `QuerySet.get()` semantics) — so templates keep rendering no rows regardless of how the result is chained.
- `CustomObjectsNamespace` caches resolved names per-instance, so a template referencing the same type multiple times in one render issues one lookup, not one per reference. A fresh instance is created per render (via `get_jinja_context()`), so this doesn't go stale across renders.
- Continues paused work from branch `jinja2-config-template-support` (blocked on the core PR landing and FR feedback), updated for the subsequent hook rename.

## Tests

New `netbox_custom_objects/tests/test_jinja_integration.py` (25 tests):
- Direct unit tests for `EmptyCustomObjectsQuerySet`, the filter function, and `CustomObjectsNamespace` (always run, independent of NetBox version) — including chaining tolerance, per-render caching, and warn-once-per-process behavior
- `get_jinja_context()` tests (always run)
- End-to-end tests exercising the real `render_jinja2()` / `ConfigTemplate.render()` pipeline, which skip cleanly with a clear reason when NetBox doesn't expose the hooks, including unknown-name behavior for both access patterns

Verified locally against both:
- NetBox `main` (no hooks): 21/25 pass, 4 end-to-end tests skip as expected
- NetBox `feature` (hooks present): 25/25 pass, confirming the full integration actually works end-to-end (not just the degradation path)

`ruff check` passes.

## Docs

Added a "Jinja Config Templates" section to `docs/index.md`, alongside the existing Config Context section.
