### PR TITLE
Fixes #628: `?id=` filter silently ignored on Custom Object REST API

### DIFF
--- a/netbox_custom_objects/filtersets.py
+++ b/netbox_custom_objects/filtersets.py
@@ -405,14 +405,15 @@ def get_filterset_class(model):
     """
     Create and return a filterset class for the given custom object model.
     """
-    # fields=[] disables auto-generation; all filters are added explicitly below
-    # via build_filter_for_field so there are no shadowed duplicates.
+    # id is the only base column filterable via Meta.fields auto-generation (matching
+    # core FilterSets); every other filter is added explicitly below via
+    # build_filter_for_field, so there are no shadowed duplicates.
     meta = type(
         "Meta",
         (),
         {
             "model": model,
-            "fields": [],
+            "fields": ["id"],
         },
     )
 

--- a/netbox_custom_objects/tests/test_api.py
+++ b/netbox_custom_objects/tests/test_api.py
@@ -2257,3 +2257,40 @@ class CoordinatesFieldAPITest(CustomObjectsTestCase, NetBoxTestCase):
         obj.refresh_from_db()
         self.assertIsNone(obj.location_latitude)
         self.assertIsNone(obj.location_longitude)
+
+
+class IdFilterAPITest(CustomObjectsTestCase, TestCase):
+    """
+    Regression #628: GET /api/plugins/custom-objects/<slug>/?id=<pk> returned every
+    object instead of just the matching one. Reproduces the exact reported steps: a
+    Custom Object Type with no fields at all, two instances, filtered by id.
+    """
+
+    def setUp(self):
+        super().setUp()
+        from netbox_custom_objects.models import CustomObjectType
+        self.cot = CustomObjectType.objects.create(name='IdFilterAPI', slug='id-filter-api')
+        self.model = self.cot.get_model()
+        token = create_token(self.user)
+        self.header = {'HTTP_AUTHORIZATION': f'Token {token}'}
+        self.client = APIClient()
+
+    def _list_url(self):
+        return reverse(
+            'plugins-api:netbox_custom_objects-api:customobject-list',
+            kwargs={'custom_object_type': self.cot.slug},
+        )
+
+    def test_filter_by_id_returns_only_matching_object(self):
+        obj1 = self.model.objects.create()
+        obj2 = self.model.objects.create()
+        perm = ObjectPermission(name='view-id-filter', actions=['view'])
+        perm.save()
+        perm.users.add(self.user)
+        perm.object_types.add(ObjectType.objects.get_for_model(self.model))
+
+        response = self.client.get(self._list_url(), {'id': obj1.pk}, **self.header)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = [r['id'] for r in response.data['results']]
+        self.assertEqual(ids, [obj1.pk])
+        self.assertNotIn(obj2.pk, ids)

--- a/netbox_custom_objects/tests/test_api.py
+++ b/netbox_custom_objects/tests/test_api.py
@@ -1894,6 +1894,22 @@ class OwnerAPITest(CustomObjectsTestCase, TestCase):
         self.assertIn(obj_x.pk, ids)
         self.assertNotIn(obj_y.pk, ids)
 
