### PR TITLE
Fixes: #625 - schema_id (and related bookkeeping fields) nulled by unrelated field edits

### DIFF
--- a/netbox_custom_objects/forms.py
+++ b/netbox_custom_objects/forms.py
@@ -248,6 +248,12 @@ class CustomObjectTypeFieldForm(CustomFieldForm):
     class Meta:
         model = CustomObjectTypeField
         fields = '__all__'
+        # deprecated/deprecated_since/scheduled_removal are set via the portable-schema
+        # import mechanism (or directly via the REST API), never through this form --
+        # excluded here so an unrelated edit doesn't silently reset them to their
+        # defaults. schema_id needs no entry: it's excluded automatically via the
+        # model field's editable=False.
+        exclude = ('deprecated', 'deprecated_since', 'scheduled_removal')
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/netbox_custom_objects/migrations/0018_alter_customobjecttypefield_schema_id.py
+++ b/netbox_custom_objects/migrations/0018_alter_customobjecttypefield_schema_id.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('netbox_custom_objects', '0017_customobjecttype_display_expression'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='customobjecttypefield',
+            name='schema_id',
+            field=models.PositiveIntegerField(blank=True, editable=False, null=True),
+        ),
+    ]

--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -2450,6 +2450,7 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
     schema_id = models.PositiveIntegerField(
         blank=True,
         null=True,
+        editable=False,
         verbose_name=_("schema ID"),
         help_text=_(
             "Stable numeric identifier for this field used during schema diffing. "

--- a/netbox_custom_objects/tests/test_api.py
+++ b/netbox_custom_objects/tests/test_api.py
@@ -1,6 +1,7 @@
 """
 Tests for API code paths.
 """
+import json
 import uuid
 from decimal import Decimal
 
@@ -1371,7 +1372,6 @@ class SchemaIdReadOnlyTest(CustomObjectsTestCase, TestCase):
 
     def test_schema_id_ignored_on_patch(self):
         """PATCHing schema_id must not change the stored value."""
-        import json
         field = self.create_custom_object_type_field(self.cot, name='gamma', type='text')
         original_id = field.schema_id
 
@@ -1393,7 +1393,6 @@ class SchemaIdReadOnlyTest(CustomObjectsTestCase, TestCase):
         via the REST API -- this is how the portable-schema import mechanism applies
         them. Unlike schema_id, they must NOT be silently ignored here.
         """
-        import json
         field = self.create_custom_object_type_field(self.cot, name='delta', type='text')
         self.assertFalse(field.deprecated)
 

--- a/netbox_custom_objects/tests/test_api.py
+++ b/netbox_custom_objects/tests/test_api.py
@@ -1386,6 +1386,30 @@ class SchemaIdReadOnlyTest(CustomObjectsTestCase, TestCase):
         field.refresh_from_db()
         self.assertEqual(field.schema_id, original_id)
 
+    def test_deprecation_fields_writable_on_patch(self):
+        """
+        Regression #625: deprecated/deprecated_since/scheduled_removal are excluded
+        from CustomObjectTypeFieldForm (the web edit form) but must remain writable
+        via the REST API -- this is how the portable-schema import mechanism applies
+        them. Unlike schema_id, they must NOT be silently ignored here.
+        """
+        import json
+        field = self.create_custom_object_type_field(self.cot, name='delta', type='text')
+        self.assertFalse(field.deprecated)
+
+        response = self.client.patch(
+            self._field_detail_url(field.pk),
+            json.dumps({'deprecated': True, 'deprecated_since': '1.0.0', 'scheduled_removal': '2.0.0'}),
+            content_type='application/json',
+            **self.header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        field.refresh_from_db()
+        self.assertTrue(field.deprecated)
+        self.assertEqual(field.deprecated_since, '1.0.0')
+        self.assertEqual(field.scheduled_removal, '2.0.0')
+
 
 # ---------------------------------------------------------------------------
 # CustomObjectLink UI panel — linked_custom_objects population

--- a/netbox_custom_objects/tests/test_forms.py
+++ b/netbox_custom_objects/tests/test_forms.py
@@ -7,7 +7,7 @@ from core.models import ObjectType
 from extras.choices import CustomFieldTypeChoices
 
 from netbox_custom_objects.forms import CustomObjectTypeFieldForm
-from netbox_custom_objects.models import CustomObjectType
+from netbox_custom_objects.models import CustomObjectType, CustomObjectTypeField
 
 from .base import CustomObjectsTestCase
 
@@ -228,3 +228,65 @@ class PolymorphicRelatedNameCollisionFormTestCase(CustomObjectsTestCase, TestCas
         validation."""
         form = self._make_polymorphic_object_form(related_name="co_safe_form_test_ref")
         self.assertTrue(form.is_valid(), form.errors)
+
+
+class SchemaBookkeepingFieldsPreservedOnEditTestCase(CustomObjectsTestCase, TestCase):
+    """
+    Regression #625: schema_id, deprecated, deprecated_since, and scheduled_removal
+    are set outside this form (auto-assigned on creation, or via the portable-schema
+    import mechanism) and are not rendered in any fieldset. An unrelated edit through
+    CustomObjectTypeFieldForm must not silently reset them.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.cot = CustomObjectType.objects.create(
+            name="SchemaBookkeepingTester",
+            slug="schema-bookkeeping-tester",
+            verbose_name_plural="Schema Bookkeeping Testers",
+        )
+
+    def test_editing_a_field_preserves_schema_id_and_deprecation_bookkeeping(self):
+        field = CustomObjectTypeField.objects.create(
+            custom_object_type=self.cot,
+            name="myfield",
+            label="My Field",
+            type=CustomFieldTypeChoices.TYPE_TEXT,
+            schema_id=7,
+            deprecated=True,
+            deprecated_since="1.0.0",
+            scheduled_removal="2.0.0",
+        )
+
+        data = {
+            "custom_object_type": self.cot.pk,
+            "name": "myfield",
+            "label": "My Field Renamed",
+            "type": CustomFieldTypeChoices.TYPE_TEXT,
+            "required": "",
+            "unique": "",
+            "primary": "",
+            "default": "",
+            "description": "",
+            "group_name": "",
+            "context": "default",
+            "search_weight": "1000",
+            "filter_logic": "loose",
+            "ui_visible": "hidden",
+            "ui_editable": "hidden",
+            "weight": "100",
+            "is_cloneable": "",
+        }
+        # Fetch fresh from the DB, as a real edit view does: CustomObjectTypeField.save()
+        # relies on ``self.original`` (populated only by from_db()) for schema-diffing.
+        field = CustomObjectTypeField.objects.get(pk=field.pk)
+        form = CustomObjectTypeFieldForm(data=data, instance=field)
+        self.assertTrue(form.is_valid(), form.errors)
+        saved = form.save()
+
+        saved.refresh_from_db()
+        self.assertEqual(saved.label, "My Field Renamed")
+        self.assertEqual(saved.schema_id, 7)
+        self.assertTrue(saved.deprecated)
+        self.assertEqual(saved.deprecated_since, "1.0.0")
+        self.assertEqual(saved.scheduled_removal, "2.0.0")


### PR DESCRIPTION
### Fixes: #625 

## Summary

- `CustomObjectTypeFieldForm.Meta.fields = '__all__'` pulled `schema_id` in as a real, writable form field, but it's never rendered in any of the form's fieldsets. The browser therefore never submits a value for it; Django reads the missing key as `None`, and `ModelForm._post_clean()` overwrites the existing `schema_id` with that `None` on every save — even when the user only changed an unrelated attribute like `label`.
- Fix: set `editable=False` on `schema_id`, matching its existing `read_only_fields` treatment in the REST API serializer (`CustomObjectTypeFieldSerializer`) and NetBox core's own convention for internal, system-managed model fields. Django's `ModelForm` machinery automatically drops non-editable fields from `Meta.fields = '__all__'`, so it's simply absent from the form and never touched.
- While investigating, found the identical bug pattern also affects `deprecated`, `deprecated_since`, and `scheduled_removal` on the same form — same root cause (never rendered in a fieldset, silently reset by an unrelated edit). These are excluded via `Meta.exclude` on the form instead of `editable=False` on the model, since they **are** meant to be writable through the REST API (set via the portable-schema import executor) and aren't declared as explicit serializer fields there — `editable=False` would have made DRF silently force them read-only in the API too, a real regression.

## Test plan

- [x] Added a regression test (`test_editing_a_field_preserves_schema_id_and_deprecation_bookkeeping`) that creates a field with pre-set `schema_id`/`deprecated`/`deprecated_since`/`scheduled_removal`, edits only its `label` via the form, and asserts all four survive unchanged.
- [x] Verified via git-stash-based regression testing: the new test fails against the pre-fix code with the exact reported symptom (`schema_id` becomes `None`), and passes after the fix.
- [x] Confirmed the REST API's write access to `deprecated`/`deprecated_since`/`scheduled_removal` is unaffected (they're not `editable=False` at the model level, only excluded from this one form).
- [x] Generated migration (`0018_alter_customobjecttypefield_schema_id`) for the `editable=False` change — a no-op at the DB level, but Django tracks it in migration state.
- [x] Ran the broader `test_forms`/`test_models`/`test_api` suites (223 tests); only 2 pre-existing, unrelated failures remain (`netbox_branching` import-guard gap, confirmed identical against unmodified `main` in earlier work this session).
- [x] `ruff check` passes.

Closes #625
