### PR TITLE
Fix bulk import failing on required Hidden/Read-only fields

### DIFF
--- a/netbox_custom_objects/tests/test_views.py
+++ b/netbox_custom_objects/tests/test_views.py
@@ -453,6 +453,49 @@ class CustomObjectViewTestCase(
         """Regression #620: CustomObjectBulkDeleteView.get_queryset()."""
         self._assert_get_queryset_does_not_full_scan(views.CustomObjectBulkDeleteView)
 
+    def test_bulk_import_omits_hidden_required_field_from_form(self):
+        """Regression #626: a Required + Hidden field must not break bulk import.
+
+        Before the fix, CustomObjectBulkImportView.get_model_form() included every
+        field in the import form and disabled the ones with ui_editable != YES
+        (mirroring the regular edit form). A disabled Django form field ignores
+        submitted data, so a required-but-hidden field always failed validation
+        with "This field is required" even though the imported row supplied a
+        value. The fix omits such fields from the import form entirely, matching
+        core NetBox's own CSV import precedent (NetBoxModelImportForm._get_custom_fields).
+
+        Uses its own dedicated Custom Object Type rather than the class-level
+        self.custom_object_type: adding a field bumps that type's model-generation
+        cache, and reusing the shared fixture here was observed to leak a stale
+        dynamic-model registry entry into other tests in this class.
+        """
+        cot = self.create_custom_object_type(name='HiddenFieldImportTest', slug='hidden-field-import-test')
+        self.create_custom_object_type_field(
+            cot, name='name', label='Name', type='text', primary=True,
+        )
+        self.create_custom_object_type_field(
+            cot,
+            name='identifier',
+            label='Identifier',
+            type='text',
+            required=True,
+            ui_editable='hidden',
+        )
+
+        request = RequestFactory().post('/')
+        request.user = self.user
+
+        view = views.CustomObjectBulkImportView()
+        view.setup(request, custom_object_type=cot.slug)
+
+        # The hidden required field must not appear in the import form at all...
+        self.assertNotIn('identifier', view.model_form.base_fields)
+
+        # ...so a row that omits it (as any importer must, since it can't be set) is valid.
+        model = view.queryset.model
+        form = view.model_form(data={'name': 'Imported Instance'}, instance=model())
+        self.assertTrue(form.is_valid(), form.errors)
+
     def test_bulk_edit_select_all_respects_full_queryset(self):
         """Regression #380: 'select all matching query' must edit all objects, not just the current page.
 

--- a/netbox_custom_objects/tests/test_views.py
+++ b/netbox_custom_objects/tests/test_views.py
@@ -486,6 +486,40 @@ class CustomObjectViewTestCase(
         form = view.model_form(data={'name': 'Imported Instance'}, instance=model())
         self.assertTrue(form.is_valid(), form.errors)
 
+    def test_bulk_import_silently_ignores_value_for_hidden_field(self):
+        """
+        Regression #626: matches the original bug report's payload (a value supplied
+        for the hidden field). It must not error, and the value must be silently
+        dropped rather than written, matching core NetBox's own CSV import behavior.
+        """
+        cot = self.create_custom_object_type(name='HiddenFieldImportTest2', slug='hidden-field-import-test-2')
+        self.create_custom_object_type_field(
+            cot, name='name', label='Name', type='text', primary=True,
+        )
+        self.create_custom_object_type_field(
+            cot,
+            name='identifier',
+            label='Identifier',
+            type='text',
+            required=True,
+            ui_editable='hidden',
+        )
+
+        request = RequestFactory().post('/')
+        request.user = self.user
+
+        view = views.CustomObjectBulkImportView()
+        view.setup(request, custom_object_type=cot.slug)
+
+        model = view.queryset.model
+        form = view.model_form(
+            data={'name': 'Imported Instance', 'identifier': '12345'}, instance=model(),
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+
+        instance = form.save()
+        self.assertIsNone(instance.identifier)
+
     def test_bulk_edit_select_all_respects_full_queryset(self):
         """Regression #380: 'select all matching query' must edit all objects, not just the current page.
 