+    def test_filter_by_id(self):
+        """Regression #628: ?id=<pk> must return only the matching instance."""
+        obj_a = self.model.objects.create()
+        obj_b = self.model.objects.create()
+        self._add_perm('view', self.model)
+
+        response = self.client.get(
+            self._list_url(),
+            {'id': obj_a.pk},
+            **self.header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = [r['id'] for r in response.data['results']]
+        self.assertIn(obj_a.pk, ids)
+        self.assertNotIn(obj_b.pk, ids)
+
 
 class ConfigContextAPITest(CustomObjectsTestCase, TestCase):
     """REST API exposure of local_context_data for config-context-enabled types (#98)."""
@@ -2257,40 +2273,3 @@ class CoordinatesFieldAPITest(CustomObjectsTestCase, NetBoxTestCase):
         obj.refresh_from_db()
         self.assertIsNone(obj.location_latitude)
         self.assertIsNone(obj.location_longitude)
-
-
-class IdFilterAPITest(CustomObjectsTestCase, TestCase):
-    """
-    Regression #628: GET /api/plugins/custom-objects/<slug>/?id=<pk> returned every
-    object instead of just the matching one. Reproduces the exact reported steps: a
-    Custom Object Type with no fields at all, two instances, filtered by id.
-    """
-
-    def setUp(self):
-        super().setUp()
-        from netbox_custom_objects.models import CustomObjectType
-        self.cot = CustomObjectType.objects.create(name='IdFilterAPI', slug='id-filter-api')
-        self.model = self.cot.get_model()
-        token = create_token(self.user)
-        self.header = {'HTTP_AUTHORIZATION': f'Token {token}'}
-        self.client = APIClient()
-
-    def _list_url(self):
-        return reverse(
-            'plugins-api:netbox_custom_objects-api:customobject-list',
-            kwargs={'custom_object_type': self.cot.slug},
-        )
-
-    def test_filter_by_id_returns_only_matching_object(self):
-        obj1 = self.model.objects.create()
-        obj2 = self.model.objects.create()
-        perm = ObjectPermission(name='view-id-filter', actions=['view'])
-        perm.save()
-        perm.users.add(self.user)
-        perm.object_types.add(ObjectType.objects.get_for_model(self.model))
-
-        response = self.client.get(self._list_url(), {'id': obj1.pk}, **self.header)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        ids = [r['id'] for r in response.data['results']]
-        self.assertEqual(ids, [obj1.pk])
-        self.assertNotIn(obj2.pk, ids)

--- a/netbox_custom_objects/tests/test_filtersets.py
+++ b/netbox_custom_objects/tests/test_filtersets.py
@@ -1447,3 +1447,41 @@ class CoordinatesFieldFiltersetTestCase(CustomObjectsTestCase, TestCase):
 
     def test_no_filter_returns_all(self):
         self.assertEqual(self._filterset({}).qs.count(), 2)
+
+
+# ---------------------------------------------------------------------------
+# id filter -- regression #628
+# ---------------------------------------------------------------------------
+
+
+class IdFilterTestCase(CustomObjectsTestCase, TestCase):
+    """
+    Regression #628: ?id=<pk> was silently ignored on a Custom Object's REST API list
+    endpoint, returning every row instead of the matching one. The dynamic FilterSet
+    disables django-filter's Meta.fields auto-generation (fields=[]) and adds every
+    other filter explicitly by iterating CustomObjectTypeField records -- which never
+    include the base `id` column, so no filter was ever registered for it.
+
+    Uses a Custom Object Type with no fields at all, matching the exact reproduction
+    steps in the reported bug (a plain COT with two instances).
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.cot = cls.create_custom_object_type(name='IdFilterFS', slug='id-filter-fs')
+
+        model = cls.cot.get_model()
+        cls.obj1 = model.objects.create()
+        cls.obj2 = model.objects.create()
+
+    def _filterset(self, params):
+        model = self.cot.get_model()
+        return get_filterset_class(model)(params, model.objects.all())
+
+    def test_filter_by_id_returns_only_matching_object(self):
+        pks = list(self._filterset({'id': [str(self.obj1.pk)]}).qs.values_list('pk', flat=True))
+        self.assertEqual(pks, [self.obj1.pk])
+
+    def test_no_filter_returns_all(self):
+        self.assertEqual(self._filterset({}).qs.count(), 2)

--- a/netbox_custom_objects/tests/test_filtersets.py
+++ b/netbox_custom_objects/tests/test_filtersets.py
@@ -875,6 +875,11 @@ class ScalarFieldFiltersetTestCase(CustomObjectsTestCase):
     def test_no_filter_returns_all(self):
         self.assertEqual(self._filterset({}).qs.count(), self.total_count)
 
+    def test_filter_by_id_returns_only_matching_object(self):
+        """Regression #628: ?id=<pk> was silently ignored, returning every row."""
+        pks = list(self._filterset({'id': [str(self.obj_match.pk)]}).qs.values_list('pk', flat=True))
+        self.assertEqual(pks, [self.obj_match.pk])
+
 
 class TextFieldFiltersetTestCase(ScalarFieldFiltersetTestCase, TestCase):
     """CharFilter with icontains is generated for TYPE_TEXT fields."""
@@ -1444,44 +1449,6 @@ class CoordinatesFieldFiltersetTestCase(CustomObjectsTestCase, TestCase):
         )
         self.assertIn(self.obj2.pk, pks)
         self.assertNotIn(self.obj1.pk, pks)
