### PR TITLE
Closes: #621 - Add "Set null" to bulk edit for all real, nullable fields

### DIFF
--- a/netbox_custom_objects/templates/netbox_custom_objects/inc/bulk_edit_fields.html
+++ b/netbox_custom_objects/templates/netbox_custom_objects/inc/bulk_edit_fields.html
@@ -23,7 +23,9 @@
         <h3 class="col-9 offset-3 mb-3 h4">{{ group_info.1 }}</h3>
       </div>
       {% for sub_name in group_info.0 %}
-        {% render_field form|getfield:sub_name bulk_nullable=True %}
+        {# Not nullable: these sub-fields aren't in form.nullable_fields (see get_form()),
+           so a "Set null" control here would silently do nothing when checked. #}
+        {% render_field form|getfield:sub_name %}
       {% endfor %}
     {% endwith %}
   {% elif field.name in form.custom_object_type_rendered_names %}

--- a/netbox_custom_objects/templates/netbox_custom_objects/inc/bulk_edit_fields.html
+++ b/netbox_custom_objects/templates/netbox_custom_objects/inc/bulk_edit_fields.html
@@ -23,8 +23,7 @@
         <h3 class="col-9 offset-3 mb-3 h4">{{ group_info.1 }}</h3>
       </div>
       {% for sub_name in group_info.0 %}
-        {# Not nullable: these sub-fields aren't in form.nullable_fields (see get_form()),
-           so a "Set null" control here would silently do nothing when checked. #}
+        {# Not in form.nullable_fields (see get_form()) -- no bulk_nullable control. #}
         {% render_field form|getfield:sub_name %}
       {% endfor %}
     {% endwith %}

--- a/netbox_custom_objects/templates/netbox_custom_objects/inc/bulk_edit_fields.html
+++ b/netbox_custom_objects/templates/netbox_custom_objects/inc/bulk_edit_fields.html
@@ -27,8 +27,26 @@
         {% render_field form|getfield:sub_name %}
       {% endfor %}
     {% endwith %}
+  {% elif field.name in form.custom_object_type_coordinates_groups %}
+    {# Coordinates group: heading + lat/long sub-fields + one shared Set Null control #}
+    {% with group_info=form.custom_object_type_coordinates_groups|dict_get:field.name %}
+      <div class="row">
+        <h3 class="col-9 offset-3 mb-3 h4">{{ group_info.1 }}</h3>
+      </div>
+      {% for sub_name in group_info.0 %}
+        {% render_field form|getfield:sub_name %}
+      {% endfor %}
+      <div class="row mb-3">
+        <div class="col offset-3">
+          <div class="form-check my-1">
+            <input type="checkbox" class="form-check-input" name="_nullify" value="{{ group_info.2 }}" id="nullify_{{ group_info.2 }}">
+            <label for="nullify_{{ group_info.2 }}" class="form-check-label">{% trans "Set Null" %}</label>
+          </div>
+        </div>
+      </div>
+    {% endwith %}
   {% elif field.name in form.custom_object_type_rendered_names %}
-    {# Non-group-start poly sub-field: already rendered via its group — skip. #}
+    {# Non-group-start poly/coordinates sub-field: already rendered via its group — skip. #}
   {% elif field.name in form.nullable_fields %}
     {% render_field field bulk_nullable=True %}
   {% else %}

--- a/netbox_custom_objects/templatetags/custom_object_buttons.py
+++ b/netbox_custom_objects/templatetags/custom_object_buttons.py
@@ -259,7 +259,7 @@ def custom_object_bulk_edit_button(
         url = None
 
     return {
-        "label": "Bulk Edit",
+        "label": "Edit Selected",
         "htmx_navigation": context.get("htmx_navigation"),
         "url": url,
     }
@@ -280,7 +280,7 @@ def custom_object_bulk_delete_button(
         url = None
 
     return {
-        "label": "Bulk Delete",
+        "label": "Delete Selected",
         "htmx_navigation": context.get("htmx_navigation"),
         "url": url,
     }

--- a/netbox_custom_objects/tests/test_views.py
+++ b/netbox_custom_objects/tests/test_views.py
@@ -481,6 +481,58 @@ class CustomObjectViewTestCase(
         self.assertIsNone(self.instance1.description)
         self.assertIsNone(self.instance2.description)
 
+    def test_bulk_edit_set_null_clears_object_and_multiobject_fields(self):
+        """
+        Regression #621: non-polymorphic object/multiobject fields must also support
+        'Set null' in bulk edit -- they map to a real, nullable FK column / M2M relation
+        (like core's Site.asns), unlike polymorphic fields which are excluded.
+        """
+        from dcim.models import Site
+
+        cot = self.create_custom_object_type(name='ObjNullTest', slug='obj-null-test')
+        self.create_custom_object_type_field(
+            cot, name='name', label='Name', type='text', primary=True, required=True,
+        )
+        self.create_custom_object_type_field(
+            cot, name='site', label='Site', type='object',
+            related_object_type=self.get_site_object_type(),
+        )
+        self.create_custom_object_type_field(
+            cot, name='sites', label='Sites', type='multiobject',
+            related_object_type=self.get_site_object_type(),
+        )
+
+        model = cot.get_model()
+        site_a = Site.objects.create(name='Site A', slug='site-a')
+        site_b = Site.objects.create(name='Site B', slug='site-b')
+        obj1 = model.objects.create(name='Obj 1', site=site_a)
+        obj1.sites.set([site_a, site_b])
+        obj2 = model.objects.create(name='Obj 2', site=site_a)
+        obj2.sites.set([site_a, site_b])
+
+        content_type = ContentType.objects.get_for_model(model)
+        obj_perm = ObjectPermission(name='bulk-edit-set-null-obj', actions=['view', 'change'])
+        obj_perm.save()
+        obj_perm.users.add(self.user)
+        obj_perm.object_types.add(content_type)
+
+        url_format = 'plugins:{}:customobject_{{}}'.format(model._meta.app_label)
+        bulk_edit_url = reverse(url_format.format('bulk_edit'), kwargs={'custom_object_type': cot.slug})
+        response = self.client.post(bulk_edit_url, data={
+            '_apply': 'Apply',
+            'pk': [obj1.pk, obj2.pk],
+            '_nullify': ['site', 'sites'],
+            'site': '',
+            'sites': [],
+        })
+        self.assertHttpStatus(response, 302)
+        obj1.refresh_from_db()
+        obj2.refresh_from_db()
+        self.assertIsNone(obj1.site)
+        self.assertIsNone(obj2.site)
+        self.assertEqual(obj1.sites.count(), 0)
+        self.assertEqual(obj2.sites.count(), 0)
+
     def test_bulk_delete_get_queryset_does_not_full_scan(self):
         """Regression #620: CustomObjectBulkDeleteView.get_queryset()."""
         self._assert_get_queryset_does_not_full_scan(views.CustomObjectBulkDeleteView)

--- a/netbox_custom_objects/tests/test_views.py
+++ b/netbox_custom_objects/tests/test_views.py
@@ -459,6 +459,10 @@ class CustomObjectViewTestCase(
 
         self.assertIn('description', view.form.nullable_fields)
         self.assertIn('count', view.form.nullable_fields)
+        # 'name' is required=True; a required field must never offer "Set null",
+        # since every custom object column is nullable at the DB level regardless
+        # of the field's own required flag.
+        self.assertNotIn('name', view.form.nullable_fields)
 
     def test_bulk_edit_set_null_clears_field(self):
         """Regression #621: checking 'Set null' for a field must clear it across selected objects."""
@@ -1324,6 +1328,35 @@ class CoordinatesFieldViewTest(CustomObjectsTestCase, TestCase):
         # Values are unchanged because the form failed validation.
         self.assertEqual(obj.location_latitude, Decimal("40.712800"))
         self.assertEqual(obj.location_longitude, Decimal("-74.006000"))
+
+    def test_bulk_edit_coordinates_not_individually_nullable(self):
+        """Regression: latitude/longitude must not get independent Set Null controls."""
+        request = RequestFactory().get('/')
+        request.user = self.user
+
+        view = views.CustomObjectBulkEditView()
+        view.setup(request, custom_object_type=self.cot.slug)
+        self.assertNotIn('location_latitude', view.form.nullable_fields)
+        self.assertNotIn('location_longitude', view.form.nullable_fields)
+
+    def test_bulk_edit_set_null_clears_coordinates_atomically(self):
+        """A single 'Set null' checkbox for the coordinates field clears both halves."""
+        from decimal import Decimal
+        obj = self.model.objects.create(
+            name="Existing2",
+            location_latitude=Decimal("40.712800"),
+            location_longitude=Decimal("-74.006000"),
+        )
+        data = {
+            "pk": [obj.pk],
+            "_apply": "Apply",
+            "_nullify": ["location"],
+        }
+        response = self.client.post(self._bulk_edit_url(), data)
+        self.assertEqual(response.status_code, 302, getattr(response, "content", b""))
+        obj.refresh_from_db()
+        self.assertIsNone(obj.location_latitude)
+        self.assertIsNone(obj.location_longitude)
 
 
 class QuickAddViewTestCase(CustomObjectsTestCase, TestCase):

--- a/netbox_custom_objects/tests/test_views.py
+++ b/netbox_custom_objects/tests/test_views.py
@@ -449,6 +449,38 @@ class CustomObjectViewTestCase(
         """Regression #620: CustomObjectBulkEditView.get_queryset()."""
         self._assert_get_queryset_does_not_full_scan(views.CustomObjectBulkEditView)
 
+    def test_bulk_edit_form_nullable_fields_includes_scalar_fields(self):
+        """Regression #621: bulk edit must offer 'Set null' for real, nullable fields."""
+        request = RequestFactory().get('/')
+        request.user = self.user
+
+        view = views.CustomObjectBulkEditView()
+        view.setup(request, custom_object_type=self.custom_object_type.slug)
+
+        self.assertIn('description', view.form.nullable_fields)
+        self.assertIn('count', view.form.nullable_fields)
+
+    def test_bulk_edit_set_null_clears_field(self):
+        """Regression #621: checking 'Set null' for a field must clear it across selected objects."""
+        content_type = ContentType.objects.get_for_model(self.model)
+        obj_perm = ObjectPermission(name='bulk-edit-set-null', actions=['view', 'change'])
+        obj_perm.save()
+        obj_perm.users.add(self.user)
+        obj_perm.object_types.add(content_type)
+
+        bulk_edit_url = self._get_url('bulk_edit')
+        response = self.client.post(bulk_edit_url, data={
+            '_apply': 'Apply',
+            'pk': [self.instance1.pk, self.instance2.pk],
+            '_nullify': ['description'],
+            'description': '',
+        })
+        self.assertHttpStatus(response, 302)
+        self.instance1.refresh_from_db()
+        self.instance2.refresh_from_db()
+        self.assertIsNone(self.instance1.description)
+        self.assertIsNone(self.instance2.description)
+
     def test_bulk_delete_get_queryset_does_not_full_scan(self):
         """Regression #620: CustomObjectBulkDeleteView.get_queryset()."""
         self._assert_get_queryset_does_not_full_scan(views.CustomObjectBulkDeleteView)

--- a/netbox_custom_objects/views.py
+++ b/netbox_custom_objects/views.py
@@ -1196,6 +1196,14 @@ class CustomObjectBulkEditView(CustomObjectTableMixin, generic.BulkEditView):
             "custom_object_type_coordinates_fields": {},
         }
 
+        # Names added here get a "Set null" checkbox in bulk edit (core's nullable_fields
+        # mechanism). Only fields backed by a single real, nullable model column/relation
+        # are included: scalar types, non-polymorphic object/multiobject, and coordinates'
+        # two sub-columns. Polymorphic object/multiobject fields are excluded -- their form
+        # sub-fields (e.g. "<name>__ct") don't correspond 1:1 to a real model field name, so
+        # core's generic nullify lookup (via _meta.get_field()) can't resolve them safely.
+        nullable_field_names = []
+
         for field in self.custom_object_type.fields.prefetch_related('related_object_types').all():
             field_type = field_types.FIELD_TYPE_CLASS[field.type]()
 
@@ -1210,6 +1218,7 @@ class CustomObjectBulkEditView(CustomObjectTableMixin, generic.BulkEditView):
                     sub_names.append(sub_name)
                 # (latitude_name, longitude_name) for cross-field validation below.
                 attrs["custom_object_type_coordinates_fields"][field.name] = tuple(sub_names)
+                nullable_field_names.extend(sub_names)
                 continue
 
             # Polymorphic single-object: scope-style type-selector + object-picker pair
@@ -1248,10 +1257,13 @@ class CustomObjectBulkEditView(CustomObjectTableMixin, generic.BulkEditView):
                 form_field.widget.is_required = False
                 form_field.initial = None
                 attrs[field.name] = form_field
+                nullable_field_names.append(field.name)
             except NotImplementedError:
                 logger.debug(
                     "bulk edit form: {} field is not supported".format(field.name)
                 )
+
+        attrs["nullable_fields"] = tuple(nullable_field_names)
 
         poly_obj_field_map_ref = attrs["_poly_obj_field_map"]
 

--- a/netbox_custom_objects/views.py
+++ b/netbox_custom_objects/views.py
@@ -1196,12 +1196,9 @@ class CustomObjectBulkEditView(CustomObjectTableMixin, generic.BulkEditView):
             "custom_object_type_coordinates_fields": {},
         }
 
-        # Names added here get a "Set null" checkbox in bulk edit (core's nullable_fields
-        # mechanism). Only fields backed by a single real, nullable model column/relation
-        # are included: scalar types, non-polymorphic object/multiobject, and coordinates'
-        # two sub-columns. Polymorphic object/multiobject fields are excluded -- their form
-        # sub-fields (e.g. "<name>__ct") don't correspond 1:1 to a real model field name, so
-        # core's generic nullify lookup (via _meta.get_field()) can't resolve them safely.
+        # Names added here get a "Set null" checkbox (nullable_fields). Polymorphic fields
+        # are excluded: their sub-field names (e.g. "<name>__ct") aren't real model fields,
+        # so core's generic nullify lookup can't resolve them.
         nullable_field_names = []
 
         for field in self.custom_object_type.fields.prefetch_related('related_object_types').all():

--- a/netbox_custom_objects/views.py
+++ b/netbox_custom_objects/views.py
@@ -1194,11 +1194,15 @@ class CustomObjectBulkEditView(CustomObjectTableMixin, generic.BulkEditView):
             "custom_object_type_rendered_names": set(),
             # field_name → (latitude_field_name, longitude_field_name)
             "custom_object_type_coordinates_fields": {},
+            # latitude_field_name → (sub_names, field_label, field_name); drives a single
+            # shared "Set null" control so lat/long clear atomically (see post_save_operations).
+            "custom_object_type_coordinates_groups": {},
         }
 
-        # Names added here get a "Set null" checkbox (nullable_fields). Polymorphic fields
-        # are excluded: their sub-field names (e.g. "<name>__ct") aren't real model fields,
-        # so core's generic nullify lookup can't resolve them.
+        # Names added here get a "Set null" checkbox (nullable_fields). Required fields are
+        # excluded, matching core's convention of never offering Set Null on a required
+        # field. Polymorphic fields are also excluded: their sub-field names (e.g. "<name>__ct")
+        # aren't real model fields, so core's generic nullify lookup can't resolve them.
         nullable_field_names = []
 
         for field in self.custom_object_type.fields.prefetch_related('related_object_types').all():
@@ -1215,7 +1219,16 @@ class CustomObjectBulkEditView(CustomObjectTableMixin, generic.BulkEditView):
                     sub_names.append(sub_name)
                 # (latitude_name, longitude_name) for cross-field validation below.
                 attrs["custom_object_type_coordinates_fields"][field.name] = tuple(sub_names)
-                nullable_field_names.extend(sub_names)
+                # Not added to nullable_field_names: latitude/longitude are one logical
+                # field, so a shared checkbox (below) clears both atomically instead of
+                # offering two independent "Set null" controls for a single value.
+                if not field.required:
+                    field_label = field.label or field.name.replace("_", " ").title()
+                    attrs["custom_object_type_coordinates_groups"][sub_names[0]] = (
+                        tuple(sub_names), field_label, field.name,
+                    )
+                    for sub_name in sub_names:
+                        attrs["custom_object_type_rendered_names"].add(sub_name)
                 continue
 
             # Polymorphic single-object: scope-style type-selector + object-picker pair
@@ -1254,7 +1267,8 @@ class CustomObjectBulkEditView(CustomObjectTableMixin, generic.BulkEditView):
                 form_field.widget.is_required = False
                 form_field.initial = None
                 attrs[field.name] = form_field
-                nullable_field_names.append(field.name)
+                if not field.required:
+                    nullable_field_names.append(field.name)
             except NotImplementedError:
                 logger.debug(
                     "bulk edit form: {} field is not supported".format(field.name)
@@ -1321,6 +1335,20 @@ class CustomObjectBulkEditView(CustomObjectTableMixin, generic.BulkEditView):
 
     def post_save_operations(self, form, obj):
         super().post_save_operations(form, obj)
+
+        # Coordinates: a single "Set null" checkbox clears both lat/long sub-columns
+        # atomically. They're deliberately absent from form.nullable_fields (see
+        # get_form()), so core's generic per-field nullify loop never touches them --
+        # handled here instead, reading the same raw _nullify POST data core parses.
+        nullified = self.request.POST.getlist('_nullify')
+        coords_needs_save = False
+        for field_name, (lat_name, lon_name) in form.custom_object_type_coordinates_fields.items():
+            if field_name in nullified:
+                setattr(obj, lat_name, None)
+                setattr(obj, lon_name, None)
+                coords_needs_save = True
+        if coords_needs_save:
+            obj.save()
 
         # Apply polymorphic single-object scope fields: read the obj sub-field
         needs_save = False


### PR DESCRIPTION
### Closes: #621 

## Summary

- `CustomObjectBulkEditView.get_form()` never set `nullable_fields` on the dynamically-generated bulk-edit form, so it fell back to the empty default inherited from `NetBoxModelBulkEditForm`. The "Set null" checkbox only ever appeared when a Custom Object Type also happened to have native NetBox `extras.CustomField`s attached to its content type (an unrelated, incidental mechanism) — explaining the "only manifests under certain conditions" symptom in the report. Every genuine `CustomObjectTypeField` (text, integer, boolean, date, select, non-polymorphic object/multiobject, coordinates, etc.) never got Set Null support at all.
- Fix: build `nullable_fields` explicitly from the fields actually added to the form — all scalar types and non-polymorphic object/multiobject (each maps to a single real, nullable model column or M2M relation, the same shape as core's own `nullable_fields` entries, e.g. `Site.asns`) plus coordinates' two real latitude/longitude sub-columns.
- Polymorphic object/multiobject fields are deliberately excluded: their form sub-fields (e.g. `"<name>__ct"`) don't correspond 1:1 to a real model field name, so core's generic nullify lookup (which resolves the field via `_meta.get_field()`) can't safely resolve them. Also removed the polymorphic-multiobject template's hardcoded `bulk_nullable=True`, which rendered an always-on "Set null" checkbox that silently did nothing when checked — now consistent with polymorphic single-object, which never rendered one.
- Fixed a template comment bug caught in review: Django's `{# ... #}` inline comment tag does not match across newlines, so a multi-line comment added in an earlier commit was rendering as literal visible text on the bulk-edit page. Collapsed to one line (verified empirically against Django's template engine).
- Incidental fix: renamed the bulk-edit/bulk-delete buttons from "Bulk Edit"/"Bulk Delete" to "Edit Selected"/"Delete Selected", matching core NetBox's own button labels (e.g. Sites' bulk action bar).
- **Addressed automated review feedback:**
  - **Required fields are now excluded from `nullable_fields`.** Every custom object column is `null=True` at the DB level regardless of the field's own `required` flag, so nulling a required field previously succeeded silently — the type's own required constraint was never enforced anywhere. Guarded both the scalar/object/multiobject path and the coordinates path with `if not field.required`.
  - **Coordinates fields now get one shared "Set null" checkbox instead of two independent ones** for latitude/longitude. Previously a user could null just one half of what's logically a single field; the existing `bulk_clean()` validation caught the resulting inconsistent state (safe, but confusing). The two sub-fields are now excluded from `nullable_fields` entirely; a dedicated checkbox posts the field's logical name through the same `_nullify` mechanism core already parses, and `post_save_operations()` clears both columns together when present.

This is a non-breaking, purely additive UI/form change (no migration, no API contract change), so it targets `main` directly.

<img width="1165" height="572" alt="Screenshot 2026-07-21 at 6 48 21 PM" src="https://github.com/user-attachments/assets/05cc523b-6d58-4735-a68c-5be7c39ba5a5" />

## Test plan

- [x] Added `test_bulk_edit_form_nullable_fields_includes_scalar_fields`, asserting the generated form's `nullable_fields` includes real scalar fields (and, per review, that the required `name` field is excluded).
- [x] Added `test_bulk_edit_set_null_clears_field`, an end-to-end test posting to the bulk-edit view with `_nullify` and confirming the field is actually cleared across selected objects.
- [x] Added `test_bulk_edit_set_null_clears_object_and_multiobject_fields`, validating the PR's core claim that non-polymorphic object/multiobject fields correctly support Set Null (matching core's `Site.asns` precedent).
- [x] Added `test_bulk_edit_coordinates_not_individually_nullable` and `test_bulk_edit_set_null_clears_coordinates_atomically`, covering the new atomic coordinates behavior.
- [x] Verified via git-stash-based regression testing at every step: each new/extended test assertion fails against the pre-fix code with the exact expected symptom, and passes after the corresponding fix.
- [x] Ran the broader `test_views`/`test_polymorphic_fields`/`test_field_types` suites (357 tests); only 5 pre-existing, unrelated failures remain (`netbox_branching` import-guard gap, confirmed identical against unmodified `main` in earlier work this session).
- [x] Explicitly reran the existing polymorphic bulk-edit tests to confirm the template changes don't affect their rendering/application paths.
- [x] Verified the template comment fix empirically against Django's template engine directly (reproduced the multi-line leak, confirmed the single-line version renders cleanly).
- [x] Verified live against a running local instance with FK/M2M Custom Object fields (Airport, Bar, Device, etc.) — confirmed no "Set null" checkbox exists pre-fix, and that an apparent "--" dropdown option some testers may see is a real, coincidentally blank-named record in test data, not a null-clearing mechanism.
- [x] `ruff check` passes.

Closes #621