--- a/netbox_custom_objects/tests/test_views.py
+++ b/netbox_custom_objects/tests/test_views.py
@@ -454,20 +454,10 @@ class CustomObjectViewTestCase(
         self._assert_get_queryset_does_not_full_scan(views.CustomObjectBulkDeleteView)
 
     def test_bulk_import_omits_hidden_required_field_from_form(self):
-        """Regression #626: a Required + Hidden field must not break bulk import.
-
-        Before the fix, CustomObjectBulkImportView.get_model_form() included every
-        field in the import form and disabled the ones with ui_editable != YES
-        (mirroring the regular edit form). A disabled Django form field ignores
-        submitted data, so a required-but-hidden field always failed validation
-        with "This field is required" even though the imported row supplied a
-        value. The fix omits such fields from the import form entirely, matching
-        core NetBox's own CSV import precedent (NetBoxModelImportForm._get_custom_fields).
-
-        Uses its own dedicated Custom Object Type rather than the class-level
-        self.custom_object_type: adding a field bumps that type's model-generation
-        cache, and reusing the shared fixture here was observed to leak a stale
-        dynamic-model registry entry into other tests in this class.
+        """
+        Regression #626: a Required+Hidden field must be omitted from the bulk import
+        form (not disabled, which ignores submitted data and always fails "This field
+        is required"). Own COT used to avoid leaking model-cache state into other tests.
         """
         cot = self.create_custom_object_type(name='HiddenFieldImportTest', slug='hidden-field-import-test')
         self.create_custom_object_type_field(

--- a/netbox_custom_objects/views.py
+++ b/netbox_custom_objects/views.py
@@ -1413,8 +1413,9 @@ class CustomObjectBulkImportView(generic.BulkImportView):
         # Match core's CSV import (NetBoxModelImportForm._get_custom_fields): a
         # non-editable field is omitted from the import form, not disabled. Must
         # also go in Meta.exclude, since fields="__all__" auto-generates one otherwise.
+        fields = list(self.custom_object_type.fields.all())
         non_editable_field_names = tuple(
-            field.name for field in self.custom_object_type.fields.all()
+            field.name for field in fields
             if field.ui_editable != CustomFieldUIEditableChoices.YES
         )
 
@@ -1433,7 +1434,7 @@ class CustomObjectBulkImportView(generic.BulkImportView):
             "__module__": "database.forms",
         }
 
-        for field in self.custom_object_type.fields.all():
+        for field in fields:
             if field.name in non_editable_field_names:
                 continue
             field_type = field_types.FIELD_TYPE_CLASS[field.type]()

--- a/netbox_custom_objects/views.py
+++ b/netbox_custom_objects/views.py
@@ -1410,13 +1410,9 @@ class CustomObjectBulkImportView(generic.BulkImportView):
         return model.objects.all()
 
     def get_model_form(self, queryset):
-        # Match core NetBox's CSV import behavior (NetBoxModelImportForm._get_custom_fields):
-        # a field that isn't editable in the UI (hidden or read-only) is omitted from the
-        # import form entirely, rather than included and disabled, so it doesn't spuriously
-        # fail "this field is required" for a value the form never accepts in the first place.
-        # Since Custom Object fields are real model fields (unlike core's JSON-stored custom
-        # fields), fields="__all__" alone would still auto-generate a field for any name left
-        # out of attrs -- they must also be listed in Meta.exclude to actually drop them.
+        # Match core's CSV import (NetBoxModelImportForm._get_custom_fields): a
+        # non-editable field is omitted from the import form, not disabled. Must
+        # also go in Meta.exclude, since fields="__all__" auto-generates one otherwise.
         non_editable_field_names = tuple(
             field.name for field in self.custom_object_type.fields.all()
             if field.ui_editable != CustomFieldUIEditableChoices.YES

--- a/netbox_custom_objects/views.py
+++ b/netbox_custom_objects/views.py
@@ -16,7 +16,7 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 from utilities.exceptions import AbortRequest, PermissionsViolation
 from django.views.generic import View
-from extras.choices import CustomFieldUIVisibleChoices
+from extras.choices import CustomFieldUIEditableChoices, CustomFieldUIVisibleChoices
 from extras.forms import JournalEntryForm
 from extras.models import ConfigContext, JournalEntry
 from extras.tables import JournalEntryTable
@@ -1410,12 +1410,25 @@ class CustomObjectBulkImportView(generic.BulkImportView):
         return model.objects.all()
 
     def get_model_form(self, queryset):
+        # Match core NetBox's CSV import behavior (NetBoxModelImportForm._get_custom_fields):
+        # a field that isn't editable in the UI (hidden or read-only) is omitted from the
+        # import form entirely, rather than included and disabled, so it doesn't spuriously
+        # fail "this field is required" for a value the form never accepts in the first place.
+        # Since Custom Object fields are real model fields (unlike core's JSON-stored custom
+        # fields), fields="__all__" alone would still auto-generate a field for any name left
+        # out of attrs -- they must also be listed in Meta.exclude to actually drop them.
+        non_editable_field_names = tuple(
+            field.name for field in self.custom_object_type.fields.all()
+            if field.ui_editable != CustomFieldUIEditableChoices.YES
+        )
+
         meta = type(
             "Meta",
             (),
             {
                 "model": queryset.model,
                 "fields": "__all__",
+                "exclude": non_editable_field_names,
             },
         )
 
@@ -1425,6 +1438,8 @@ class CustomObjectBulkImportView(generic.BulkImportView):
         }
 
         for field in self.custom_object_type.fields.all():
+            if field.name in non_editable_field_names:
+                continue
             field_type = field_types.FIELD_TYPE_CLASS[field.type]()
             try:
                 attrs[field.name] = field_type.get_annotated_form_field(


### PR DESCRIPTION
## Summary

- `CustomObjectBulkImportView.get_model_form()` included every Custom Object Type Field in the import form and disabled the ones with `ui_editable != YES`, mirroring the regular edit form's behavior — but Django's `disabled=True` form fields ignore submitted data entirely. A `Required` + `Hidden` field therefore always failed bulk import with `This field is required`, even though the imported row supplied a value (the `for_csv_import=True` kwarg passed at the call site isn't a real parameter of `get_annotated_form_field()`, so it silently did nothing).
- Fix: omit non-editable (Hidden/Read-only) fields from the import form entirely, matching core NetBox's own CSV import precedent (`NetBoxModelImportForm._get_custom_fields`). Since Custom Object fields are real model columns (unlike core's JSON-stored custom fields), this also requires listing them in `Meta.exclude` — `fields="__all__"` alone still auto-generates a field for any model column left out of the form's declared attrs.

## Test plan

- [x] Added a regression test (`test_bulk_import_omits_hidden_required_field_from_form`) asserting the hidden field is absent from the import form and that a row omitting it validates successfully.
- [x] Verified via git-stash-based regression testing: the new test fails against the pre-fix code with the exact reported error shape, and passes after the fix.
- [x] Ran the full `test_views.py` module; only 4 pre-existing, unrelated failures remain (confirmed identical against unmodified `main` — a `netbox_branching` import-guard gap).
- [x] `ruff check` passes.

Closes #626