-
-    def test_no_filter_returns_all(self):
-        self.assertEqual(self._filterset({}).qs.count(), 2)
-
-
-# ---------------------------------------------------------------------------
-# id filter -- regression #628
-# ---------------------------------------------------------------------------
-
-
-class IdFilterTestCase(CustomObjectsTestCase, TestCase):
-    """
-    Regression #628: ?id=<pk> was silently ignored on a Custom Object's REST API list
-    endpoint, returning every row instead of the matching one. The dynamic FilterSet
-    disables django-filter's Meta.fields auto-generation (fields=[]) and adds every
-    other filter explicitly by iterating CustomObjectTypeField records -- which never
-    include the base `id` column, so no filter was ever registered for it.
-
-    Uses a Custom Object Type with no fields at all, matching the exact reproduction
-    steps in the reported bug (a plain COT with two instances).
-    """
-
-    @classmethod
-    def setUpTestData(cls):
-        super().setUpTestData()
-        cls.cot = cls.create_custom_object_type(name='IdFilterFS', slug='id-filter-fs')
-
-        model = cls.cot.get_model()
-        cls.obj1 = model.objects.create()
-        cls.obj2 = model.objects.create()
-
-    def _filterset(self, params):
-        model = self.cot.get_model()
-        return get_filterset_class(model)(params, model.objects.all())
-
-    def test_filter_by_id_returns_only_matching_object(self):
-        pks = list(self._filterset({'id': [str(self.obj1.pk)]}).qs.values_list('pk', flat=True))
-        self.assertEqual(pks, [self.obj1.pk])
 
     def test_no_filter_returns_all(self):
         self.assertEqual(self._filterset({}).qs.count(), 2)


### PR DESCRIPTION
### Fixes: #628

## Summary

- `get_filterset_class()` builds the dynamic FilterSet for a Custom Object Type with `Meta.fields = []` (to disable django-filter's auto-generation) and adds every filter explicitly by iterating `CustomObjectTypeField` records. That loop never includes the base `id` primary key column, since it isn't a user-defined field — so no filter was ever registered for `id`, and `GET .../?id=<pk>` silently returned every row instead of just the matching one.
- Fix: add `"id"` to `Meta.fields`, matching core NetBox's own FilterSets (which explicitly list `'id'` first in `Meta.fields`). django-filter auto-generates a `MultiValueNumberFilter` for it via `BaseFilterSet.FILTER_DEFAULTS`' `AutoField` mapping — the same mechanism core relies on. No other field handled by `build_filter_for_field` is affected, since that loop only ever touches `CustomObjectTypeField`-backed columns, never `id`.

## Test plan

- [x] Added `test_filter_by_id_returns_only_matching_object` directly to `ScalarFieldFiltersetTestCase` (the shared base class in `test_filtersets.py`), so it runs automatically across all 11 of its field-type subclasses (text, longtext, integer, decimal, boolean, date, datetime, URL, JSON, select, multiselect) rather than needing a dedicated fixture.
- [x] Added `test_filter_by_id` to `OwnerAPITest` in `test_api.py`, which already creates a Custom Object Type with zero fields in `setUp()` — the exact reproduction scenario from the reported bug — and already has the `_list_url()`/`_add_perm()` helpers needed.
- [x] Verified via git-stash-based regression testing: both tests fail against the pre-fix code with the exact reported symptom (all rows returned instead of one), and pass after the fix.
- [x] Ran the full `test_filtersets`/`test_api` suites (214 tests); all pass, no regressions.
- [x] Confirmed no migration is needed (`makemigrations --check` reports no changes) — this is a pure Python FilterSet change, no model modification.
- [x] `ruff check` passes.

Closes #628