### PR TITLE
Closes #496: Add optional link title to URL fields

### DIFF
--- a/docs/field-attributes.md
+++ b/docs/field-attributes.md
@@ -116,13 +116,14 @@ A `url` field stores the URL value plus an optional human-readable **link title*
 Adding one `url` field named `website` creates two backing columns:
 
 - `website` — the URL itself
-- `website_title` — optional display text shown in place of the raw URL on the
-  object's detail page
+- `website_title` — optional display text shown in place of the raw URL
 
 Behaviour:
 
-- **Detail page only.** The title is used as the visible link text on the object
-  detail page. List/table views continue to show the raw URL as plain text.
+- **Detail page and list view.** The title, when set, is used as the visible link
+  text both on the object's detail page and in its column in list/table views —
+  the two backing columns are never shown as separate table columns. Falls back to
+  the raw URL as link text when no title is set.
 - **Optional independently.** The title has no relationship to the URL value —
   setting one without the other is allowed and harmless.
 - **REST API.** The pair is exposed as two flat fields, `<name>` and `<name>_title`.
@@ -131,3 +132,8 @@ Behaviour:
 - **CSV import.** Bulk CSV import only populates the URL value; the title column is
   not importable via CSV (the same limitation applies to `coordinates` fields' backing
   columns).
+- **Upgrading from an older release.** Existing `url` fields gain the `<name>_title`
+  column automatically on the next `manage.py migrate` (or immediately via
+  `manage.py upgrade_custom_objects`). On a NetBox Branching branch, it's healed the
+  next time that branch itself is migrated. See the [release notes](releases.md) for
+  details.

--- a/docs/field-attributes.md
+++ b/docs/field-attributes.md
@@ -134,5 +134,7 @@ Behaviour:
   columns).
 - **Upgrading from an older release.** Existing `url` fields gain the `<name>_title`
   column automatically on the next `manage.py migrate` (or immediately via
-  `manage.py upgrade_custom_objects`). On a NetBox Branching branch, it's healed the
-  next time that branch itself is migrated.
+  `manage.py upgrade_custom_objects`) -- this also heals every existing NetBox
+  Branching branch's own schema, not just main's. A branch migrating on its own
+  afterward re-heals itself too, as a secondary safeguard, but isn't required for
+  the column to already be there.

--- a/docs/field-attributes.md
+++ b/docs/field-attributes.md
@@ -135,5 +135,4 @@ Behaviour:
 - **Upgrading from an older release.** Existing `url` fields gain the `<name>_title`
   column automatically on the next `manage.py migrate` (or immediately via
   `manage.py upgrade_custom_objects`). On a NetBox Branching branch, it's healed the
-  next time that branch itself is migrated. See the [release notes](releases.md) for
-  details.
+  next time that branch itself is migrated.

--- a/docs/field-attributes.md
+++ b/docs/field-attributes.md
@@ -128,3 +128,6 @@ Behaviour:
 - **REST API.** The pair is exposed as two flat fields, `<name>` and `<name>_title`.
 - `Must be unique` and `Default` continue to apply to the URL value itself, exactly
   as for any other `url` field.
+- **CSV import.** Bulk CSV import only populates the URL value; the title column is
+  not importable via CSV (the same limitation applies to `coordinates` fields' backing
+  columns).

--- a/docs/field-attributes.md
+++ b/docs/field-attributes.md
@@ -13,7 +13,7 @@ The following attributes are available when creating or editing a Custom Object 
 | `boolean` | True/false |
 | `date` | Date |
 | `datetime` | Date and time |
-| `url` | URL |
+| `url` | URL, with an optional link title |
 | `json` | Arbitrary JSON value |
 | `select` | Single selection from a choice set |
 | `multiselect` | Multiple selections from a choice set |
@@ -107,3 +107,24 @@ Behaviour:
 - **Map link.** Detail views render the coordinates with a **Map** button that opens the location
   using NetBox's `MAPS_URL` configuration parameter (Google Maps by default).
 - `Must be unique` and `Default` are not supported for `coordinates` fields.
+
+## URL Fields
+
+Field type: `url`
+
+A `url` field stores the URL value plus an optional human-readable **link title**.
+Adding one `url` field named `website` creates two backing columns:
+
+- `website` — the URL itself
+- `website_title` — optional display text shown in place of the raw URL on the
+  object's detail page
+
+Behaviour:
+
+- **Detail page only.** The title is used as the visible link text on the object
+  detail page. List/table views continue to show the raw URL as plain text.
+- **Optional independently.** The title has no relationship to the URL value —
+  setting one without the other is allowed and harmless.
+- **REST API.** The pair is exposed as two flat fields, `<name>` and `<name>_title`.
+- `Must be unique` and `Default` continue to apply to the URL value itself, exactly
+  as for any other `url` field.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -17,14 +17,6 @@ Custom Object Types and their instances are now queryable and mutable via the Ne
 
 - [#30](https://github.com/netboxlabs/netbox-custom-objects/issues/30) - GraphQL support for Custom Objects
 
-**Optional Link Title for URL Fields**
-
-`url`-type fields now support an optional, human-readable link title, shown as the link text in place of the raw URL on both the object's detail page and in list views.
-
-Upgrading: existing `url` fields gain the new `<name>_title` column automatically — no manual migration is needed. On the main schema this happens the next time `manage.py migrate` runs (or immediately via `manage.py upgrade_custom_objects`, which also supports `--dry-run`). On a NetBox Branching branch it happens the next time that branch itself is migrated (its "Migrate branch" action, available whenever the branch's migration state lags behind main).
-
-- [#496](https://github.com/netboxlabs/netbox-custom-objects/issues/496) - Add optional link title to URL fields
-
 ### Enhancements
 
 - [#98](https://github.com/netboxlabs/netbox-custom-objects/issues/98) - Config context support for Custom Objects

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -17,6 +17,14 @@ Custom Object Types and their instances are now queryable and mutable via the Ne
 
 - [#30](https://github.com/netboxlabs/netbox-custom-objects/issues/30) - GraphQL support for Custom Objects
 
+**Optional Link Title for URL Fields**
+
+`url`-type fields now support an optional, human-readable link title, shown as the link text in place of the raw URL on both the object's detail page and in list views.
+
+Upgrading: existing `url` fields gain the new `<name>_title` column automatically — no manual migration is needed. On the main schema this happens the next time `manage.py migrate` runs (or immediately via `manage.py upgrade_custom_objects`, which also supports `--dry-run`). On a NetBox Branching branch it happens the next time that branch itself is migrated (its "Migrate branch" action, available whenever the branch's migration state lags behind main).
+
+- [#496](https://github.com/netboxlabs/netbox-custom-objects/issues/496) - Add optional link title to URL fields
+
 ### Enhancements
 
 - [#98](https://github.com/netboxlabs/netbox-custom-objects/issues/98) - Config context support for Custom Objects

--- a/netbox_custom_objects/__init__.py
+++ b/netbox_custom_objects/__init__.py
@@ -66,13 +66,16 @@ def _reset_deferred_co_field_data(sender, **kwargs):
 def _heal_branch_on_migrate(sender, branch, **kwargs):
     """netbox-branching's own ``post_migrate`` receiver.
 
-    ``Branch.migrate()`` applies migrations directly via Django's
-    ``MigrationExecutor`` against the branch's own connection and never calls
-    ``call_command('migrate', ...)``, so Django's core ``post_migrate`` signal
-    (handled by ``_heal_mixin_columns`` below) never fires for it. Without this
-    receiver, a branch provisioned before a plugin release that adds a new base
-    column (e.g. a multi-column field type's extra sub-column) never gets that
-    column healed into its own schema — only into the default connection's.
+    Secondary/defense-in-depth path only. The reliable trigger for healing
+    *existing* branches is ``heal_all_branches()``, called unconditionally
+    from ``_heal_mixin_columns`` below (Django's core ``post_migrate``, fired
+    by every ``manage.py migrate`` run) -- a schema change like a new
+    multi-column sub-column ships with no actual Django migration file, so
+    there's nothing for netbox-branching's ``MigrationExecutor`` to detect as
+    "pending" against a branch, and ``Branch.migrate()`` never runs for it.
+    This receiver still re-heals the one branch that was just migrated,
+    covering a *future* plugin release that does ship a real migration
+    alongside a schema change.
     """
     try:
         from netbox_custom_objects.mixin_migration import heal_branch  # noqa: PLC0415
@@ -161,6 +164,12 @@ def _heal_mixin_columns(sender, **kwargs):
     process so the cost is negligible on normal server starts where no
     migrations run.
 
+    Also heals every live Branch's own schema (heal_all_branches()), not just
+    the default connection's.  This can't be delegated to Branch.migrate()'s
+    own post_migrate signal (see heal_branch()'s docstring in
+    mixin_migration.py for why) -- the main upgrade path is the only reliable
+    trigger, so it runs unconditionally here alongside the main-schema heal.
+
     Skipped during makemigrations and collectstatic (DB may be unavailable or
     in an inconsistent state for our purposes).
     """
@@ -172,8 +181,11 @@ def _heal_mixin_columns(sender, **kwargs):
         return
 
     try:
-        from netbox_custom_objects.mixin_migration import heal_all_cots  # noqa: PLC0415
+        from netbox_custom_objects.mixin_migration import heal_all_branches, heal_all_cots  # noqa: PLC0415
         heal_all_cots(verbosity=kwargs.get("verbosity", 1))
+        # No-ops (zero-result) when netbox-branching isn't installed -- see
+        # heal_all_branches()'s own apps.is_installed() check.
+        heal_all_branches(verbosity=kwargs.get("verbosity", 1))
     except Exception:
         import logging  # noqa: PLC0415
         logging.getLogger(__name__).exception(

--- a/netbox_custom_objects/__init__.py
+++ b/netbox_custom_objects/__init__.py
@@ -63,6 +63,27 @@ def _reset_deferred_co_field_data(sender, **kwargs):
     _deferred_co_field_data.set(None)
 
 
+def _heal_branch_on_migrate(sender, branch, **kwargs):
+    """netbox-branching's own ``post_migrate`` receiver.
+
+    ``Branch.migrate()`` applies migrations directly via Django's
+    ``MigrationExecutor`` against the branch's own connection and never calls
+    ``call_command('migrate', ...)``, so Django's core ``post_migrate`` signal
+    (handled by ``_heal_mixin_columns`` below) never fires for it. Without this
+    receiver, a branch provisioned before a plugin release that adds a new base
+    column (e.g. a multi-column field type's extra sub-column) never gets that
+    column healed into its own schema — only into the default connection's.
+    """
+    try:
+        from netbox_custom_objects.mixin_migration import heal_branch  # noqa: PLC0415
+        heal_branch(branch, verbosity=kwargs.get("verbosity", 1))
+    except Exception:
+        logging.getLogger(__name__).exception(
+            "netbox_custom_objects: unexpected error healing branch %s after migrate",
+            getattr(branch, "pk", branch),
+        )
+
+
 def _register_branching_hooks_once():
     """Register netbox-branching integration hooks at most once per process.
 
@@ -87,6 +108,12 @@ def _register_branching_hooks_once():
 
     for sig in (pre_merge, post_merge, pre_sync, post_sync, pre_revert, post_revert):
         sig.connect(_reset_deferred_co_field_data, weak=False)
+
+    try:
+        from netbox_branching.signals import post_migrate as branching_post_migrate
+        branching_post_migrate.connect(_heal_branch_on_migrate, weak=False)
+    except ImportError:
+        pass
 
     try:
         from netbox_branching.utilities import (

--- a/netbox_custom_objects/api/serializers.py
+++ b/netbox_custom_objects/api/serializers.py
@@ -502,6 +502,11 @@ def get_serializer_class(model, skip_object_fields=False):
         if field.type == CustomObjectFieldTypeChoices.TYPE_COORDINATES:
             custom_field_names += [f"{field.name}_latitude", f"{field.name}_longitude"]
             continue
+        # URL fields expand into the URL itself plus an optional title column;
+        # expose both flat, mirroring the coordinates treatment above.
+        if field.type == CustomObjectFieldTypeChoices.TYPE_URL:
+            custom_field_names += [field.name, f"{field.name}_title"]
+            continue
         if field.name not in model_field_names:
             continue  # excluded during model generation (e.g. broken FK)
         if skip_object_fields and field.type in [

--- a/netbox_custom_objects/field_types.py
+++ b/netbox_custom_objects/field_types.py
@@ -5,6 +5,7 @@ import json
 import logging
 from decimal import Decimal
 from typing import List
+from urllib.parse import urlparse
 
 import django_tables2 as tables
 from strawberry.scalars import JSON
@@ -22,8 +23,9 @@ from django.db.models.fields.related import ForeignKey, ManyToManyDescriptor
 from django.db.models.manager import Manager
 from django.db.models.signals import m2m_changed
 from django.urls import reverse
-from django.utils.html import escape
+from django.utils.html import escape, format_html
 from django.utils.safestring import mark_safe
+from django.utils.text import Truncator
 from django.utils.translation import gettext_lazy as _
 from extras.choices import CustomFieldTypeChoices, CustomFieldUIEditableChoices
 from utilities.api import get_serializer_for_model
@@ -41,6 +43,7 @@ from utilities.forms.widgets import (
     DateTimePicker,
 )
 from utilities.templatetags.builtins.filters import linkify, render_markdown
+from netbox.config import get_config
 from netbox.tables.columns import BooleanColumn
 
 from netbox_custom_objects.choices import (CustomObjectFieldTypeChoices,
@@ -538,6 +541,27 @@ class URLFieldType(FieldType):
     def title_field_name(field):
         return f"{field.name}_title"
 
+    @staticmethod
+    def render_url_html(url, title):
+        """
+        Render *url* as a safe, truncated link -- the title as link text if set,
+        falling back to the URL itself -- mirroring NetBox core's
+        builtins/customfield_value.html convention for 'url' custom fields,
+        including its scheme-allowlist guard against unsafe schemes (e.g.
+        javascript:).  Returns '' if *url* is falsy.  Shared by the detail-page
+        template filter and the list-view table column so both render identically.
+        """
+        if not url:
+            return ""
+        try:
+            scheme = urlparse(url).scheme.lower()
+        except ValueError:
+            scheme = ""
+        display_text = Truncator(title or url).chars(70)
+        if not scheme or scheme in get_config().ALLOWED_URL_SCHEMES:
+            return format_html('<a href="{}">{}</a>', url, display_text)
+        return display_text
+
     def get_model_field(self, field, **kwargs):
         field_kwargs = self._safe_kwargs(**kwargs)
         field_kwargs.update({"default": field.default, "unique": field.unique})
@@ -595,6 +619,16 @@ class URLFieldType(FieldType):
             label=field,
             required=False,
         )
+
+    def render_table_column(self, record, bound_column):
+        """
+        Render the same title-as-link-text HTML as the detail page, rather than
+        showing the two backing columns (<name>, <name>_title) as separate table
+        columns -- keeps the list view consistent with the detail view.
+        """
+        url = getattr(record, bound_column.name, None)
+        title = getattr(record, f"{bound_column.name}_title", None)
+        return self.render_url_html(url, title)
 
 
 class JSONFieldType(FieldType):

--- a/netbox_custom_objects/field_types.py
+++ b/netbox_custom_objects/field_types.py
@@ -543,10 +543,17 @@ class URLFieldType(FieldType):
         field_kwargs.update({"default": field.default, "unique": field.unique})
         return {
             field.name: models.URLField(null=True, blank=True, **field_kwargs),
+            # blank=True, default='' (not null=True): a CharField with null=True lets
+            # "no title" be represented as both NULL (ORM/API create omitting the key)
+            # and '' (a form submission clearing the field), which would make
+            # isnull-based filtering unreliable. default='' also keeps this column
+            # eligible for mixin_migration.py's post_migrate auto-heal pass on
+            # existing installations, which only auto-ADDs a new column when it is
+            # nullable or has a Django-level default (see _can_auto_add()).
             self.title_field_name(field): models.CharField(
                 max_length=200,
-                null=True,
                 blank=True,
+                default="",
                 help_text=_("Human-readable text shown instead of the raw URL."),
             ),
         }

--- a/netbox_custom_objects/field_types.py
+++ b/netbox_custom_objects/field_types.py
@@ -524,17 +524,62 @@ class DateTimeFieldType(FieldType):
 
 
 class URLFieldType(FieldType):
+    """
+    A URL field. Expands into two real DB columns: ``<name>``, the URL itself, and
+    ``<name>_title``, an optional human-readable title shown in place of the raw URL
+    on an object's detail page. Unlike CoordinatesFieldType, the primary ``<name>``
+    column keeps behaving like any other single-value column (unique/default/regex
+    validation all still apply to it) -- only the title is new.
+    """
+
     graphql_annotation = str
+
+    @staticmethod
+    def title_field_name(field):
+        return f"{field.name}_title"
 
     def get_model_field(self, field, **kwargs):
         field_kwargs = self._safe_kwargs(**kwargs)
         field_kwargs.update({"default": field.default, "unique": field.unique})
-        return models.URLField(null=True, blank=True, **field_kwargs)
+        return {
+            field.name: models.URLField(null=True, blank=True, **field_kwargs),
+            self.title_field_name(field): models.CharField(
+                max_length=200,
+                null=True,
+                blank=True,
+                help_text=_("Human-readable text shown instead of the raw URL."),
+            ),
+        }
 
     def get_form_field(self, field, **kwargs):
         return LaxURLField(
             assume_scheme="https", required=field.required, initial=field.default
         )
+
+    def get_form_fields(self, field):
+        """
+        Return the URL and title form fields, keyed by their backing column names
+        (mirrors CoordinatesFieldType.get_form_fields).
+        """
+        base_label = field.label or field.name.replace("_", " ").title()
+        url_field = LaxURLField(
+            label=base_label,
+            assume_scheme="https",
+            required=field.required,
+            initial=field.default,
+        )
+        title_field = forms.CharField(
+            label=f"{base_label} ({_('link title')})",
+            required=False,
+            max_length=200,
+        )
+        if field.ui_editable != CustomFieldUIEditableChoices.YES:
+            url_field.disabled = True
+            title_field.disabled = True
+        return {
+            field.name: url_field,
+            self.title_field_name(field): title_field,
+        }
 
     def get_filterform_field(self, field, **kwargs):
         return forms.CharField(

--- a/netbox_custom_objects/field_types.py
+++ b/netbox_custom_objects/field_types.py
@@ -574,11 +574,13 @@ class URLFieldType(FieldType):
             assume_scheme="https",
             required=field.required,
             initial=field.default,
+            help_text=render_markdown(field.description) if field.description else None,
         )
         title_field = forms.CharField(
             label=f"{base_label} ({_('link title')})",
             required=False,
             max_length=200,
+            help_text=_("Text shown as the link instead of the raw URL."),
         )
         if field.ui_editable != CustomFieldUIEditableChoices.YES:
             url_field.disabled = True

--- a/netbox_custom_objects/management/commands/upgrade_custom_objects.py
+++ b/netbox_custom_objects/management/commands/upgrade_custom_objects.py
@@ -5,15 +5,21 @@ Checks all Custom Object Type tables for mixin column drift and applies safe
 fixes.  Intended as an explicit escape hatch alongside the automatic
 post_migrate signal handler (issue #391).
 
+A full run (no --cot filter) also heals every live NetBox Branching branch's
+own schema, mirroring the post_migrate signal handler -- see
+mixin_migration.heal_all_branches()'s docstring for why that can't be left to
+a branch's own migration signal.  --cot only heals main (a branch-scoped
+single-COT filter isn't supported).
+
 Usage examples
 --------------
-    # Check and fix all COTs
+    # Check and fix all COTs (and all branch schemas)
     manage.py upgrade_custom_objects
 
     # Preview changes without touching the DB
     manage.py upgrade_custom_objects --dry-run
 
-    # Operate on a single COT (by name or numeric ID)
+    # Operate on a single COT on main only (by name or numeric ID)
     manage.py upgrade_custom_objects --cot my_device
     manage.py upgrade_custom_objects --cot 7 --dry-run
 """
@@ -65,20 +71,55 @@ class Command(BaseCommand):
 
             result = heal_cot(cot, verbosity=verbosity, dry_run=dry_run)
             self._print_cot_result(cot.name, result, dry_run, verbosity)
-        else:
-            cots = list(CustomObjectType.objects.all())
-            total = len(cots)
-            healed = warnings = 0
-            for cot in cots:
-                result = heal_cot(cot, verbosity=verbosity, dry_run=dry_run)
-                self._print_cot_result(cot.name, result, dry_run, verbosity)
-                if result["added"]:
-                    healed += 1
-                warnings += len(result["warned"])
-            self._print_summary(
-                {"total": total, "healed": healed, "warnings": warnings},
-                dry_run,
+            return
+
+        cots = list(CustomObjectType.objects.all())
+        total = len(cots)
+        healed = warnings = 0
+        for cot in cots:
+            result = heal_cot(cot, verbosity=verbosity, dry_run=dry_run)
+            self._print_cot_result(cot.name, result, dry_run, verbosity)
+            if result["added"]:
+                healed += 1
+            warnings += len(result["warned"])
+        self._print_summary(
+            {"total": total, "healed": healed, "warnings": warnings},
+            dry_run,
+        )
+
+        self._heal_branches(dry_run, verbosity)
+
+    def _heal_branches(self, dry_run, verbosity):
+        """
+        Heal every live Branch's own schema too.  heal_all_branches() itself
+        no-ops (returns an all-zero summary) when netbox-branching isn't
+        installed, so nothing extra is printed in that case.
+        """
+        from netbox_custom_objects.mixin_migration import heal_all_branches  # noqa: PLC0415
+        result = heal_all_branches(verbosity=verbosity, dry_run=dry_run)
+
+        if result["total"] == 0:
+            return
+
+        tag = " (dry run)" if dry_run else ""
+        if result["healed"] == 0 and result["warnings"] == 0:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"All {result['total']} branch schema(s) are up to date{tag}."
+                )
             )
+        else:
+            self.stdout.write(
+                f"{result['total']} branch(es) checked{tag}: "
+                f"{result['healed']} healed, "
+                f"{result['warnings']} warning(s)."
+            )
+            if result["warnings"]:
+                self.stdout.write(
+                    self.style.WARNING(
+                        "Run with -v 2 or check the application log for warning details."
+                    )
+                )
 
     # ------------------------------------------------------------------
     # Output helpers

--- a/netbox_custom_objects/mixin_migration.py
+++ b/netbox_custom_objects/mixin_migration.py
@@ -26,7 +26,10 @@ Safety rules
 
 import logging
 
+from django.apps import apps as django_apps
 from django.db import DEFAULT_DB_ALIAS, connections
+
+from netbox_custom_objects.models import detect_backing_column_collisions
 
 logger = logging.getLogger(__name__)
 
@@ -87,6 +90,24 @@ def _actual_column_names(table_name, using=DEFAULT_DB_ALIAS):
         }
 
 
+def _branch_schema_exists(schema_name, using=DEFAULT_DB_ALIAS):
+    """
+    Return True if *schema_name* is a real PostgreSQL schema in the database.
+
+    Queried via the *default* connection's catalog, not the branch's own
+    connection -- a branch connection's search path falls through to main
+    when its own schema doesn't exist, so introspecting through it would
+    silently report main's tables instead of raising. information_schema
+    is per-database (not per-schema), so it's visible regardless of which
+    schema is actually live.
+    """
+    with connections[using].cursor() as cursor:
+        cursor.execute(
+            "SELECT 1 FROM information_schema.schemata WHERE schema_name = %s", [schema_name]
+        )
+        return cursor.fetchone() is not None
+
+
 def _can_auto_add(field):
     """
     Return True if it is safe to ADD COLUMN for *field* on a table that
@@ -131,11 +152,11 @@ def heal_cot(cot, verbosity=1, dry_run=False, using=DEFAULT_DB_ALIAS):
     # "<url_field>_title" predating the validation that now blocks this).
     # Independent of DB introspection -- purely a field-definition check --
     # so it runs even if the table itself can't be introspected below.
-    from netbox_custom_objects.models import detect_backing_column_collisions  # noqa: PLC0415
     for collision in detect_backing_column_collisions(cot):
         entry = {
             "type": "backing_column_collision",
             "field": collision["field"],
+            "safe_to_rename": collision["safe_to_rename"],
             "message": collision["message"],
         }
         warned.append(entry)
@@ -356,11 +377,31 @@ def heal_all_branches(verbosity=1, dry_run=False):
     Excludes branches with no live schema: NEW and PROVISIONING haven't been
     provisioned yet (or are mid-provision); ARCHIVED has had its schema
     dropped. Every other status (READY, PENDING_MIGRATIONS, the transitional
-    SYNCING/MIGRATING/MERGING/REVERTING, MERGED, FAILED) keeps its schema
-    until the branch is archived or deleted, so all of those are healed.
-    heal_cot()'s existing per-COT try/except around table introspection
-    means a branch whose schema is unexpectedly missing or broken is
-    reported as a warning for that COT, not a hard failure for the whole run.
+    SYNCING/MIGRATING/MERGING/REVERTING, MERGED, FAILED) normally still has
+    its schema and is a healing candidate, but two further checks are needed
+    before actually touching one:
+
+    - FAILED can mean provisioning itself failed after the schema was
+      created (or the schema was since dropped) -- its status alone doesn't
+      guarantee a live schema the way READY etc. do. Verified explicitly via
+      _branch_schema_exists() rather than assumed from status, since healing
+      through a branch connection whose schema doesn't exist would silently
+      introspect and alter *main*'s tables instead (see that helper's
+      docstring) -- exactly the kind of silent cross-branch corruption this
+      sweep must not risk.
+    - A branch with pending migrations has an ORM that may not match its
+      actual (outdated) schema yet -- heal_cot() could misdiagnose drift, or
+      the branch's schema might be missing entire unrelated tables/columns
+      current model code assumes exist. Skipped here in favor of
+      _heal_branch_on_migrate() (netbox_branching's own per-branch
+      post_migrate receiver in __init__.py), which re-heals that branch once
+      it actually migrates and its schema catches up.
+
+    Each branch's heal_branch() call is wrapped individually so one branch's
+    unexpected failure (e.g. a connection error specific to its schema)
+    doesn't abort the sweep for every other branch; heal_cot()'s own
+    per-COT try/except handles introspection failures within a single
+    otherwise-healthy branch.
 
     Returns
     -------
@@ -369,8 +410,6 @@ def heal_all_branches(verbosity=1, dry_run=False):
       "healed"   : number of branches with at least one COT healed
       "warnings" : total number of non-auto-fixable issues across all branches
     """
-    from django.apps import apps as django_apps  # noqa: PLC0415
-
     if not django_apps.is_installed('netbox_branching'):
         return {"total": 0, "healed": 0, "warnings": 0}
 
@@ -386,7 +425,36 @@ def heal_all_branches(verbosity=1, dry_run=False):
     total = healed = warnings = 0
     for branch in Branch.objects.exclude(status__in=no_schema_statuses):
         total += 1
-        result = heal_branch(branch, verbosity=verbosity, dry_run=dry_run)
+
+        if not _branch_schema_exists(branch.schema_name):
+            logger.warning(
+                "upgrade_custom_objects: skipping branch %r (id=%s, status=%s) -- schema %r "
+                "does not exist (likely a failed or interrupted provision); it will be healed "
+                "once it has a live schema.",
+                branch.name, branch.pk, branch.status, branch.schema_name,
+            )
+            warnings += 1
+            continue
+
+        if branch.pending_migrations:
+            if verbosity >= 2:
+                logger.info(
+                    "upgrade_custom_objects: skipping branch %r (id=%s) -- has pending "
+                    "migrations; will be healed by its own post_migrate hook once migrated.",
+                    branch.name, branch.pk,
+                )
+            continue
+
+        try:
+            result = heal_branch(branch, verbosity=verbosity, dry_run=dry_run)
+        except Exception:
+            logger.exception(
+                "upgrade_custom_objects: unexpected error healing branch %r (id=%s)",
+                branch.name, branch.pk,
+            )
+            warnings += 1
+            continue
+
         if result["healed"]:
             healed += 1
         warnings += result["warnings"]

--- a/netbox_custom_objects/mixin_migration.py
+++ b/netbox_custom_objects/mixin_migration.py
@@ -47,6 +47,14 @@ def _expected_base_fields(cot, model=None):
     (f.name).  This is equivalent to matching by f.column for user-defined COT
     fields because they are never created with db_column overrides.
 
+    Multi-column custom field types (e.g. CoordinatesFieldType's "_latitude"/
+    "_longitude", URLFieldType's "_title") are NOT excluded here, since their
+    backing columns' attribute names never equal the user field's own f.name --
+    so this heal pass also covers them as a deliberate side effect. This is why
+    a newly introduced sub-column for one of those types needs no dedicated
+    migration/upgrade code: as long as it's nullable, the next post_migrate run
+    (or `upgrade_custom_objects`) auto-adds it to every existing COT table.
+
     Pass *model* to avoid a second get_model() call when the caller already
     holds the model reference.
     """

--- a/netbox_custom_objects/mixin_migration.py
+++ b/netbox_custom_objects/mixin_migration.py
@@ -397,11 +397,12 @@ def heal_all_branches(verbosity=1, dry_run=False):
       post_migrate receiver in __init__.py), which re-heals that branch once
       it actually migrates and its schema catches up.
 
-    Each branch's heal_branch() call is wrapped individually so one branch's
-    unexpected failure (e.g. a connection error specific to its schema)
-    doesn't abort the sweep for every other branch; heal_cot()'s own
-    per-COT try/except handles introspection failures within a single
-    otherwise-healthy branch.
+    Each branch's pending_migrations check and heal_branch() call are wrapped
+    individually (one shared try/finally) so one branch's unexpected failure
+    doesn't abort the sweep for every other branch, and its connection is
+    always closed afterward rather than accumulating across the loop;
+    heal_cot()'s own per-COT try/except handles introspection failures
+    within a single otherwise-healthy branch.
 
     Returns
     -------
@@ -436,16 +437,23 @@ def heal_all_branches(verbosity=1, dry_run=False):
             warnings += 1
             continue
 
-        if branch.pending_migrations:
-            if verbosity >= 2:
-                logger.info(
-                    "upgrade_custom_objects: skipping branch %r (id=%s) -- has pending "
-                    "migrations; will be healed by its own post_migrate hook once migrated.",
-                    branch.name, branch.pk,
-                )
-            continue
-
+        # pending_migrations and heal_branch() share one try/finally: both open a
+        # connection on branch.connection_name (pending_migrations via MigrationExecutor),
+        # and neither closes it. netbox_branching hit the same leak in its own per-branch
+        # migration sweep (issue #581) -- accumulating open connections across many
+        # branches can exhaust PostgreSQL's connection limit during `manage.py migrate`.
+        # The shared try also means a broken pending_migrations check can't abort the
+        # sweep for every other branch, matching heal_branch()'s own isolation.
         try:
+            if branch.pending_migrations:
+                if verbosity >= 2:
+                    logger.info(
+                        "upgrade_custom_objects: skipping branch %r (id=%s) -- has pending "
+                        "migrations; will be healed by its own post_migrate hook once migrated.",
+                        branch.name, branch.pk,
+                    )
+                continue
+
             result = heal_branch(branch, verbosity=verbosity, dry_run=dry_run)
         except Exception:
             logger.exception(
@@ -454,6 +462,8 @@ def heal_all_branches(verbosity=1, dry_run=False):
             )
             warnings += 1
             continue
+        finally:
+            connections[branch.connection_name].close()
 
         if result["healed"]:
             healed += 1

--- a/netbox_custom_objects/mixin_migration.py
+++ b/netbox_custom_objects/mixin_migration.py
@@ -22,7 +22,7 @@ Safety rules
 
 import logging
 
-from django.db import connection
+from django.db import DEFAULT_DB_ALIAS, connections
 
 logger = logging.getLogger(__name__)
 
@@ -68,16 +68,18 @@ def _expected_base_fields(cot, model=None):
     }
 
 
-def _actual_column_names(table_name):
+def _actual_column_names(table_name, using=DEFAULT_DB_ALIAS):
     """
-    Return the set of column names currently present in *table_name*.
+    Return the set of column names currently present in *table_name* on the
+    *using* connection (a branch's own schema when healing a branch).
 
     Raises OperationalError / ProgrammingError if the table does not exist.
     """
-    with connection.cursor() as cursor:
+    conn = connections[using]
+    with conn.cursor() as cursor:
         return {
             col.name
-            for col in connection.introspection.get_table_description(cursor, table_name)
+            for col in conn.introspection.get_table_description(cursor, table_name)
         }
 
 
@@ -98,7 +100,7 @@ def _can_auto_add(field):
 # Public API
 # ---------------------------------------------------------------------------
 
-def heal_cot(cot, verbosity=1, dry_run=False):
+def heal_cot(cot, verbosity=1, dry_run=False, using=DEFAULT_DB_ALIAS):
     """
     Detect and repair mixin column drift for a single CustomObjectType.
 
@@ -107,6 +109,8 @@ def heal_cot(cot, verbosity=1, dry_run=False):
     cot       : CustomObjectType instance
     verbosity : int  0=silent, 1=changes+warnings, 2=verbose
     dry_run   : bool  if True, report but do not modify the DB
+    using     : str   connection alias to introspect/alter — a branch's own
+                connection when healing a branch schema (see heal_branch())
 
     Returns
     -------
@@ -119,7 +123,7 @@ def heal_cot(cot, verbosity=1, dry_run=False):
     warned = []
 
     try:
-        actual_names = _actual_column_names(table_name)
+        actual_names = _actual_column_names(table_name, using=using)
     except Exception as exc:
         logger.warning(
             "upgrade_custom_objects: cannot introspect table %r (COT %s): %s",
@@ -164,7 +168,7 @@ def heal_cot(cot, verbosity=1, dry_run=False):
             continue
 
         try:
-            with connection.schema_editor() as editor:
+            with connections[using].schema_editor() as editor:
                 # Flush pending DEFERRABLE FK trigger events before ALTER TABLE;
                 # PostgreSQL rejects ADD COLUMN when deferred triggers are pending.
                 editor.execute('SET CONSTRAINTS ALL IMMEDIATE')
@@ -238,19 +242,20 @@ def heal_cot(cot, verbosity=1, dry_run=False):
                 "null": field.null,
             }
         doc["base_columns"] = list(current_cols.values())
-        cot.__class__.objects.filter(pk=cot.pk).update(schema_document=doc)
+        cot.__class__.objects.using(using).filter(pk=cot.pk).update(schema_document=doc)
         cot.schema_document = doc
 
     return {"added": added, "warned": warned}
 
 
-def heal_all_cots(verbosity=1, dry_run=False):
+def heal_all_cots(verbosity=1, dry_run=False, using=DEFAULT_DB_ALIAS):
     """
     Run heal_cot() for every CustomObjectType.
 
     Called by the post_migrate signal handler.  The upgrade_custom_objects
     management command iterates COTs directly so it can print per-COT output
-    to stdout.
+    to stdout.  heal_branch() calls this with using set to a branch's own
+    connection, from inside activate_branch(), to heal that branch's schema.
 
     Returns
     -------
@@ -263,9 +268,9 @@ def heal_all_cots(verbosity=1, dry_run=False):
 
     total = healed = warnings = 0
 
-    for cot in CustomObjectType.objects.all():
+    for cot in CustomObjectType.objects.using(using).all():
         total += 1
-        result = heal_cot(cot, verbosity=verbosity, dry_run=dry_run)
+        result = heal_cot(cot, verbosity=verbosity, dry_run=dry_run, using=using)
         if result["added"]:
             healed += 1
         warnings += len(result["warned"])
@@ -282,3 +287,26 @@ def heal_all_cots(verbosity=1, dry_run=False):
         )
 
     return {"total": total, "healed": healed, "warnings": warnings}
+
+
+def heal_branch(branch, verbosity=1, dry_run=False):
+    """
+    Run heal_all_cots() against a single Branch's own PostgreSQL schema.
+
+    Branch schema migrations run via netbox-branching's own MigrationExecutor
+    (Branch.migrate()), which never emits Django's core post_migrate signal —
+    only netbox-branching's own post_migrate (see the receiver registered in
+    __init__.py). A branch created before a plugin release that adds a new
+    base column (e.g. #496's <name>_title column) therefore never gets that
+    column added to its own schema: the plugin's post_migrate heal pass only
+    ever ran against DEFAULT_DB_ALIAS.
+
+    activate_branch() makes get_model() resolve each COT's branch-specific
+    model variant (a branch may have renamed columns that don't exist in
+    main); using=branch.connection_name makes the actual introspection/DDL
+    target the branch's own schema, not main's. Both are required together.
+    """
+    from netbox_branching.utilities import activate_branch  # noqa: PLC0415
+
+    with activate_branch(branch):
+        return heal_all_cots(verbosity=verbosity, dry_run=dry_run, using=branch.connection_name)

--- a/netbox_custom_objects/mixin_migration.py
+++ b/netbox_custom_objects/mixin_migration.py
@@ -5,10 +5,12 @@ Phase 2 of issue #391: when NetBox is upgraded and a mixin (e.g.
 ChangeLoggingMixin) gains a new concrete column, existing COT tables will be
 missing that column.  This module provides:
 
-  heal_cot(cot, verbosity, dry_run)   — check and repair a single COT table
-  heal_all_cots(verbosity, dry_run)   — iterate over all COTs
+  heal_cot(cot, verbosity, dry_run)          — check and repair a single COT table
+  heal_all_cots(verbosity, dry_run)          — iterate over all COTs on one connection
+  heal_branch(branch, verbosity, dry_run)    — heal_all_cots() against one Branch's schema
+  heal_all_branches(verbosity, dry_run)      — heal_branch() for every live Branch
 
-Both are called from:
+All four are called from:
   - The post_migrate signal handler in __init__.py (automatic, zero-config)
   - The upgrade_custom_objects management command (explicit, with --dry-run)
 
@@ -17,6 +19,8 @@ Safety rules
   ADD allowed  : new column is nullable OR has a Django-level default
   Warn only    : new column is NOT NULL with no default (would fail for existing rows)
   Warn only    : column type appears to have changed
+  Warn only    : a field's name collides with another field's backing column
+                 (see detect_backing_column_collisions() in models.py)
   Never        : auto-drop a column that is no longer in the base class
 """
 
@@ -121,6 +125,21 @@ def heal_cot(cot, verbosity=1, dry_run=False, using=DEFAULT_DB_ALIAS):
     table_name = cot.get_database_table_name()
     added = []
     warned = []
+
+    # Detect pre-existing field-name collisions with a multi-column type's
+    # synthesized backing column (e.g. a plain field literally named
+    # "<url_field>_title" predating the validation that now blocks this).
+    # Independent of DB introspection -- purely a field-definition check --
+    # so it runs even if the table itself can't be introspected below.
+    from netbox_custom_objects.models import detect_backing_column_collisions  # noqa: PLC0415
+    for collision in detect_backing_column_collisions(cot):
+        entry = {
+            "type": "backing_column_collision",
+            "field": collision["field"],
+            "message": collision["message"],
+        }
+        warned.append(entry)
+        logger.warning(entry["message"])
 
     try:
         actual_names = _actual_column_names(table_name, using=using)
@@ -293,13 +312,17 @@ def heal_branch(branch, verbosity=1, dry_run=False):
     """
     Run heal_all_cots() against a single Branch's own PostgreSQL schema.
 
-    Branch schema migrations run via netbox-branching's own MigrationExecutor
-    (Branch.migrate()), which never emits Django's core post_migrate signal —
-    only netbox-branching's own post_migrate (see the receiver registered in
-    __init__.py). A branch created before a plugin release that adds a new
-    base column (e.g. #496's <name>_title column) therefore never gets that
-    column added to its own schema: the plugin's post_migrate heal pass only
-    ever ran against DEFAULT_DB_ALIAS.
+    A schema change like #496's <name>_title column ships with no Django
+    migration of its own (URLFieldType.get_model_field() just changes what
+    columns a dynamically generated model has -- there's no migration file
+    for netbox-branching's MigrationExecutor to detect as "pending" against
+    a branch). Branch.migrate() therefore has nothing to apply and never
+    fires, so this can't rely on being triggered by a branch's own migrate
+    step or its post_migrate signal. heal_all_branches() (below) is the
+    reliable trigger: it's called unconditionally from the main upgrade
+    path (post_migrate on the default connection, and
+    `manage.py upgrade_custom_objects`), independent of any branch's
+    migration state.
 
     activate_branch() makes get_model() resolve each COT's branch-specific
     model variant (a branch may have renamed columns that don't exist in
@@ -310,3 +333,73 @@ def heal_branch(branch, verbosity=1, dry_run=False):
 
     with activate_branch(branch):
         return heal_all_cots(verbosity=verbosity, dry_run=dry_run, using=branch.connection_name)
+
+
+def heal_all_branches(verbosity=1, dry_run=False):
+    """
+    Run heal_branch() for every Branch that has a real PostgreSQL schema.
+
+    Called unconditionally from the main upgrade path (the post_migrate
+    signal handler in __init__.py, and the upgrade_custom_objects management
+    command) rather than from any branch-specific migration signal -- see
+    heal_branch()'s docstring for why that signal can't be relied on.
+
+    Returns immediately (all-zero summary) when netbox-branching isn't
+    installed -- checked via apps.is_installed(), NOT a bare
+    "import netbox_branching" try/except: netbox-branching can be pip-
+    installed in the environment without being enabled in PLUGINS (e.g. a
+    shared venv, or during the version-check window in checks.py), and in
+    that case importing its models raises `RuntimeError: Model class ...
+    isn't in an application in INSTALLED_APPS` -- not ImportError -- because
+    the package itself resolves fine; only its Django app isn't registered.
+
+    Excludes branches with no live schema: NEW and PROVISIONING haven't been
+    provisioned yet (or are mid-provision); ARCHIVED has had its schema
+    dropped. Every other status (READY, PENDING_MIGRATIONS, the transitional
+    SYNCING/MIGRATING/MERGING/REVERTING, MERGED, FAILED) keeps its schema
+    until the branch is archived or deleted, so all of those are healed.
+    heal_cot()'s existing per-COT try/except around table introspection
+    means a branch whose schema is unexpectedly missing or broken is
+    reported as a warning for that COT, not a hard failure for the whole run.
+
+    Returns
+    -------
+    dict with keys:
+      "total"    : number of branches checked
+      "healed"   : number of branches with at least one COT healed
+      "warnings" : total number of non-auto-fixable issues across all branches
+    """
+    from django.apps import apps as django_apps  # noqa: PLC0415
+
+    if not django_apps.is_installed('netbox_branching'):
+        return {"total": 0, "healed": 0, "warnings": 0}
+
+    from netbox_branching.choices import BranchStatusChoices  # noqa: PLC0415
+    from netbox_branching.models import Branch  # noqa: PLC0415
+
+    no_schema_statuses = (
+        BranchStatusChoices.NEW,
+        BranchStatusChoices.PROVISIONING,
+        BranchStatusChoices.ARCHIVED,
+    )
+
+    total = healed = warnings = 0
+    for branch in Branch.objects.exclude(status__in=no_schema_statuses):
+        total += 1
+        result = heal_branch(branch, verbosity=verbosity, dry_run=dry_run)
+        if result["healed"]:
+            healed += 1
+        warnings += result["warnings"]
+
+    if verbosity >= 2:
+        logger.info(
+            "upgrade_custom_objects: %d branch(es) checked, %d healed, %d warning(s)",
+            total, healed, warnings,
+        )
+    elif verbosity >= 1 and (healed > 0 or warnings > 0):
+        logger.info(
+            "upgrade_custom_objects: %d branch(es) healed, %d warning(s)",
+            healed, warnings,
+        )
+
+    return {"total": total, "healed": healed, "warnings": warnings}

--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -253,6 +253,17 @@ def _apply_deferred_co_field(field_instance):
     if field_instance.pk is not None:
         candidate_keys.update(_historical_names_for_field(field_instance.pk))
 
+    # A URL field has a second backing column (<name>_title) whose value must
+    # be replayed too, or it silently reverts to its default empty string —
+    # the URL and title can be set independently, so each is matched and
+    # applied on its own.
+    title_col_name = None
+    title_candidate_keys = set()
+    if field_instance.type == CustomFieldTypeChoices.TYPE_URL:
+        from netbox_custom_objects.field_types import URLFieldType  # noqa: PLC0415
+        title_col_name = URLFieldType.title_field_name(field_instance)
+        title_candidate_keys = {f'{k}_title' for k in candidate_keys}
+
     schema_conn = _get_schema_connection()
 
     with schema_conn.cursor() as cursor:
@@ -261,19 +272,25 @@ def _apply_deferred_co_field(field_instance):
             # Distinguish "key absent" from "key present with NULL" — explicit
             # None is a legitimate write and must reach the column.
             matched = next((k for k in candidate_keys if k in data), None)
-            if matched is None:
+            title_matched = next((k for k in title_candidate_keys if k in data), None)
+            if matched is None and title_matched is None:
                 continue
-            value = data[matched]
             # table_name / col_name come from validated identifiers
             # (^[a-z0-9_]+$ on field.name) — safe to interpolate.
-            cursor.execute(
-                f'UPDATE "{table_name}" SET "{col_name}" = %s WHERE id = %s',
-                [value, co_pk],
-            )
+            if matched is not None:
+                cursor.execute(
+                    f'UPDATE "{table_name}" SET "{col_name}" = %s WHERE id = %s',
+                    [data[matched], co_pk],
+                )
+            if title_matched is not None:
+                cursor.execute(
+                    f'UPDATE "{table_name}" SET "{title_col_name}" = %s WHERE id = %s',
+                    [data[title_matched], co_pk],
+                )
             # Pop consumed keys immediately so a mid-loop failure leaves
             # un-applied rows intact for retry but doesn't re-apply
             # rows that already succeeded.
-            for k in candidate_keys:
+            for k in candidate_keys | title_candidate_keys:
                 data.pop(k, None)
 
     exhausted = [pk for pk, entry in per_table.items() if not entry['data']]
@@ -395,6 +412,53 @@ def _schema_remove_field(fi, model, schema_editor, schema_conn=None, existing_ta
     schema_editor.remove_field(model, mf)
 
 
+def _alter_column_with_rename_conflict_resolution(
+    old_mf, new_mf, model, schema_editor, schema_conn, resolve_live_column, log_label,
+):
+    """``alter_field`` from *old_mf* to *new_mf*, resolving a rename conflict
+    (neither the old nor the new column exists — independent renames on
+    branch A→X vs. main A→Y that must converge) by asking
+    *resolve_live_column* for the field's actual current column.
+
+    *resolve_live_column* takes no arguments and returns the live ``Field``
+    (already ``contribute_to_class``-ed onto *model*), or ``None`` if it
+    can't be resolved — in which case the rename is skipped for this replay.
+    Idempotent: a no-op if *new_mf*'s column already exists.
+    """
+    with schema_conn.cursor() as cursor:
+        existing_cols = {
+            col.name
+            for col in schema_conn.introspection.get_table_description(cursor, model._meta.db_table)
+        }
+    if old_mf.column not in existing_cols:
+        if new_mf.column in existing_cols:
+            logger.debug(
+                '%s: %r already renamed to %r on %s, skipping',
+                log_label, old_mf.column, new_mf.column, model._meta.db_table,
+            )
+            return
+        # Both source and target columns absent → independent rename in this
+        # schema; look up the live column and converge on the merge target.
+        logger.warning(
+            '%s: rename conflict on %s — neither %r nor %r exists; '
+            'resolving via live field',
+            log_label, model._meta.db_table, old_mf.column, new_mf.column,
+        )
+        live_mf = resolve_live_column()
+        if live_mf is None:
+            return
+        if live_mf.column not in existing_cols:
+            logger.debug(
+                '%s: live column %r also absent on %s; skipping',
+                log_label, live_mf.column, model._meta.db_table,
+            )
+            return
+        schema_editor.alter_field(model, live_mf, new_mf)
+        return
+
+    schema_editor.alter_field(model, old_mf, new_mf)
+
+
 def _schema_alter_field(old_fi, new_fi, model, schema_editor, schema_conn, existing_tables=None):
     """``alter_field`` from *old_fi* to *new_fi*; idempotent across replays.
 
@@ -427,25 +491,7 @@ def _schema_alter_field(old_fi, new_fi, model, schema_editor, schema_conn, exist
             )
         return
 
-    with schema_conn.cursor() as cursor:
-        existing_cols = {
-            col.name
-            for col in schema_conn.introspection.get_table_description(cursor, model._meta.db_table)
-        }
-    if old_mf.column not in existing_cols:
-        if new_mf.column in existing_cols:
-            logger.debug(
-                '_schema_alter_field: %r already renamed to %r on %s, skipping',
-                old_mf.column, new_mf.column, model._meta.db_table,
-            )
-            return
-        # Both source and target columns absent → independent rename in this
-        # schema; look up the live column and converge on the merge target.
-        logger.warning(
-            '_schema_alter_field: rename conflict on %s — neither %r nor %r '
-            'exists; resolving via live field pk=%d',
-            model._meta.db_table, old_mf.column, new_mf.column, new_fi.pk,
-        )
+    def _resolve_live_primary_column():
         try:
             live_fi = CustomObjectTypeField.objects.using(schema_conn.alias).get(pk=new_fi.pk)
         except CustomObjectTypeField.DoesNotExist:
@@ -453,19 +499,16 @@ def _schema_alter_field(old_fi, new_fi, model, schema_editor, schema_conn, exist
                 '_schema_alter_field: field pk=%d not found in %s; skipping',
                 new_fi.pk, schema_conn.alias,
             )
-            return
+            return None
         live_mf = _primary_model_field(live_fi)
         live_mf.contribute_to_class(model, live_fi.name)
-        if live_mf.column not in existing_cols:
-            logger.debug(
-                '_schema_alter_field: live column %r also absent on %s; skipping',
-                live_mf.column, model._meta.db_table,
-            )
-            return
-        schema_editor.alter_field(model, live_mf, new_mf)
-        return
+        return live_mf
 
-    schema_editor.alter_field(model, old_mf, new_mf)
+    _alter_column_with_rename_conflict_resolution(
+        old_mf, new_mf, model, schema_editor, schema_conn,
+        resolve_live_column=_resolve_live_primary_column,
+        log_label='_schema_alter_field',
+    )
 
 
 def _rename_or_create_m2m_through(old_fi, new_fi, model, schema_editor, schema_conn, existing_tables):
@@ -3592,7 +3635,24 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
                             new_title_field = field_type.get_model_field(self)[new_title]
                             old_title_field.contribute_to_class(model, old_title)
                             new_title_field.contribute_to_class(model, new_title)
-                            schema_editor.alter_field(model, old_title_field, new_title_field)
+
+                            def _resolve_live_title_column():
+                                try:
+                                    live_fi = CustomObjectTypeField.objects.using(
+                                        schema_conn.alias
+                                    ).get(pk=self.pk)
+                                except CustomObjectTypeField.DoesNotExist:
+                                    return None
+                                live_title_name = field_type.title_field_name(live_fi)
+                                live_title_field = field_type.get_model_field(live_fi)[live_title_name]
+                                live_title_field.contribute_to_class(model, live_title_name)
+                                return live_title_field
+
+                            _alter_column_with_rename_conflict_resolution(
+                                old_title_field, new_title_field, model, schema_editor, schema_conn,
+                                resolve_live_column=_resolve_live_title_column,
+                                log_label='CustomObjectTypeField.save (title column)',
+                            )
 
             # Rewrite historical audit-data keys so any future replay can
             # resolve old or new name to the current field name.
@@ -3602,6 +3662,12 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
                 and self._original_name != self.name
             ):
                 _rename_objectchange_field_key(self, self._original_name, self.name)
+                if self.type == CustomObjectFieldTypeChoices.TYPE_URL:
+                    _rename_objectchange_field_key(
+                        self,
+                        field_type.title_field_name(self.original),
+                        field_type.title_field_name(self),
+                    )
 
             # FK-constraint decision inside the atomic so a rollback discards it too.
             should_ensure_fk = False

--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -3547,7 +3547,19 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
                             title_name = field_type.title_field_name(self)
                             title_field = field_type.get_model_field(self)[title_name]
                             title_field.contribute_to_class(model, title_name)
-                            schema_editor.add_field(model, title_field)
+                            with schema_conn.cursor() as cursor:
+                                existing_cols = {
+                                    col.name for col in schema_conn.introspection.get_table_description(
+                                        cursor, model._meta.db_table
+                                    )
+                                }
+                            if title_field.column in existing_cols:
+                                logger.debug(
+                                    '_schema_add_field: %r already exists on %s, skipping',
+                                    title_field.column, model._meta.db_table,
+                                )
+                            else:
+                                schema_editor.add_field(model, title_field)
                 else:
                     if self.type == CustomObjectFieldTypeChoices.TYPE_COORDINATES:
                         # Only a rename touches the schema; other attribute changes

--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -368,15 +368,9 @@ def detect_backing_column_collisions(cot):
             if clash:
                 seen_pairs.add(pair_key)
                 column = sorted(clash)[0]
-                # Only the field whose OWN name literally equals the clashing column
-                # name is safe to rename: renaming the *other* field would, via its
-                # own multi-column rename, also rename this same column out from
-                # under whichever field's data actually lives there -- e.g. renaming
-                # a "website" (url) field whose derived "website_title" sub-column
-                # collides with a plain field literally named "website_title" would
-                # rename that column to "<new-name>_title", moving the plain field's
-                # data into what looks like the URL's title and leaving the plain
-                # field pointing at a column that no longer exists.
+                # Renaming the *other* field would carry this column along via its
+                # own multi-column rename instead of leaving it in place -- only
+                # whichever field's own name equals it is safe to rename.
                 safe_to_rename = field.name if field.name == column else sibling.name
                 collisions.append({
                     "field": field.name,

--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -312,6 +312,74 @@ MULTI_COLUMN_TYPES = {
 }
 
 
+def _occupied_columns(name, field_type):
+    """Real DB column name(s) that a field named *name* of *field_type* occupies.
+
+    Single-column types occupy just {name}; multi-column types (coordinates,
+    url) occupy more than one -- see MULTI_COLUMN_TYPES. Shared by
+    CustomObjectTypeField.clean()'s collision guard (new/renamed fields going
+    forward) and detect_backing_column_collisions() (pre-existing fields at
+    heal time).
+    """
+    if field_type == CustomObjectFieldTypeChoices.TYPE_COORDINATES:
+        return {f"{name}_latitude", f"{name}_longitude"}
+    if field_type == CustomObjectFieldTypeChoices.TYPE_URL:
+        return {name, f"{name}_title"}
+    return {name}
+
+
+def detect_backing_column_collisions(cot):
+    """
+    Detect pairs of fields on *cot* whose backing columns collide.
+
+    ``CustomObjectTypeField.clean()`` rejects this combination for any *new*
+    or *renamed* field going forward (see its collision guard), but a plain
+    field literally named e.g. ``"<url_field>_title"`` could already exist
+    from before that validation shipped -- ``URLFieldType.get_model_field()``
+    didn't expand into a second backing column until #496, so nothing stopped
+    a sibling field from claiming that name first. After upgrading, both
+    fields would silently share one Django model attribute in
+    ``CustomObjectType._fetch_and_generate_field_attrs()`` (whichever is
+    processed last wins, discarding the other) with no error raised. Called
+    from ``mixin_migration.heal_cot()`` so this is surfaced as an actionable
+    warning instead of proceeding silently.
+
+    Returns a list of ``{"field", "other", "column", "message"}`` dicts, one
+    per colliding pair (each unordered pair reported once).
+    """
+    fields = list(cot.fields.all())
+    collisions = []
+    seen_pairs = set()
+    for field in fields:
+        if field.type not in MULTI_COLUMN_TYPES:
+            continue
+        own_columns = _occupied_columns(field.name, field.type)
+        for sibling in fields:
+            if sibling.pk == field.pk:
+                continue
+            pair_key = frozenset((field.pk, sibling.pk))
+            if pair_key in seen_pairs:
+                continue
+            clash = own_columns & _occupied_columns(sibling.name, sibling.type)
+            if clash:
+                seen_pairs.add(pair_key)
+                column = sorted(clash)[0]
+                collisions.append({
+                    "field": field.name,
+                    "other": sibling.name,
+                    "column": column,
+                    "message": (
+                        f"Custom Object Type {cot.name!r}: field {field.name!r} "
+                        f"({field.type}) and field {sibling.name!r} ({sibling.type}) "
+                        f"both map to backing column {column!r}. This predates "
+                        f"validation that now blocks creating this combination; "
+                        f"rename one of the two fields to resolve the collision, "
+                        f"then re-run 'manage.py upgrade_custom_objects'."
+                    ),
+                })
+    return collisions
+
+
 def _primary_model_field(fi):
     """fi's own <name>-column Field, unwrapping FieldType.get_model_field()'s dict
     return for a multi-column type (coordinates, url) so single-column DDL/validation
@@ -2903,13 +2971,6 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
         # issue a duplicate-column ALTER and PostgreSQL would raise a ProgrammingError
         # instead of a clean validation error. Detect the overlap here.
         if self.custom_object_type_id:
-            def _occupied_columns(name, field_type):
-                if field_type == CustomObjectFieldTypeChoices.TYPE_COORDINATES:
-                    return {f"{name}_latitude", f"{name}_longitude"}
-                if field_type == CustomObjectFieldTypeChoices.TYPE_URL:
-                    return {name, f"{name}_title"}
-                return {name}
-
             own_columns = _occupied_columns(self.name, self.type)
             # A clash can only involve a multi-column field's expanded columns. If this
             # field isn't multi-column, only sibling multi-column fields can collide with
@@ -3583,10 +3644,11 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
                             field_type.create_polymorphic_m2m_table(self, model, schema_editor)
                     else:
                         _schema_add_field(self, model, schema_editor, schema_conn)
-                        _apply_deferred_co_field(self)
                         if self.type == CustomObjectFieldTypeChoices.TYPE_URL:
-                            # A url field's title column has no deferred-CO-field
-                            # replay support (matches the existing coordinates gap).
+                            # Add the title column before _apply_deferred_co_field()
+                            # runs below -- it replays both <name> and <name>_title
+                            # from buffered squash-merge data, and an UPDATE against
+                            # a column that doesn't exist yet would fail.
                             title_name = field_type.title_field_name(self)
                             title_field = field_type.get_model_field(self)[title_name]
                             title_field.contribute_to_class(model, title_name)
@@ -3603,6 +3665,7 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
                                 )
                             else:
                                 schema_editor.add_field(model, title_field)
+                        _apply_deferred_co_field(self)
                 else:
                     if self.type == CustomObjectFieldTypeChoices.TYPE_COORDINATES:
                         # Only a rename touches the schema; other attribute changes

--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -344,8 +344,12 @@ def detect_backing_column_collisions(cot):
     from ``mixin_migration.heal_cot()`` so this is surfaced as an actionable
     warning instead of proceeding silently.
 
-    Returns a list of ``{"field", "other", "column", "message"}`` dicts, one
-    per colliding pair (each unordered pair reported once).
+    Returns a list of ``{"field", "other", "column", "safe_to_rename", "message"}``
+    dicts, one per colliding pair (each unordered pair reported once).
+    ``safe_to_rename`` names whichever of ``field``/``other`` has that column
+    as its own primary name -- the only one of the two safe to rename, since
+    renaming the *other* field would carry this shared column along with it
+    (see the comment at the collision-detection site below).
     """
     fields = list(cot.fields.all())
     collisions = []
@@ -364,17 +368,30 @@ def detect_backing_column_collisions(cot):
             if clash:
                 seen_pairs.add(pair_key)
                 column = sorted(clash)[0]
+                # Only the field whose OWN name literally equals the clashing column
+                # name is safe to rename: renaming the *other* field would, via its
+                # own multi-column rename, also rename this same column out from
+                # under whichever field's data actually lives there -- e.g. renaming
+                # a "website" (url) field whose derived "website_title" sub-column
+                # collides with a plain field literally named "website_title" would
+                # rename that column to "<new-name>_title", moving the plain field's
+                # data into what looks like the URL's title and leaving the plain
+                # field pointing at a column that no longer exists.
+                safe_to_rename = field.name if field.name == column else sibling.name
                 collisions.append({
                     "field": field.name,
                     "other": sibling.name,
                     "column": column,
+                    "safe_to_rename": safe_to_rename,
                     "message": (
                         f"Custom Object Type {cot.name!r}: field {field.name!r} "
                         f"({field.type}) and field {sibling.name!r} ({sibling.type}) "
                         f"both map to backing column {column!r}. This predates "
-                        f"validation that now blocks creating this combination; "
-                        f"rename one of the two fields to resolve the collision, "
-                        f"then re-run 'manage.py upgrade_custom_objects'."
+                        f"validation that now blocks creating this combination. Rename "
+                        f"{safe_to_rename!r} (the field whose own name matches the "
+                        f"colliding column) to resolve this -- renaming the other field "
+                        f"instead would move {safe_to_rename!r}'s data into that field's "
+                        f"sub-column -- then re-run 'manage.py upgrade_custom_objects'."
                     ),
                 })
     return collisions

--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -285,6 +285,24 @@ def _apply_deferred_co_field(field_instance):
         _deferred_co_field_data.set(None)
 
 
+# Field types whose FieldType.get_model_field() returns a dict of multiple backing
+# columns rather than a single Field (coordinates: latitude/longitude; url: the URL
+# itself plus an optional title). Used to reject type conversion to/from these types
+# (see CustomObjectTypeField.clean()) and to widen the backing-column-collision scan.
+MULTI_COLUMN_TYPES = {
+    CustomObjectFieldTypeChoices.TYPE_COORDINATES,
+    CustomObjectFieldTypeChoices.TYPE_URL,
+}
+
+
+def _primary_model_field(fi):
+    """fi's own <name>-column Field, unwrapping FieldType.get_model_field()'s dict
+    return for a multi-column type (coordinates, url) so single-column DDL/validation
+    code can keep treating every field type uniformly."""
+    mf = FIELD_TYPE_CLASS[fi.type]().get_model_field(fi)
+    return mf[fi.name] if isinstance(mf, dict) else mf
+
+
 def _schema_add_field(fi, model, schema_editor, schema_conn):
     """``add_field`` against *schema_conn*; idempotent (skips if column exists).
 
@@ -292,7 +310,7 @@ def _schema_add_field(fi, model, schema_editor, schema_conn):
     applied here — call ``_apply_deferred_co_field`` separately after.
     """
     ft = FIELD_TYPE_CLASS[fi.type]()
-    mf = ft.get_model_field(fi)
+    mf = _primary_model_field(fi)
     mf.contribute_to_class(model, fi.name)
 
     with schema_conn.cursor() as cursor:
@@ -342,8 +360,7 @@ def _schema_remove_field(fi, model, schema_editor, schema_conn=None, existing_ta
     PostgreSQL doesn't reject the call with "pending trigger events".
     *existing_tables* optionally short-circuits the per-call introspection.
     """
-    ft = FIELD_TYPE_CLASS[fi.type]()
-    mf = ft.get_model_field(fi)
+    mf = _primary_model_field(fi)
     mf.contribute_to_class(model, fi.name)
 
     if fi.type == CustomFieldTypeChoices.TYPE_MULTIOBJECT:
@@ -397,8 +414,8 @@ def _schema_alter_field(old_fi, new_fi, model, schema_editor, schema_conn, exist
         )
         return
 
-    old_mf = FIELD_TYPE_CLASS[old_fi.type]().get_model_field(old_fi)
-    new_mf = FIELD_TYPE_CLASS[new_fi.type]().get_model_field(new_fi)
+    old_mf = _primary_model_field(old_fi)
+    new_mf = _primary_model_field(new_fi)
     old_mf.contribute_to_class(model, old_fi.name)
     new_mf.contribute_to_class(model, new_fi.name)
 
@@ -437,7 +454,7 @@ def _schema_alter_field(old_fi, new_fi, model, schema_editor, schema_conn, exist
                 new_fi.pk, schema_conn.alias,
             )
             return
-        live_mf = FIELD_TYPE_CLASS[live_fi.type]().get_model_field(live_fi)
+        live_mf = _primary_model_field(live_fi)
         live_mf.contribute_to_class(model, live_fi.name)
         if live_mf.column not in existing_cols:
             logger.debug(
@@ -955,6 +972,8 @@ class CustomObject(
             # Coordinates fields have no single column; clone the two backing columns.
             if field_type == CustomObjectFieldTypeChoices.TYPE_COORDINATES:
                 names += [f"{name}_latitude", f"{name}_longitude"]
+            elif field_type == CustomObjectFieldTypeChoices.TYPE_URL:
+                names += [name, f"{name}_title"]
             else:
                 names.append(name)
 
@@ -2667,12 +2686,11 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
             and hasattr(self, '_original')
             and not self.original.unique
         ):
-            field_type = FIELD_TYPE_CLASS[self.type]()
-            model_field = field_type.get_model_field(self)
+            model_field = _primary_model_field(self)
             model = self.custom_object_type.get_model()
             model_field.contribute_to_class(model, self.name)
 
-            old_field = field_type.get_model_field(self.original)
+            old_field = _primary_model_field(self.original)
             old_field.contribute_to_class(model, self._original_name)
 
             # Route the probe through the branch's connection so the ALTER
@@ -2811,46 +2829,53 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
                 {"name": _("Cannot rename a polymorphic field after creation.")}
             )
 
-        # Prevent converting an existing field to or from coordinates.
+        # Prevent converting an existing field to or from a multi-column type
+        # (coordinates, url).
         #
-        # A coordinates field occupies two concrete columns ("{name}_latitude" and
-        # "{name}_longitude") while every other field type occupies a single column
-        # named "{name}". The save() path has no logic to migrate between those two
-        # shapes, so allowing the conversion would either leave the original column
-        # orphaned (→ coordinates) or attempt to alter a column that doesn't exist
-        # (coordinates → other), raising an uncaught database error. Reject it here,
+        # A multi-column field occupies more than one concrete column ("{name}_latitude"/
+        # "{name}_longitude" for coordinates, "{name}"/"{name}_title" for url) while every
+        # other field type (and, prior to this conversion, the field itself) occupies a
+        # single column. The save() path has no logic to migrate between those shapes, so
+        # allowing the conversion would either leave columns orphaned or attempt to alter a
+        # column that doesn't exist, raising an uncaught database error. Reject it here,
         # mirroring the polymorphic-flag guard above.
-        is_coordinates = self.type == CustomObjectFieldTypeChoices.TYPE_COORDINATES
-        was_coordinates = self._original_type == CustomObjectFieldTypeChoices.TYPE_COORDINATES
-        if self.pk and not self._state.adding and is_coordinates != was_coordinates:
+        if (
+            self.pk
+            and not self._state.adding
+            and self.type != self._original_type
+            and (self.type in MULTI_COLUMN_TYPES or self._original_type in MULTI_COLUMN_TYPES)
+        ):
             raise ValidationError(
-                {"type": _("Cannot change a field's type to or from coordinates after creation.")}
+                {"type": _(
+                    "Cannot change a field's type to or from a multi-column type "
+                    "(coordinates, URL) after creation."
+                )}
             )
 
         # Guard against backing-column name collisions.
         #
-        # A coordinates field expands into "{name}_latitude"/"{name}_longitude". If a
-        # sibling field already occupies one of those column names (or vice versa: a
-        # plain field named "<coord>_latitude"), the schema editor would issue a
-        # duplicate-column ALTER and PostgreSQL would raise a ProgrammingError instead
-        # of a clean validation error. Detect the overlap here.
+        # A multi-column field expands into more than one real column (see above). If a
+        # sibling field already occupies one of those column names (or vice versa: a plain
+        # field named e.g. "<coord>_latitude" or "<url>_title"), the schema editor would
+        # issue a duplicate-column ALTER and PostgreSQL would raise a ProgrammingError
+        # instead of a clean validation error. Detect the overlap here.
         if self.custom_object_type_id:
             def _occupied_columns(name, field_type):
                 if field_type == CustomObjectFieldTypeChoices.TYPE_COORDINATES:
                     return {f"{name}_latitude", f"{name}_longitude"}
+                if field_type == CustomObjectFieldTypeChoices.TYPE_URL:
+                    return {name, f"{name}_title"}
                 return {name}
 
             own_columns = _occupied_columns(self.name, self.type)
-            # A clash can only involve a coordinates field's expanded columns. If
-            # this field isn't coordinates, only sibling coordinates fields can
-            # collide with it — so skip the full sibling scan and query just those
-            # (usually zero) to avoid an extra queryset on every field's save.
-            if self.type == CustomObjectFieldTypeChoices.TYPE_COORDINATES:
+            # A clash can only involve a multi-column field's expanded columns. If this
+            # field isn't multi-column, only sibling multi-column fields can collide with
+            # it — so skip the full sibling scan and query just those (usually zero) to
+            # avoid an extra queryset on every field's save.
+            if self.type in MULTI_COLUMN_TYPES:
                 siblings = self.custom_object_type.fields.all()
             else:
-                siblings = self.custom_object_type.fields.filter(
-                    type=CustomObjectFieldTypeChoices.TYPE_COORDINATES
-                )
+                siblings = self.custom_object_type.fields.filter(type__in=MULTI_COLUMN_TYPES)
             if self.pk:
                 siblings = siblings.exclude(pk=self.pk)
             for sibling in siblings:
@@ -3516,6 +3541,13 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
                     else:
                         _schema_add_field(self, model, schema_editor, schema_conn)
                         _apply_deferred_co_field(self)
+                        if self.type == CustomObjectFieldTypeChoices.TYPE_URL:
+                            # A url field's title column has no deferred-CO-field
+                            # replay support (matches the existing coordinates gap).
+                            title_name = field_type.title_field_name(self)
+                            title_field = field_type.get_model_field(self)[title_name]
+                            title_field.contribute_to_class(model, title_name)
+                            schema_editor.add_field(model, title_field)
                 else:
                     if self.type == CustomObjectFieldTypeChoices.TYPE_COORDINATES:
                         # Only a rename touches the schema; other attribute changes
@@ -3536,6 +3568,19 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
                             )
                     else:
                         _schema_alter_field(self.original, self, model, schema_editor, schema_conn)
+                        if (
+                            self.type == CustomObjectFieldTypeChoices.TYPE_URL
+                            and self.name != self._original_name
+                        ):
+                            # Only a rename touches the title column; other attribute
+                            # changes are persisted by super().save() below.
+                            old_title = field_type.title_field_name(self.original)
+                            new_title = field_type.title_field_name(self)
+                            old_title_field = field_type.get_model_field(self.original)[old_title]
+                            new_title_field = field_type.get_model_field(self)[new_title]
+                            old_title_field.contribute_to_class(model, old_title)
+                            new_title_field.contribute_to_class(model, new_title)
+                            schema_editor.alter_field(model, old_title_field, new_title_field)
 
             # Rewrite historical audit-data keys so any future replay can
             # resolve old or new name to the current field name.
@@ -3660,6 +3705,12 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
                     except LookupError:
                         pass
                 _schema_remove_field(self, model, schema_editor, schema_conn=schema_conn)
+                if self.type == CustomObjectFieldTypeChoices.TYPE_URL:
+                    # Drop the title column alongside the primary URL column.
+                    title_name = field_type.title_field_name(self)
+                    title_field = field_type.get_model_field(self)[title_name]
+                    title_field.contribute_to_class(model, title_name)
+                    schema_editor.remove_field(model, title_field)
 
         # Deregister the dropped through model (both polymorphic and plain MULTIOBJECT)
         # so the cascade-delete collector no longer queries the now-missing table.

--- a/netbox_custom_objects/templates/netbox_custom_objects/customobject.html
+++ b/netbox_custom_objects/templates/netbox_custom_objects/customobject.html
@@ -153,6 +153,14 @@
                             {{ ''|placeholder }}
                           {% endif %}
                         {% endwith %}
+                      {% elif field.type == 'url' %}
+                        {% with url_html=object|get_url_field_html:field %}
+                          {% if url_html %}
+                            {{ url_html }}
+                          {% else %}
+                            {{ ''|placeholder }}
+                          {% endif %}
+                        {% endwith %}
                       {% else %}
                         {% customfield_value field object|get_field_value:field %}
                       {% endif %}

--- a/netbox_custom_objects/templatetags/custom_object_utils.py
+++ b/netbox_custom_objects/templatetags/custom_object_utils.py
@@ -1,8 +1,10 @@
+from urllib.parse import urlparse
+
 from django import template
 from django.utils.html import format_html
 from django.utils.text import Truncator
 from extras.choices import CustomFieldUIVisibleChoices
-from utilities.validators import url_scheme_is_allowed
+from netbox.config import get_config
 
 from netbox_custom_objects.choices import CustomObjectFieldTypeChoices
 from netbox_custom_objects.models import CustomObjectTypeField
@@ -72,13 +74,29 @@ def get_field_is_ui_visible(obj, field: CustomObjectTypeField) -> bool:
     return False
 
 
+def _url_scheme_is_allowed(value):
+    """
+    Return True if value's URL scheme is permitted by ALLOWED_URL_SCHEMES (a
+    schemeless/unparseable value is treated as relative and allowed). Reimplemented
+    locally rather than imported from NetBox core's utilities.validators, since
+    url_scheme_is_allowed() only exists on NetBox's feature branch (added 2026-07-23)
+    and this plugin supports NetBox versions well before that -- ALLOWED_URL_SCHEMES
+    itself has existed since 2020 and is safe to rely on across the supported range.
+    """
+    try:
+        scheme = urlparse(value).scheme.lower()
+    except ValueError:
+        scheme = ""
+    return not scheme or scheme in get_config().ALLOWED_URL_SCHEMES
+
+
 @register.filter(name="get_url_field_html")
 def get_url_field_html(obj, field: CustomObjectTypeField):
     """
     Render a url-type field as a safe link: the title as link text if set, falling
     back to the URL itself, truncated to 70 chars -- mirrors NetBox core's
     builtins/customfield_value.html convention for 'url' custom fields, including
-    its url_scheme_is_allowed() guard against unsafe schemes (e.g. javascript:).
+    its scheme-allowlist guard against unsafe schemes (e.g. javascript:).
     Returns '' when the URL itself is unset, regardless of whether a title is set.
     """
     if field.type != CustomObjectFieldTypeChoices.TYPE_URL:
@@ -88,7 +106,7 @@ def get_url_field_html(obj, field: CustomObjectTypeField):
         return ""
     title = getattr(obj, f"{field.name}_title", None)
     display_text = Truncator(title or url).chars(70)
-    if url_scheme_is_allowed(url):
+    if _url_scheme_is_allowed(url):
         return format_html('<a href="{}">{}</a>', url, display_text)
     return display_text
 

--- a/netbox_custom_objects/templatetags/custom_object_utils.py
+++ b/netbox_custom_objects/templatetags/custom_object_utils.py
@@ -1,5 +1,8 @@
 from django import template
+from django.utils.html import format_html
+from django.utils.text import Truncator
 from extras.choices import CustomFieldUIVisibleChoices
+from utilities.validators import url_scheme_is_allowed
 
 from netbox_custom_objects.choices import CustomObjectFieldTypeChoices
 from netbox_custom_objects.models import CustomObjectTypeField
@@ -12,6 +15,7 @@ __all__ = (
     "get_field_is_ui_visible",
     "get_child_relations",
     "get_coordinate_map_url",
+    "get_url_field_html",
 )
 
 register = template.Library()
@@ -66,6 +70,27 @@ def get_field_is_ui_visible(obj, field: CustomObjectTypeField) -> bool:
     if field.ui_visible == CustomFieldUIVisibleChoices.IF_SET and field_value:
         return True
     return False
+
+
+@register.filter(name="get_url_field_html")
+def get_url_field_html(obj, field: CustomObjectTypeField):
+    """
+    Render a url-type field as a safe link: the title as link text if set, falling
+    back to the URL itself, truncated to 70 chars -- mirrors NetBox core's
+    builtins/customfield_value.html convention for 'url' custom fields, including
+    its url_scheme_is_allowed() guard against unsafe schemes (e.g. javascript:).
+    Returns '' when the URL itself is unset, regardless of whether a title is set.
+    """
+    if field.type != CustomObjectFieldTypeChoices.TYPE_URL:
+        return ""
+    url = getattr(obj, field.name, None)
+    if not url:
+        return ""
+    title = getattr(obj, f"{field.name}_title", None)
+    display_text = Truncator(title or url).chars(70)
+    if url_scheme_is_allowed(url):
+        return format_html('<a href="{}">{}</a>', url, display_text)
+    return display_text
 
 
 @register.filter(name="get_child_relations")

--- a/netbox_custom_objects/templatetags/custom_object_utils.py
+++ b/netbox_custom_objects/templatetags/custom_object_utils.py
@@ -1,12 +1,8 @@
-from urllib.parse import urlparse
-
 from django import template
-from django.utils.html import format_html
-from django.utils.text import Truncator
 from extras.choices import CustomFieldUIVisibleChoices
-from netbox.config import get_config
 
 from netbox_custom_objects.choices import CustomObjectFieldTypeChoices
+from netbox_custom_objects.field_types import URLFieldType
 from netbox_custom_objects.models import CustomObjectTypeField
 from netbox_custom_objects.utilities import build_map_url
 
@@ -74,41 +70,19 @@ def get_field_is_ui_visible(obj, field: CustomObjectTypeField) -> bool:
     return False
 
 
-def _url_scheme_is_allowed(value):
-    """
-    Return True if value's URL scheme is permitted by ALLOWED_URL_SCHEMES (a
-    schemeless/unparseable value is treated as relative and allowed). Reimplemented
-    locally rather than imported from NetBox core's utilities.validators, since
-    url_scheme_is_allowed() only exists on NetBox's feature branch (added 2026-07-23)
-    and this plugin supports NetBox versions well before that -- ALLOWED_URL_SCHEMES
-    itself has existed since 2020 and is safe to rely on across the supported range.
-    """
-    try:
-        scheme = urlparse(value).scheme.lower()
-    except ValueError:
-        scheme = ""
-    return not scheme or scheme in get_config().ALLOWED_URL_SCHEMES
-
-
 @register.filter(name="get_url_field_html")
 def get_url_field_html(obj, field: CustomObjectTypeField):
     """
-    Render a url-type field as a safe link: the title as link text if set, falling
-    back to the URL itself, truncated to 70 chars -- mirrors NetBox core's
-    builtins/customfield_value.html convention for 'url' custom fields, including
-    its scheme-allowlist guard against unsafe schemes (e.g. javascript:).
+    Render a url-type field as a safe link: the title as link text if set,
+    falling back to the URL itself.  Delegates to URLFieldType.render_url_html()
+    so the detail page and the list-view table column render identically.
     Returns '' when the URL itself is unset, regardless of whether a title is set.
     """
     if field.type != CustomObjectFieldTypeChoices.TYPE_URL:
         return ""
     url = getattr(obj, field.name, None)
-    if not url:
-        return ""
     title = getattr(obj, f"{field.name}_title", None)
-    display_text = Truncator(title or url).chars(70)
-    if _url_scheme_is_allowed(url):
-        return format_html('<a href="{}">{}</a>', url, display_text)
-    return display_text
+    return URLFieldType.render_url_html(url, title)
 
 
 @register.filter(name="get_child_relations")

--- a/netbox_custom_objects/tests/query_counts.json
+++ b/netbox_custom_objects/tests/query_counts.json
@@ -1,6 +1,6 @@
 {
-  "customobject-complex:list_objects_with_permission": 41,
-  "customobject-objectfields:list_objects_with_permission": 47,
-  "customobject-simple:list_objects_with_permission": 33,
-  "customobjecttype:list_objects_with_permission": 34
+  "customobject-complex:list_objects_with_permission": 39,
+  "customobject-objectfields:list_objects_with_permission": 45,
+  "customobject-simple:list_objects_with_permission": 31,
+  "customobjecttype:list_objects_with_permission": 32
 }

--- a/netbox_custom_objects/tests/test_api.py
+++ b/netbox_custom_objects/tests/test_api.py
@@ -2067,3 +2067,77 @@ class CoordinatesFieldAPITest(CustomObjectsTestCase, NetBoxTestCase):
         obj.refresh_from_db()
         self.assertIsNone(obj.location_latitude)
         self.assertIsNone(obj.location_longitude)
+
+
+class URLFieldLinkTitleAPITest(CustomObjectsTestCase, NetBoxTestCase):
+    """REST API behaviour for the url field type's link-title support (issue #496)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.cot = CustomObjectType.objects.create(
+            name="LinkObject",
+            verbose_name_plural="Link Objects",
+            slug="link-objects",
+        )
+        cls.create_custom_object_type_field(
+            cls.cot, name="name", type="text", primary=True, required=True
+        )
+        cls.create_custom_object_type_field(cls.cot, name="website", type="url")
+        cls.model = cls.cot.get_model()
+
+    def setUp(self):
+        super().setUp()
+        self.user = create_test_user("linkuser")
+        self.client = APIClient()
+        token_key = create_token(self.user)
+        self.header = {"HTTP_AUTHORIZATION": f"Token {token_key}"}
+        perm = ObjectPermission(
+            name="link all", actions=["view", "add", "change", "delete"]
+        )
+        perm.save()
+        perm.users.add(self.user)
+        perm.object_types.add(ObjectType.objects.get_for_model(self.model))
+
+    def _list_url(self):
+        return reverse(
+            "plugins-api:netbox_custom_objects-api:customobject-list",
+            kwargs={"custom_object_type": self.cot.slug},
+        )
+
+    def _detail_url(self, instance):
+        return reverse(
+            "plugins-api:netbox_custom_objects-api:customobject-detail",
+            kwargs={"pk": instance.pk, "custom_object_type": self.cot.slug},
+        )
+
+    def test_serializer_exposes_flat_url_title(self):
+        """The URL and title columns are serialized as two flat fields."""
+        obj = self.model.objects.create(
+            name="Box", website="https://example.com/", website_title="Example Site",
+        )
+        response = self.client.get(self._detail_url(obj), **self.header)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        self.assertEqual(response.data["website"], "https://example.com/")
+        self.assertEqual(response.data["website_title"], "Example Site")
+
+    def test_create_with_url_and_title(self):
+        """Creating an object via the API persists both the URL and title columns."""
+        data = {
+            "name": "Created box",
+            "website": "https://example.com/",
+            "website_title": "Example Site",
+        }
+        response = self.client.post(self._list_url(), data, format="json", **self.header)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+        obj = self.model.objects.get(pk=response.data["id"])
+        self.assertEqual(obj.website, "https://example.com/")
+        self.assertEqual(obj.website_title, "Example Site")
+
+    def test_create_with_url_and_no_title_allowed(self):
+        """Creating with a URL and no title is accepted (no both-required rule)."""
+        data = {"name": "Created box", "website": "https://example.com/"}
+        response = self.client.post(self._list_url(), data, format="json", **self.header)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+        obj = self.model.objects.get(pk=response.data["id"])
+        self.assertEqual(obj.website, "https://example.com/")
+        self.assertIsNone(obj.website_title)

--- a/netbox_custom_objects/tests/test_api.py
+++ b/netbox_custom_objects/tests/test_api.py
@@ -2140,4 +2140,4 @@ class URLFieldLinkTitleAPITest(CustomObjectsTestCase, NetBoxTestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
         obj = self.model.objects.get(pk=response.data["id"])
         self.assertEqual(obj.website, "https://example.com/")
-        self.assertIsNone(obj.website_title)
+        self.assertEqual(obj.website_title, "")

--- a/netbox_custom_objects/tests/test_branching.py
+++ b/netbox_custom_objects/tests/test_branching.py
@@ -2639,6 +2639,103 @@ class BranchUpgradeHealTestCase(BranchingTestBase, TransactionTestCase):
             "the command must not have broken main's already-healthy schema",
         )
 
+    def test_heal_all_branches_skips_branch_with_missing_schema(self):
+        """
+        A branch's schema can be gone even when its status doesn't obviously say
+        so -- e.g. provisioning failed after the schema was created, or it was
+        since dropped (PR #641 review). Introspecting through that branch's own
+        connection wouldn't raise: its search path falls through to main, so it
+        would silently report (and risk "healing") main's table instead. Confirm
+        the branch is skipped instead -- no exception, main untouched, no COT
+        reported healed for it.
+        """
+        from netbox_custom_objects.mixin_migration import heal_all_branches
+
+        cot, branch, table_name, branch_conn, _columns = (
+            self._setup_branch_with_dropped_title_column('heal_missing', 'heal-missing', 'site_link')
+        )
+        branch_conn.close()
+        with main_conn.cursor() as cursor:
+            cursor.execute(f'DROP SCHEMA IF EXISTS "{branch.schema_name}" CASCADE')
+        # Simulates provisioning having failed (or the schema having been dropped)
+        # without going through the normal archive/deprovision flow.
+        Branch.objects.filter(pk=branch.pk).update(status=BranchStatusChoices.FAILED)
+
+        result = heal_all_branches(verbosity=0)
+
+        self.assertEqual(result['total'], 1)
+        self.assertEqual(result['healed'], 0)
+        self.assertGreaterEqual(result['warnings'], 1)
+        self.assertIn(
+            'site_link_title', _columns(main_conn),
+            "main's own schema must be unaffected by a branch with no schema",
+        )
+
+    def test_heal_all_branches_skips_branch_with_pending_migrations(self):
+        """
+        A branch with pending migrations has an ORM that may not match its
+        actual (outdated) schema yet -- heal_cot() could misdiagnose drift
+        against columns the branch doesn't have for unrelated reasons (PR #641
+        review). Confirm such a branch is skipped rather than healed; it's
+        picked up later by the branch's own post_migrate hook once it migrates.
+        """
+        from netbox_custom_objects.mixin_migration import heal_all_branches
+
+        cot, branch, table_name, branch_conn, _columns = (
+            self._setup_branch_with_dropped_title_column('heal_pending', 'heal-pending', 'site_link')
+        )
+
+        with mock.patch(
+            'netbox_branching.models.Branch.pending_migrations',
+            new_callable=mock.PropertyMock,
+            return_value=[('dcim', '9999_fake_pending_migration')],
+        ):
+            result = heal_all_branches(verbosity=0)
+
+        self.assertEqual(result['healed'], 0)
+        self.assertNotIn(
+            'site_link_title', _columns(branch_conn),
+            "a branch with pending migrations must not be healed yet",
+        )
+
+    def test_heal_all_branches_continues_after_one_branch_fails(self):
+        """
+        One branch failing unexpectedly during heal_branch() must not abort the
+        sweep for every other branch (PR #641 review).
+        """
+        from netbox_custom_objects import mixin_migration
+        from netbox_custom_objects.mixin_migration import heal_all_branches
+
+        cot, branch1, table_name, branch1_conn, _columns = (
+            self._setup_branch_with_dropped_title_column('heal_multi_a', 'heal-multi-a', 'site_link')
+        )
+        branch2 = _provision_branch('heal_multi_b branch', None, self.user)
+        table_name2 = cot.get_database_table_name()
+        branch2_conn = connections[branch2.connection_name]
+        with branch2_conn.cursor() as cursor:
+            cursor.execute(f'ALTER TABLE "{table_name2}" DROP COLUMN "site_link_title"')
+        self.assertNotIn('site_link_title', _columns(branch2_conn))
+
+        original_heal_branch = mixin_migration.heal_branch
+
+        def _flaky_heal_branch(branch, **kwargs):
+            if branch.pk == branch1.pk:
+                raise RuntimeError('simulated failure healing branch1')
+            return original_heal_branch(branch, **kwargs)
+
+        with mock.patch('netbox_custom_objects.mixin_migration.heal_branch', side_effect=_flaky_heal_branch):
+            result = heal_all_branches(verbosity=0)
+
+        self.assertNotIn(
+            'site_link_title', _columns(branch1_conn),
+            'branch1 was never healed (its heal_branch() call raised)',
+        )
+        self.assertIn(
+            'site_link_title', _columns(branch2_conn),
+            "branch2 must still be healed despite branch1's failure",
+        )
+        self.assertGreaterEqual(result['warnings'], 1)
+
 
 # ── Missing field-type coverage (iterative only) ──────────────────────────────
 

--- a/netbox_custom_objects/tests/test_branching.py
+++ b/netbox_custom_objects/tests/test_branching.py
@@ -2736,6 +2736,36 @@ class BranchUpgradeHealTestCase(BranchingTestBase, TransactionTestCase):
         )
         self.assertGreaterEqual(result['warnings'], 1)
 
+    def test_heal_all_branches_closes_branch_connections(self):
+        """
+        pending_migrations (via MigrationExecutor) and heal_branch() both open a
+        connection on branch.connection_name without closing it -- left open, these
+        accumulate across every branch in the sweep, the same leak netbox_branching
+        fixed in its own per-branch migration sweep (issue #581). Confirm the
+        connection is closed afterward, for both a healed branch and one skipped for
+        pending migrations.
+        """
+        from netbox_custom_objects.mixin_migration import heal_all_branches
+
+        cot, branch, table_name, branch_conn, _columns = (
+            self._setup_branch_with_dropped_title_column('heal_close', 'heal-close', 'site_link')
+        )
+        branch2 = _provision_branch('heal_close_pending branch', None, self.user)
+        branch2_conn = connections[branch2.connection_name]
+
+        # A plain PropertyMock has no access to the instance being accessed, so it can't
+        # distinguish branch from branch2 -- use a real property bound to the class instead.
+        def _pending_migrations(self):
+            if self.pk == branch2.pk:
+                return [('dcim', '9999_fake_pending_migration')]
+            return []
+
+        with mock.patch.object(Branch, 'pending_migrations', property(_pending_migrations)):
+            heal_all_branches(verbosity=0)
+
+        self.assertIsNone(branch_conn.connection, "healed branch's connection must be closed")
+        self.assertIsNone(branch2_conn.connection, "skipped branch's connection must be closed too")
+
 
 # ── Missing field-type coverage (iterative only) ──────────────────────────────
 

--- a/netbox_custom_objects/tests/test_branching.py
+++ b/netbox_custom_objects/tests/test_branching.py
@@ -253,6 +253,13 @@ class BaseBranchingTests(BranchingTestBase):
         select      — VARCHAR column with a ChoiceSet
         object      — ForeignKey column (to dcim.Site)
         multiobject — M2M through-table (to dcim.Site)
+        url         — two backing columns (<name>, <name>_title); the CO is
+                      created in the same atomic block as the field, so under
+                      squash the CO's CREATE can replay before the field's own
+                      CREATE — exercising _apply_deferred_co_field's replay of
+                      both the URL and title values (title only reverts to its
+                      default empty string, not the URL, if the replay ever
+                      drops it)
 
         This exercises every distinct schema-editor operation
         (add_field, add_FK, create_through_table) across a merge cycle and
@@ -294,6 +301,7 @@ class BaseBranchingTests(BranchingTestBase):
                 ('select_field', {'type': 'select', 'choice_set': choice_set}),
                 ('obj_field', {'type': 'object', 'related_object_type': site_ot}),
                 ('multi_field', {'type': 'multiobject', 'related_object_type': site_ot}),
+                ('url_field', {'type': 'url'}),
             ]
             for name, kwargs in field_specs:
                 f = CustomObjectTypeField.objects.create(
@@ -314,6 +322,8 @@ class BaseBranchingTests(BranchingTestBase):
                 select_field='active',
                 obj_field_id=site.pk,
                 # multi_field left empty — through-table creation is still exercised
+                url_field='https://example.com/path',
+                url_field_title='Example Path',
             )
             co_pk = co.pk
 
@@ -353,6 +363,11 @@ class BaseBranchingTests(BranchingTestBase):
         self.assertEqual(co_main.dt_field, test_dt)
         self.assertEqual(co_main.select_field, 'active')
         self.assertEqual(co_main.obj_field_id, site.pk)
+        self.assertEqual(co_main.url_field, 'https://example.com/path')
+        self.assertEqual(
+            co_main.url_field_title, 'Example Path',
+            'Title value must survive replay alongside the URL value',
+        )
 
         # Capture the multi_field's physical through-table name *while* it
         # still exists so we can confirm it's gone after revert.
@@ -2336,6 +2351,174 @@ class SequentialRenameTestCase(BranchingTestBase, TransactionTestCase):
         self.assertNotIn('beta', main_cols, 'beta column must be gone after merge')
         self.assertNotIn('alpha', main_cols, 'alpha column must be gone after merge')
 
+    # ── url field: title column rename + replay/revert ─────────────────────
+
+    def test_url_field_rename_replays_title_and_reverts(self):
+        """
+        Rename a ``url``-type field inside a branch, updating both the URL
+        and title values under the new name.  After merge, both backing
+        columns (``<name>``, ``<name>_title``) must have been renamed and
+        both values must be present under the new name.  After revert, both
+        must be restored under the old name.
+
+        Regression test for the naive ``alter_field()`` call on the title
+        column (previously assumed the old title column always existed,
+        unlike the primary column's conflict-aware ``_schema_alter_field``
+        path) and for the title key's audit-data rewrite.
+        """
+        request = _make_request(self.user)
+
+        with event_tracking(request):
+            cot = CustomObjectType.objects.create(name='url_rename_cot', slug='url-rename-cot')
+            CustomObjectTypeField.objects.create(
+                custom_object_type=cot, name='site_link', label='Site Link', type='url',
+            )
+            co = cot.get_model().objects.create(
+                site_link='https://old.example.com', site_link_title='Old Title',
+            )
+
+        co_pk = co.pk
+        branch = _provision_branch('URL Rename Branch', self.MERGE_STRATEGY, self.user)
+        branch_request = _make_request(self.user)
+
+        with activate_branch(branch), event_tracking(branch_request):
+            field = CustomObjectTypeField.objects.get(custom_object_type=cot, name='site_link')
+            field.snapshot()
+            field.name = 'external_link'
+            field.label = 'External Link'
+            field.save()
+            BM = cot.get_model()
+            b_co = BM.objects.get(pk=co_pk)
+            b_co.snapshot()
+            b_co.external_link = 'https://new.example.com'
+            b_co.external_link_title = 'New Title'
+            b_co.save()
+
+        branch.merge(user=self.user, commit=True)
+        branch.refresh_from_db()
+        self.assertEqual(branch.status, BranchStatusChoices.MERGED)
+
+        with main_conn.cursor() as cursor:
+            main_cols = {
+                col.name
+                for col in main_conn.introspection.get_table_description(
+                    cursor, cot.get_database_table_name(),
+                )
+            }
+        self.assertIn('external_link', main_cols)
+        self.assertIn('external_link_title', main_cols)
+        self.assertNotIn('site_link', main_cols)
+        self.assertNotIn('site_link_title', main_cols)
+
+        MergedModel = cot.get_model()
+        co_main = MergedModel.objects.get(pk=co_pk)
+        self.assertEqual(co_main.external_link, 'https://new.example.com')
+        self.assertEqual(co_main.external_link_title, 'New Title')
+
+        branch.revert(user=self.user, commit=True)
+
+        with main_conn.cursor() as cursor:
+            main_cols_r = {
+                col.name
+                for col in main_conn.introspection.get_table_description(
+                    cursor, cot.get_database_table_name(),
+                )
+            }
+        self.assertIn('site_link', main_cols_r)
+        self.assertIn('site_link_title', main_cols_r)
+        self.assertNotIn('external_link', main_cols_r)
+        self.assertNotIn('external_link_title', main_cols_r)
+
+        RevertedModel = cot.get_model()
+        co_reverted = RevertedModel.objects.get(pk=co_pk)
+        self.assertEqual(co_reverted.site_link, 'https://old.example.com')
+        self.assertEqual(co_reverted.site_link_title, 'Old Title')
+
+    def test_url_field_title_column_rename_conflict_merge(self):
+        """
+        Same independent-rename conflict as ``test_sequential_renames_both_sides_merge``
+        (branch renames A→B→C while main independently renames A→D), but for a
+        ``url``-type field, asserting the *title* column resolves the conflict
+        the same way the primary column does.
+
+        Regression test: the naive ``alter_field()`` call for the title column
+        assumed the old title column still existed; when it doesn't (because
+        main independently renamed the field first), the title rename must
+        resolve via the live field record — exactly like
+        ``_schema_alter_field`` already does for the primary column — instead
+        of crashing or silently leaving the title column stale.
+        """
+        request = _make_request(self.user)
+
+        with event_tracking(request):
+            cot = CustomObjectType.objects.create(name='url_conflict_cot', slug='url-conflict-cot')
+            CustomObjectTypeField.objects.create(
+                custom_object_type=cot, name='alpha', label='Alpha', type='url',
+            )
+            co = cot.get_model().objects.create(alpha='https://a.example.com', alpha_title='A')
+
+        co_pk = co.pk
+        branch = _provision_branch('URL Conflict Branch', self.MERGE_STRATEGY, self.user)
+        branch_request = _make_request(self.user)
+
+        # ── branch: alpha → beta → gamma ──────────────────────────────────
+        with activate_branch(branch), event_tracking(branch_request):
+            f = CustomObjectTypeField.objects.get(custom_object_type=cot, name='alpha')
+            f.snapshot()
+            f.name = 'beta'
+            f.label = 'Beta'
+            f.save()
+            BM = cot.get_model()
+            co_b = BM.objects.get(pk=co_pk)
+            co_b.snapshot()
+            co_b.beta = 'https://b.example.com'
+            co_b.beta_title = 'B'
+            co_b.save()
+
+        with activate_branch(branch), event_tracking(branch_request):
+            f = CustomObjectTypeField.objects.get(custom_object_type=cot, name='beta')
+            f.snapshot()
+            f.name = 'gamma'
+            f.label = 'Gamma'
+            f.save()
+            BM = cot.get_model()
+            co_g = BM.objects.get(pk=co_pk)
+            co_g.snapshot()
+            co_g.gamma = 'https://g.example.com'
+            co_g.gamma_title = 'G'
+            co_g.save()
+
+        # ── main: alpha → delta (independent rename) ──────────────────────
+        with event_tracking(request):
+            f = CustomObjectTypeField.objects.get(custom_object_type=cot, name='alpha')
+            f.name = 'delta'
+            f.label = 'Delta'
+            f.save()
+
+        # ── merge — let any failure propagate with its original traceback ──
+        branch.merge(user=self.user, commit=True)
+        branch.refresh_from_db()
+
+        with main_conn.cursor() as cursor:
+            main_cols = {
+                col.name
+                for col in main_conn.introspection.get_table_description(
+                    cursor, cot.get_database_table_name(),
+                )
+            }
+        self.assertIn('gamma', main_cols, 'Main URL column must be gamma after merge')
+        self.assertIn(
+            'gamma_title', main_cols,
+            'Main title column must converge to gamma_title, not be left as delta_title/stale',
+        )
+        for stale in ('alpha', 'beta', 'delta', 'alpha_title', 'beta_title', 'delta_title'):
+            self.assertNotIn(stale, main_cols, f'{stale!r} column must be gone after merge')
+
+        MergedModel = cot.get_model()
+        co_main = MergedModel.objects.get(pk=co_pk)
+        self.assertEqual(co_main.gamma, 'https://g.example.com')
+        self.assertEqual(co_main.gamma_title, 'G')
+
 
 @unittest.skipUnless(HAS_BRANCHING, 'netbox-branching is not installed')
 class SequentialRenameSquashTestCase(SequentialRenameTestCase, TransactionTestCase):
@@ -2344,6 +2527,79 @@ class SequentialRenameSquashTestCase(SequentialRenameTestCase, TransactionTestCa
 
     def test_sequential_renames_alpha_beta_gamma_merge(self):
         self._run_sequential_rename_merge('seq_squash_cot', 'seq-squash-cot')
+
+
+# ── Branch upgrade heal (mixin_migration.heal_branch) ──────────────────────────
+
+@unittest.skipUnless(HAS_BRANCHING, 'netbox-branching is not installed')
+class BranchUpgradeHealTestCase(BranchingTestBase, TransactionTestCase):
+    """
+    Regression test for upgrading a branch that already existed before a
+    plugin release added a new base column (here, URLFieldType's
+    ``<name>_title`` column from issue #496).
+
+    Branch schema migrations run via netbox-branching's own
+    ``MigrationExecutor`` (``Branch.migrate()``), which never triggers
+    Django's core ``post_migrate`` signal — only netbox-branching's own,
+    which ``heal_branch()`` is wired to.  Before that wiring existed, the
+    plugin's post_migrate heal pass only ever ran against the default
+    connection, so a pre-existing branch's own schema never got the new
+    column added.
+    """
+
+    def test_heal_branch_adds_missing_title_column_to_branch_schema_only(self):
+        """
+        Create a ``url`` field in main (so both main and a subsequently
+        provisioned branch have the full ``<name>``/``<name>_title`` schema),
+        then simulate a pre-upgrade branch by dropping ``<name>_title`` from
+        *only* the branch's own connection.  ``heal_branch()`` must restore
+        it on the branch's schema without touching main's.
+        """
+        from netbox_custom_objects.mixin_migration import heal_branch
+
+        request = _make_request(self.user)
+        with event_tracking(request):
+            cot = CustomObjectType.objects.create(name='heal_cot', slug='heal-cot')
+            CustomObjectTypeField.objects.create(
+                custom_object_type=cot, name='site_link', label='Site Link', type='url',
+            )
+
+        branch = _provision_branch('Heal Branch', None, self.user)
+        table_name = cot.get_database_table_name()
+        branch_conn = connections[branch.connection_name]
+
+        # Simulate a branch provisioned before #496 shipped: drop the title
+        # column from *only* the branch's own schema.
+        with branch_conn.cursor() as cursor:
+            cursor.execute(f'ALTER TABLE "{table_name}" DROP COLUMN "site_link_title"')
+
+        def _columns(conn):
+            with conn.cursor() as cursor:
+                return {
+                    col.name
+                    for col in conn.introspection.get_table_description(cursor, table_name)
+                }
+
+        self.assertNotIn(
+            'site_link_title', _columns(branch_conn),
+            'Precondition: title column must be absent from the branch schema',
+        )
+        self.assertIn(
+            'site_link_title', _columns(main_conn),
+            'Precondition: title column must still be present in main',
+        )
+
+        result = heal_branch(branch)
+
+        self.assertIn(
+            'site_link_title', _columns(branch_conn),
+            'heal_branch() must add the missing title column to the branch schema',
+        )
+        self.assertIn(
+            'site_link_title', _columns(main_conn),
+            "heal_branch() must not have touched main's schema",
+        )
+        self.assertEqual(result['healed'], 1)
 
 
 # ── Missing field-type coverage (iterative only) ──────────────────────────────
@@ -2393,6 +2649,7 @@ class MissingFieldTypesTestCase(BranchingTestBase, TransactionTestCase):
                 longtext_field='line1\nline2',
                 date_field=datetime.date(2026, 5, 21),
                 url_field='https://example.com/path',
+                url_field_title='Example Path',
                 json_field={'k': 'v', 'n': 1, 'list': [1, 2, 3]},
                 multiselect_field=['a', 'c'],
             )
@@ -2408,6 +2665,7 @@ class MissingFieldTypesTestCase(BranchingTestBase, TransactionTestCase):
         self.assertEqual(co_main.longtext_field, 'line1\nline2')
         self.assertEqual(co_main.date_field, datetime.date(2026, 5, 21))
         self.assertEqual(co_main.url_field, 'https://example.com/path')
+        self.assertEqual(co_main.url_field_title, 'Example Path')
         self.assertEqual(co_main.json_field, {'k': 'v', 'n': 1, 'list': [1, 2, 3]})
         self.assertEqual(sorted(co_main.multiselect_field), ['a', 'c'])
 

--- a/netbox_custom_objects/tests/test_branching.py
+++ b/netbox_custom_objects/tests/test_branching.py
@@ -2534,44 +2534,41 @@ class SequentialRenameSquashTestCase(SequentialRenameTestCase, TransactionTestCa
 @unittest.skipUnless(HAS_BRANCHING, 'netbox-branching is not installed')
 class BranchUpgradeHealTestCase(BranchingTestBase, TransactionTestCase):
     """
-    Regression test for upgrading a branch that already existed before a
+    Regression tests for upgrading a branch that already existed before a
     plugin release added a new base column (here, URLFieldType's
     ``<name>_title`` column from issue #496).
 
-    Branch schema migrations run via netbox-branching's own
-    ``MigrationExecutor`` (``Branch.migrate()``), which never triggers
-    Django's core ``post_migrate`` signal — only netbox-branching's own,
-    which ``heal_branch()`` is wired to.  Before that wiring existed, the
-    plugin's post_migrate heal pass only ever ran against the default
-    connection, so a pre-existing branch's own schema never got the new
-    column added.
+    A schema change like this ships with no actual Django migration file
+    (URLFieldType.get_model_field() just changes what columns a dynamically
+    generated model has), so there's nothing for netbox-branching's own
+    ``MigrationExecutor`` to detect as "pending" against a branch --
+    ``Branch.migrate()`` never runs for it, and neither does its
+    ``post_migrate`` signal.  The reliable trigger is ``heal_all_branches()``,
+    called unconditionally from the main upgrade path (the post_migrate
+    signal handler, and ``manage.py upgrade_custom_objects``) -- see
+    ``mixin_migration.heal_branch()``'s docstring.
     """
 
-    def test_heal_branch_adds_missing_title_column_to_branch_schema_only(self):
+    def _setup_branch_with_dropped_title_column(self, cot_name, cot_slug, field_name):
+        """Shared fixture: a COT+url field in main, a branch with a full schema
+        copy, then the title column dropped from *only* the branch's schema to
+        simulate a branch provisioned before #496 shipped.  Returns
+        (cot, branch, table_name, branch_conn, _columns) where _columns(conn)
+        introspects the live column set.
         """
-        Create a ``url`` field in main (so both main and a subsequently
-        provisioned branch have the full ``<name>``/``<name>_title`` schema),
-        then simulate a pre-upgrade branch by dropping ``<name>_title`` from
-        *only* the branch's own connection.  ``heal_branch()`` must restore
-        it on the branch's schema without touching main's.
-        """
-        from netbox_custom_objects.mixin_migration import heal_branch
-
         request = _make_request(self.user)
         with event_tracking(request):
-            cot = CustomObjectType.objects.create(name='heal_cot', slug='heal-cot')
+            cot = CustomObjectType.objects.create(name=cot_name, slug=cot_slug)
             CustomObjectTypeField.objects.create(
-                custom_object_type=cot, name='site_link', label='Site Link', type='url',
+                custom_object_type=cot, name=field_name, label=field_name.title(), type='url',
             )
 
-        branch = _provision_branch('Heal Branch', None, self.user)
+        branch = _provision_branch(f'{cot_name} branch', None, self.user)
         table_name = cot.get_database_table_name()
         branch_conn = connections[branch.connection_name]
 
-        # Simulate a branch provisioned before #496 shipped: drop the title
-        # column from *only* the branch's own schema.
         with branch_conn.cursor() as cursor:
-            cursor.execute(f'ALTER TABLE "{table_name}" DROP COLUMN "site_link_title"')
+            cursor.execute(f'ALTER TABLE "{table_name}" DROP COLUMN "{field_name}_title"')
 
         def _columns(conn):
             with conn.cursor() as cursor:
@@ -2581,12 +2578,25 @@ class BranchUpgradeHealTestCase(BranchingTestBase, TransactionTestCase):
                 }
 
         self.assertNotIn(
-            'site_link_title', _columns(branch_conn),
+            f'{field_name}_title', _columns(branch_conn),
             'Precondition: title column must be absent from the branch schema',
         )
         self.assertIn(
-            'site_link_title', _columns(main_conn),
+            f'{field_name}_title', _columns(main_conn),
             'Precondition: title column must still be present in main',
+        )
+        return cot, branch, table_name, branch_conn, _columns
+
+    def test_heal_branch_adds_missing_title_column_to_branch_schema_only(self):
+        """
+        Lower-level unit check of heal_branch() itself, called directly.  See
+        test_upgrade_custom_objects_command_heals_existing_branch below for
+        the end-to-end trigger this plugin actually relies on in production.
+        """
+        from netbox_custom_objects.mixin_migration import heal_branch
+
+        cot, branch, table_name, branch_conn, _columns = (
+            self._setup_branch_with_dropped_title_column('heal_cot', 'heal-cot', 'site_link')
         )
 
         result = heal_branch(branch)
@@ -2600,6 +2610,34 @@ class BranchUpgradeHealTestCase(BranchingTestBase, TransactionTestCase):
             "heal_branch() must not have touched main's schema",
         )
         self.assertEqual(result['healed'], 1)
+
+    def test_upgrade_custom_objects_command_heals_existing_branch(self):
+        """
+        End-to-end regression test for the reviewer's concern that the only
+        prior coverage called heal_branch() directly, bypassing the actual
+        trigger a real upgrade uses.  Drives the management command instead
+        -- the same entry point an administrator runs after upgrading the
+        plugin, and the same code path the post_migrate signal handler uses
+        internally (heal_all_branches()) -- and never calls heal_branch()
+        directly.
+        """
+        from django.core.management import call_command
+
+        cot, branch, table_name, branch_conn, _columns = (
+            self._setup_branch_with_dropped_title_column('heal_cmd_cot', 'heal-cmd-cot', 'site_link')
+        )
+
+        call_command('upgrade_custom_objects', verbosity=0)
+
+        self.assertIn(
+            'site_link_title', _columns(branch_conn),
+            "'manage.py upgrade_custom_objects' must heal the branch's schema too, "
+            'not just main\'s',
+        )
+        self.assertIn(
+            'site_link_title', _columns(main_conn),
+            "the command must not have broken main's already-healthy schema",
+        )
 
 
 # ── Missing field-type coverage (iterative only) ──────────────────────────────

--- a/netbox_custom_objects/tests/test_field_types.py
+++ b/netbox_custom_objects/tests/test_field_types.py
@@ -710,7 +710,10 @@ class URLFieldTypeTestCase(FieldTypeTestCase):
         self.assertEqual(instance.website_title, "Example Site")
 
     def test_url_field_title_is_optional(self):
-        """A url value with no title set is valid (no both-required rule)."""
+        """
+        A url value with no title set is valid (no both-required rule). The title
+        column defaults to '' (not None) so "unset" has one canonical representation.
+        """
         self.create_custom_object_type_field(
             self.custom_object_type,
             name="website",
@@ -720,7 +723,7 @@ class URLFieldTypeTestCase(FieldTypeTestCase):
         model = self.custom_object_type.get_model()
         instance = model.objects.create(name="Test", website="https://example.com/")
         self.assertEqual(instance.website, "https://example.com/")
-        self.assertIsNone(instance.website_title)
+        self.assertEqual(instance.website_title, "")
 
     def test_url_field_unique_still_enforced(self):
         """
@@ -792,6 +795,61 @@ class URLFieldTypeTestCase(FieldTypeTestCase):
         )
         with self.assertRaises(ValidationError):
             field.full_clean()
+
+    def test_get_url_field_html_renders_link_with_title(self):
+        """get_url_field_html renders <a href> using the title as link text when set."""
+        from netbox_custom_objects.templatetags.custom_object_utils import get_url_field_html
+        cotf = self.create_custom_object_type_field(
+            self.custom_object_type, name="website3", label="Website", type="url",
+        )
+        model = self.custom_object_type.get_model(no_cache=True)
+        instance = model.objects.create(
+            name="Test", website3="https://example.com/", website3_title="Example Site",
+        )
+        html = get_url_field_html(instance, cotf)
+        self.assertIn('href="https://example.com/"', html)
+        self.assertIn("Example Site", html)
+
+    def test_get_url_field_html_falls_back_to_url_text_without_title(self):
+        """get_url_field_html uses the URL itself as link text when no title is set."""
+        from netbox_custom_objects.templatetags.custom_object_utils import get_url_field_html
+        cotf = self.create_custom_object_type_field(
+            self.custom_object_type, name="website4", label="Website", type="url",
+        )
+        model = self.custom_object_type.get_model(no_cache=True)
+        instance = model.objects.create(name="Test", website4="https://example.com/")
+        html = get_url_field_html(instance, cotf)
+        self.assertIn('href="https://example.com/"', html)
+        self.assertIn(">https://example.com/<", html)
+
+    def test_get_url_field_html_rejects_disallowed_scheme(self):
+        """
+        A disallowed URL scheme (e.g. javascript:) renders as plain text, not a link.
+        Guards the security-relevant _url_scheme_is_allowed() check -- the value is
+        assigned directly (bypassing form/URLField validation) to simulate data that
+        reached the column via any path other than the add/edit form.
+        """
+        from netbox_custom_objects.templatetags.custom_object_utils import get_url_field_html
+        cotf = self.create_custom_object_type_field(
+            self.custom_object_type, name="website5", label="Website", type="url",
+        )
+        model = self.custom_object_type.get_model(no_cache=True)
+        instance = model.objects.create(
+            name="Test", website5="javascript:alert(1)", website5_title="Click me",
+        )
+        html = get_url_field_html(instance, cotf)
+        self.assertNotIn("<a ", html)
+        self.assertIn("Click me", html)
+
+    def test_get_url_field_html_returns_empty_string_when_url_unset(self):
+        """get_url_field_html returns '' when the URL itself is unset, regardless of title."""
+        from netbox_custom_objects.templatetags.custom_object_utils import get_url_field_html
+        cotf = self.create_custom_object_type_field(
+            self.custom_object_type, name="website6", label="Website", type="url",
+        )
+        model = self.custom_object_type.get_model(no_cache=True)
+        instance = model.objects.create(name="Test")
+        self.assertEqual(get_url_field_html(instance, cotf), "")
 
 
 class JSONFieldTypeTestCase(FieldTypeTestCase):

--- a/netbox_custom_objects/tests/test_field_types.py
+++ b/netbox_custom_objects/tests/test_field_types.py
@@ -687,7 +687,10 @@ class URLFieldTypeTestCase(FieldTypeTestCase):
             field.validate("http:/example.com")
 
     def test_url_field_model_generation(self):
-        """Test URL field model generation."""
+        """
+        Test URL field model generation. A url field expands into two backing
+        columns: the URL itself and an optional link title (issue #496).
+        """
         self.create_custom_object_type_field(
             self.custom_object_type,
             name="website",
@@ -696,9 +699,99 @@ class URLFieldTypeTestCase(FieldTypeTestCase):
         )
 
         model = self.custom_object_type.get_model()
-        instance = model.objects.create(name="Test", website="https://example.com")
+        column_names = {f.name for f in model._meta.local_fields}
+        self.assertIn("website", column_names)
+        self.assertIn("website_title", column_names)
 
+        instance = model.objects.create(
+            name="Test", website="https://example.com", website_title="Example Site",
+        )
         self.assertEqual(instance.website, "https://example.com")
+        self.assertEqual(instance.website_title, "Example Site")
+
+    def test_url_field_title_is_optional(self):
+        """A url value with no title set is valid (no both-required rule)."""
+        self.create_custom_object_type_field(
+            self.custom_object_type,
+            name="website",
+            label="Website",
+            type="url",
+        )
+        model = self.custom_object_type.get_model()
+        instance = model.objects.create(name="Test", website="https://example.com/")
+        self.assertEqual(instance.website, "https://example.com/")
+        self.assertIsNone(instance.website_title)
+
+    def test_url_field_unique_still_enforced(self):
+        """
+        Unique still applies to the URL column itself for a url field (unlike
+        coordinates, which disallows unique entirely) -- guards the fix making the
+        clean() uniqueness-conversion probe dict-aware.
+        """
+        self.create_custom_object_type_field(
+            self.custom_object_type,
+            name="website",
+            label="Website",
+            type="url",
+            unique=True,
+        )
+        model = self.custom_object_type.get_model()
+        model.objects.create(name="A", website="https://example.com/a")
+        with self.assertRaises(ValidationError):
+            duplicate = model(name="B", website="https://example.com/a")
+            duplicate.full_clean()
+
+    def test_change_existing_field_to_url_rejected(self):
+        """An existing non-url field cannot be converted to url."""
+        field = self.create_custom_object_type_field(
+            self.custom_object_type, name="website2", label="Website", type="text",
+        )
+        field.type = "url"
+        with self.assertRaises(ValidationError):
+            field.full_clean()
+
+    def test_change_url_field_to_other_type_rejected(self):
+        """An existing url field cannot be converted to another type."""
+        field = self.create_custom_object_type_field(
+            self.custom_object_type, name="website2", label="Website", type="url",
+        )
+        field.type = "text"
+        with self.assertRaises(ValidationError):
+            field.full_clean()
+
+    def test_url_backing_column_collision_rejected(self):
+        """
+        Adding a url field whose title column collides with an existing field's
+        column raises a ValidationError rather than a DB error.
+        """
+        self.create_custom_object_type_field(
+            self.custom_object_type, name="website2_title", label="Title", type="text",
+        )
+        field = CustomObjectTypeField(
+            custom_object_type=self.custom_object_type,
+            name="website2",
+            label="Website",
+            type="url",
+        )
+        with self.assertRaises(ValidationError):
+            field.full_clean()
+
+    def test_field_colliding_with_url_backing_column_rejected(self):
+        """
+        The reverse collision: a plain field named "<url>_title" cannot be added
+        when a url field "<url>" already exists.
+        """
+        self.create_custom_object_type_field(
+            self.custom_object_type, name="website2", label="Website", type="url",
+        )
+        field = CustomObjectTypeField(
+            custom_object_type=self.custom_object_type,
+            name="website2_title",
+            label="Title",
+            type="text",
+        )
+        with self.assertRaises(ValidationError):
+            field.full_clean()
 
 
 class JSONFieldTypeTestCase(FieldTypeTestCase):

--- a/netbox_custom_objects/tests/test_mixin_migration.py
+++ b/netbox_custom_objects/tests/test_mixin_migration.py
@@ -23,7 +23,7 @@ from netbox_custom_objects.mixin_migration import (
     heal_all_cots,
     heal_cot,
 )
-from netbox_custom_objects.models import CustomObjectType
+from netbox_custom_objects.models import CustomObjectType, detect_backing_column_collisions
 
 from .base import CustomObjectsTestCase, TransactionCleanupMixin
 
@@ -341,6 +341,86 @@ class HealCotTestCase(
 
         cot.refresh_from_db()
         self.assertEqual(cot.schema_document, original_doc)
+
+
+# ---------------------------------------------------------------------------
+# detect_backing_column_collisions() / heal_cot() collision surfacing
+# ---------------------------------------------------------------------------
+
+class BackingColumnCollisionTestCase(
+    TransactionCleanupMixin, CustomObjectsTestCase, TransactionTestCase
+):
+    """
+    Regression tests (PR #641 review) for pre-existing backing-column
+    collisions: a plain field literally named "<url_field>_title" (or
+    "<coord_field>_latitude"/"_longitude") could have been created before
+    CustomObjectTypeField.clean()'s collision guard existed -- URLFieldType
+    didn't expand into a second backing column until #496, so nothing
+    stopped a sibling field from claiming that name first.  clean() blocks
+    this combination for any *new* field going forward, but heal_cot() must
+    also detect it for a COT that already has the collision baked in, since
+    it's otherwise silently resolved by whichever field wins the attrs dict
+    slot in CustomObjectType._fetch_and_generate_field_attrs() -- with no
+    error raised anywhere.
+
+    ``.objects.create()`` bypasses clean() (only full_clean() calls it), so
+    creating the colliding pair directly reproduces a pre-validation COT
+    without needing to disable or monkeypatch the guard.
+    """
+
+    def test_detects_pre_existing_url_title_collision(self):
+        cot = self.create_custom_object_type(name="bcc_url", slug="bcc-url")
+        self.create_custom_object_type_field(cot, name="website", label="Website", type="url")
+        self.create_custom_object_type_field(
+            cot, name="website_title", label="Website Title", type="text",
+        )
+
+        collisions = detect_backing_column_collisions(cot)
+
+        self.assertEqual(len(collisions), 1)
+        self.assertEqual(collisions[0]["field"], "website")
+        self.assertEqual(collisions[0]["other"], "website_title")
+        self.assertEqual(collisions[0]["column"], "website_title")
+
+    def test_detects_pre_existing_coordinates_collision(self):
+        cot = self.create_custom_object_type(name="bcc_coord", slug="bcc-coord")
+        self.create_custom_object_type_field(cot, name="loc", label="Location", type="coordinates")
+        self.create_custom_object_type_field(
+            cot, name="loc_latitude", label="Loc Latitude", type="decimal",
+        )
+
+        collisions = detect_backing_column_collisions(cot)
+
+        self.assertEqual(len(collisions), 1)
+        self.assertEqual(collisions[0]["column"], "loc_latitude")
+
+    def test_no_collision_for_normal_url_field(self):
+        cot = self.create_custom_object_type(name="bcc_ok", slug="bcc-ok")
+        self.create_custom_object_type_field(cot, name="website", label="Website", type="url")
+
+        self.assertEqual(detect_backing_column_collisions(cot), [])
+
+    def test_no_collision_between_two_plain_fields(self):
+        cot = self.create_custom_object_type(name="bcc_plain", slug="bcc-plain")
+        self.create_custom_object_type_field(cot, name="alpha", type="text")
+        self.create_custom_object_type_field(cot, name="beta", type="text")
+
+        self.assertEqual(detect_backing_column_collisions(cot), [])
+
+    def test_heal_cot_surfaces_collision_as_warning(self):
+        """heal_cot() must report the collision, not silently proceed."""
+        cot = self.create_custom_object_type(name="bcc_heal", slug="bcc-heal")
+        self.create_custom_object_type_field(cot, name="website", label="Website", type="url")
+        self.create_custom_object_type_field(
+            cot, name="website_title", label="Website Title", type="text",
+        )
+
+        result = heal_cot(cot, verbosity=0)
+
+        warned_types = [w["type"] for w in result["warned"]]
+        self.assertIn("backing_column_collision", warned_types)
+        entry = next(w for w in result["warned"] if w["type"] == "backing_column_collision")
+        self.assertEqual(entry["field"], "website")
 
 
 # ---------------------------------------------------------------------------

--- a/netbox_custom_objects/tests/test_mixin_migration.py
+++ b/netbox_custom_objects/tests/test_mixin_migration.py
@@ -23,7 +23,11 @@ from netbox_custom_objects.mixin_migration import (
     heal_all_cots,
     heal_cot,
 )
-from netbox_custom_objects.models import CustomObjectType, detect_backing_column_collisions
+from netbox_custom_objects.models import (
+    CustomObjectType,
+    CustomObjectTypeField,
+    detect_backing_column_collisions,
+)
 
 from .base import CustomObjectsTestCase, TransactionCleanupMixin
 
@@ -381,6 +385,98 @@ class BackingColumnCollisionTestCase(
         self.assertEqual(collisions[0]["field"], "website")
         self.assertEqual(collisions[0]["other"], "website_title")
         self.assertEqual(collisions[0]["column"], "website_title")
+        # "website_title" (the plain field) is the one whose own name matches the
+        # clashing column -- it's safe to rename; renaming "website" instead would
+        # carry this same column along with it. See models.py's comment at the
+        # collision-detection site for why.
+        self.assertEqual(collisions[0]["safe_to_rename"], "website_title")
+        self.assertIn("Rename 'website_title'", collisions[0]["message"])
+
+    def test_safe_rename_preserves_sibling_data_and_resolves_collision(self):
+        """
+        Renaming the field identified by `safe_to_rename` (PR #641 review) must
+        preserve that field's own data and leave the *other* field's column
+        untouched -- proving the recovery guidance is actually safe to follow,
+        not just that the collision is detected.
+        """
+        cot = self.create_custom_object_type(name="bcc_recover", slug="bcc-recover")
+        self.create_custom_object_type_field(cot, name="name", label="Name", type="text", primary=True)
+        self.create_custom_object_type_field(
+            cot, name="website", label="Website", type="url",
+        )
+        plain_field = self.create_custom_object_type_field(
+            cot, name="website_title", label="Website Title", type="text", required=False,
+        )
+
+        collisions = detect_backing_column_collisions(cot)
+        self.assertEqual(collisions[0]["safe_to_rename"], "website_title")
+
+        # Write a known value directly to the shared physical column, bypassing
+        # the ORM: with two fields mapped to the same attribute, only whichever
+        # was processed last in _fetch_and_generate_field_attrs() is reachable
+        # through the model, so this is the only unambiguous way to establish
+        # "the plain field's own data" independent of that resolution order.
+        model = cot.get_model()
+        # website_title="" sidesteps a quirk that's itself a symptom of the collision:
+        # the physical column was created NOT NULL DEFAULT '' by the url field (created
+        # first; see URLFieldType.get_model_field()'s comment on why its title column
+        # isn't null=True), but the plain field's own definition -- which won the model
+        # attrs slot since it was created second -- believes the column is nullable, so
+        # create() with no value for it would try to insert NULL and violate that
+        # constraint. Overwritten via raw SQL immediately below regardless.
+        instance = model.objects.create(
+            name="Test Object", website="https://example.com/", website_title="",
+        )
+        with connection.cursor() as cursor:
+            cursor.execute(
+                f'UPDATE {model._meta.db_table} SET website_title = %s WHERE id = %s',
+                ["plain field's own value", instance.pk],
+            )
+
+        # The safe rename: reload from DB so the rename path has the original
+        # snapshot, exactly as the edit view would (see test_schema_operations.py).
+        plain_field = CustomObjectTypeField.objects.get(pk=plain_field.pk)
+        plain_field.name = "description"
+        plain_field.save()
+
+        # Collision resolved, and the plain field's data followed it to the new
+        # column name rather than being left behind or overwritten.
+        self.assertEqual(detect_backing_column_collisions(cot), [])
+        model = cot.get_model(no_cache=True)
+        columns = {
+            col.name for col in connection.introspection.get_table_description(
+                connection.cursor(), model._meta.db_table,
+            )
+        }
+        self.assertIn("description", columns)
+        # The rename also carried the physical column away from "website_title" --
+        # the url field's title sub-column name is derived from its own (unchanged)
+        # name, not stored, so nothing renamed *it* back into existence. This is
+        # exactly why the guidance says to re-run the heal afterward: it re-adds
+        # "website_title" fresh (nullable, default ''), now unambiguously the url
+        # field's alone.
+        self.assertNotIn("website_title", columns)
+        heal_cot(cot, verbosity=0)
+        model = cot.get_model(no_cache=True)
+        columns = {
+            col.name for col in connection.introspection.get_table_description(
+                connection.cursor(), model._meta.db_table,
+            )
+        }
+        self.assertIn("website_title", columns)
+
+        # Re-fetched via the post-heal model class: `instance` was built from an
+        # earlier class that no longer matches the current columns.
+        instance = model.objects.get(pk=instance.pk)
+        self.assertEqual(instance.description, "plain field's own value")
+
+        # The url field's own title sub-column is now unambiguously its own --
+        # setting it doesn't touch (or get confused with) the renamed sibling.
+        instance.website_title = "My Website"
+        instance.save()
+        instance = model.objects.get(pk=instance.pk)
+        self.assertEqual(instance.website_title, "My Website")
+        self.assertEqual(instance.description, "plain field's own value")
 
     def test_detects_pre_existing_coordinates_collision(self):
         cot = self.create_custom_object_type(name="bcc_coord", slug="bcc-coord")

--- a/netbox_custom_objects/tests/test_models.py
+++ b/netbox_custom_objects/tests/test_models.py
@@ -2514,3 +2514,54 @@ class LazySerializerRegistrationTestCase(CustomObjectsTestCase, TestCase):
                       "building child serializer must not clobber parent's full serializer")
         self.assertIn("title", registered_parent.Meta.fields,
                       "parent's full field set must be intact after child serializer is built")
+
+
+class DeferredCOFieldReplayOrderingTestCase(CustomObjectsTestCase, TestCase):
+    """
+    Regression test (PR #641 review) for an ordering bug in the deferred CO
+    field replay: _apply_deferred_co_field() replays a url field's title value
+    via a raw UPDATE against "<name>_title", but in CustomObjectTypeField.save()
+    the title column used to be added *after* that call ran. A deferred title
+    value would therefore issue an UPDATE against a column that doesn't exist
+    yet and raise psycopg.errors.UndefinedColumn.
+
+    The scenario this guards against — a CO's CREATE replaying before its
+    field's CREATE — normally only arises from netbox-branching squash-merge
+    ordering, but the replay mechanism itself doesn't depend on branching at
+    all: it's driven purely by the _deferred_co_field_data contextvar and
+    CustomObjectTypeField.save(). This manufactures that scenario directly
+    (populating the contextvar before creating the field) so the ordering fix
+    is covered without needing netbox-branching installed.
+    """
+
+    def test_title_column_exists_before_deferred_title_replay_runs(self):
+        from netbox_custom_objects.models import _deferred_co_field_data
+
+        cot = self.create_custom_object_type(name="DeferredCOT", slug="deferred-cot")
+        model = cot.get_model()
+        co = model.objects.create()
+        table_name = cot.get_database_table_name()
+
+        _deferred_co_field_data.set({
+            table_name: {
+                co.pk: {
+                    "data": {
+                        "website": "https://example.com/",
+                        "website_title": "Example Site",
+                    },
+                },
+            },
+        })
+        try:
+            self.create_custom_object_type_field(
+                cot, name="website", label="Website", type="url",
+            )
+        finally:
+            _deferred_co_field_data.set(None)
+
+        fresh_co = cot.get_model().objects.get(pk=co.pk)
+        self.assertEqual(fresh_co.website, "https://example.com/")
+        self.assertEqual(
+            fresh_co.website_title, "Example Site",
+            "deferred title value must be replayed once the title column exists",
+        )

--- a/netbox_custom_objects/tests/test_schema_operations.py
+++ b/netbox_custom_objects/tests/test_schema_operations.py
@@ -275,3 +275,49 @@ class SchemaOperationsTestCase(TransactionCleanupMixin, CustomObjectsTestCase, T
         columns = self._db_columns(cot.get_model())
         self.assertNotIn('location_latitude', columns)
         self.assertNotIn('location_longitude', columns)
+
+    def test_url_field_rename_renames_both_columns(self):
+        """Renaming a url field renames both backing DB columns (issue #496)."""
+        cot = self.create_custom_object_type(name='urlrename', slug='url-rename')
+        self.create_custom_object_type_field(
+            cot, name='name', label='Name', type='text', primary=True,
+        )
+        field = self.create_custom_object_type_field(
+            cot, name='website', label='Website', type='url',
+        )
+
+        columns = self._db_columns(cot.get_model())
+        self.assertIn('website', columns)
+        self.assertIn('website_title', columns)
+
+        # Reload from DB so the rename path has the original snapshot (set in
+        # from_db) — this mirrors how the edit view loads the field before saving.
+        field = CustomObjectTypeField.objects.get(pk=field.pk)
+        field.name = 'homepage'
+        field.save()
+
+        columns = self._db_columns(cot.get_model())
+        self.assertNotIn('website', columns)
+        self.assertNotIn('website_title', columns)
+        self.assertIn('homepage', columns)
+        self.assertIn('homepage_title', columns)
+
+    def test_url_field_delete_drops_both_columns(self):
+        """Deleting a url field drops both backing DB columns (issue #496)."""
+        cot = self.create_custom_object_type(name='urldelete', slug='url-delete')
+        self.create_custom_object_type_field(
+            cot, name='name', label='Name', type='text', primary=True,
+        )
+        field = self.create_custom_object_type_field(
+            cot, name='website', label='Website', type='url',
+        )
+
+        columns = self._db_columns(cot.get_model())
+        self.assertIn('website', columns)
+        self.assertIn('website_title', columns)
+
+        field.delete()
+
+        columns = self._db_columns(cot.get_model())
+        self.assertNotIn('website', columns)
+        self.assertNotIn('website_title', columns)

--- a/netbox_custom_objects/tests/test_views.py
+++ b/netbox_custom_objects/tests/test_views.py
@@ -1145,7 +1145,7 @@ class URLFieldLinkTitleViewTest(CustomObjectsTestCase, TestCase):
         self.assertEqual(response.status_code, 302, getattr(response, "content", b""))
         obj = self.model.objects.get(name="Box")
         self.assertEqual(obj.website, "https://example.com/")
-        self.assertFalse(obj.website_title)
+        self.assertEqual(obj.website_title, "")
 
 
 class QuickAddViewTestCase(CustomObjectsTestCase, TestCase):

--- a/netbox_custom_objects/tests/test_views.py
+++ b/netbox_custom_objects/tests/test_views.py
@@ -1072,6 +1072,67 @@ class CoordinatesFieldViewTest(CustomObjectsTestCase, TestCase):
         self.assertEqual(obj.location_longitude, Decimal("-74.006000"))
 
 
+class URLFieldLinkTitleViewTest(CustomObjectsTestCase, TestCase):
+    """UI form behaviour for the url field type's link-title support (issue #496)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.cot = CustomObjectType.objects.create(
+            name="LinkView",
+            verbose_name_plural="Link Views",
+            slug="link-views",
+        )
+        CustomObjectTypeField.objects.create(
+            custom_object_type=cls.cot, name="name", type="text", primary=True, required=True
+        )
+        CustomObjectTypeField.objects.create(
+            custom_object_type=cls.cot, name="website", type="url"
+        )
+        cls.model = cls.cot.get_model()
+
+    def setUp(self):
+        super().setUp()
+        perm = ObjectPermission(
+            name="link view all", actions=["view", "add", "change", "delete"]
+        )
+        perm.save()
+        perm.users.add(self.user)
+        perm.object_types.add(ObjectType.objects.get_for_model(self.model))
+
+    def _add_url(self):
+        return reverse(
+            "plugins:netbox_custom_objects:customobject_add",
+            kwargs={"custom_object_type": self.cot.slug},
+        )
+
+    def test_add_form_renders_url_and_title_inputs(self):
+        response = self.client.get(self._add_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "website")
+        self.assertContains(response, "website_title")
+
+    def test_create_valid_url_with_title(self):
+        data = {
+            "name": "Box",
+            "website": "https://example.com/",
+            "website_title": "Example Site",
+        }
+        response = self.client.post(self._add_url(), data)
+        self.assertEqual(response.status_code, 302, getattr(response, "content", b""))
+        obj = self.model.objects.get(name="Box")
+        self.assertEqual(obj.website, "https://example.com/")
+        self.assertEqual(obj.website_title, "Example Site")
+
+    def test_create_valid_url_with_no_title(self):
+        """A URL with no title is accepted (no both-required rule, unlike coordinates)."""
+        data = {"name": "Box", "website": "https://example.com/"}
+        response = self.client.post(self._add_url(), data)
+        self.assertEqual(response.status_code, 302, getattr(response, "content", b""))
+        obj = self.model.objects.get(name="Box")
+        self.assertEqual(obj.website, "https://example.com/")
+        self.assertFalse(obj.website_title)
+
+
 class QuickAddViewTestCase(CustomObjectsTestCase, TestCase):
     """
     Tests for the quick-add flow in CustomObjectEditView.

--- a/netbox_custom_objects/tests/test_views.py
+++ b/netbox_custom_objects/tests/test_views.py
@@ -1120,6 +1120,12 @@ class URLFieldLinkTitleViewTest(CustomObjectsTestCase, TestCase):
             kwargs={"custom_object_type": self.cot.slug},
         )
 
+    def _list_url(self):
+        return reverse(
+            "plugins:netbox_custom_objects:customobject_list",
+            kwargs={"custom_object_type": self.cot.slug},
+        )
+
     def test_add_form_renders_url_and_title_inputs(self):
         response = self.client.get(self._add_url())
         self.assertEqual(response.status_code, 200)
@@ -1146,6 +1152,31 @@ class URLFieldLinkTitleViewTest(CustomObjectsTestCase, TestCase):
         obj = self.model.objects.get(name="Box")
         self.assertEqual(obj.website, "https://example.com/")
         self.assertEqual(obj.website_title, "")
+
+    def test_list_view_renders_title_as_link_text(self):
+        """
+        The list view must render the same title-as-link-text HTML as the detail
+        page, rather than the raw URL or two separate columns for the URL and
+        title -- keeps the list view consistent with the detail view.
+        """
+        self.model.objects.create(name="Titled", website="https://example.com/", website_title="Example Site")
+        response = self.client.get(self._list_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '<a href="https://example.com/">Example Site</a>', html=False)
+        self.assertNotContains(response, ">https://example.com/<")
+
+    def test_list_view_falls_back_to_url_when_no_title(self):
+        self.model.objects.create(name="Untitled", website="https://example.org/")
+        response = self.client.get(self._list_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '<a href="https://example.org/">https://example.org/</a>', html=False)
+
+    def test_list_view_shows_placeholder_when_url_unset(self):
+        """A title with no URL renders the standard empty-field placeholder, not a bare title."""
+        self.model.objects.create(name="TitleOnly", website="", website_title="Orphan Title")
+        response = self.client.get(self._list_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "Orphan Title")
 
 
 class QuickAddViewTestCase(CustomObjectsTestCase, TestCase):

--- a/netbox_custom_objects/views.py
+++ b/netbox_custom_objects/views.py
@@ -787,6 +787,20 @@ class CustomObjectEditView(generic.ObjectEditView):
                 attrs["custom_object_type_coordinates_fields"][field.name] = tuple(sub_names)
                 continue
 
+            # URL: one logical field rendered as two grouped url/title inputs. Unlike
+            # coordinates, there's no "both required" pairing rule, so no tracking dict
+            # is needed here beyond the generic field-group/rendered-names bookkeeping.
+            if field.type == CustomObjectFieldTypeChoices.TYPE_URL:
+                sub_fields = field_type.get_form_fields(field)
+                sub_names = list(sub_fields.keys())
+                for sub_name, sub_field in sub_fields.items():
+                    attrs[sub_name] = sub_field
+                    attrs["custom_object_type_rendered_names"].add(sub_name)
+                if group_name not in attrs["custom_object_type_field_groups"]:
+                    attrs["custom_object_type_field_groups"][group_name] = []
+                attrs["custom_object_type_field_groups"][group_name].extend(sub_names)
+                continue
+
             # Polymorphic single-object: type-selector + object-picker pair
             if field.is_polymorphic and field.type == CustomFieldTypeChoices.TYPE_OBJECT:
                 ct_sub = f"{field.name}__ct"
@@ -1210,6 +1224,17 @@ class CustomObjectBulkEditView(CustomObjectTableMixin, generic.BulkEditView):
                     sub_names.append(sub_name)
                 # (latitude_name, longitude_name) for cross-field validation below.
                 attrs["custom_object_type_coordinates_fields"][field.name] = tuple(sub_names)
+                continue
+
+            # URL: two optional url/title inputs in bulk edit. No cross-field
+            # validation rule exists for URL (unlike coordinates), so no tracking
+            # dict is needed beyond adding the sub-fields themselves.
+            if field.type == CustomObjectFieldTypeChoices.TYPE_URL:
+                for sub_name, sub_field in field_type.get_form_fields(field).items():
+                    sub_field.required = False
+                    sub_field.widget.is_required = False
+                    sub_field.initial = None
+                    attrs[sub_name] = sub_field
                 continue
 
             # Polymorphic single-object: scope-style type-selector + object-picker pair

--- a/netbox_custom_objects/views.py
+++ b/netbox_custom_objects/views.py
@@ -447,6 +447,13 @@ class CustomObjectTypeFieldDeleteView(generic.ObjectDeleteView):
             # Polymorphic Object (GFK): query via the concrete content_type column
             ct_field = f"{obj.name}_content_type__isnull"
             num_dependent_objects = model.objects.filter(**{ct_field: False}).count()
+        elif obj.type == CustomObjectFieldTypeChoices.TYPE_URL:
+            # The title may be set independently of the URL value, so an object with
+            # only a title (no URL) is dependent too and must not be omitted.
+            title_col = field_types.FIELD_TYPE_CLASS[obj.type]().title_field_name(obj)
+            num_dependent_objects = model.objects.filter(
+                Q(**{f"{obj.name}__isnull": False}) | ~Q(**{title_col: ""})
+            ).count()
         else:
             num_dependent_objects = model.objects.filter(**{f"{obj.name}__isnull": False}).count()
 
@@ -497,6 +504,11 @@ class CustomObjectTypeFieldDeleteView(generic.ObjectDeleteView):
             # Polymorphic GFK: filter on the concrete content_type column.
             ct_field = f"{obj.name}_content_type__isnull"
             dependent_objects[model] = list(model.objects.filter(**{ct_field: False}))
+        elif obj.type == CustomObjectFieldTypeChoices.TYPE_URL:
+            title_col = field_types.FIELD_TYPE_CLASS[obj.type]().title_field_name(obj)
+            dependent_objects[model] = list(model.objects.filter(
+                Q(**{f"{obj.name}__isnull": False}) | ~Q(**{title_col: ""})
+            ))
         else:
             dependent_objects[model] = list(model.objects.filter(**{f"{obj.name}__isnull": False}))
 


### PR DESCRIPTION
### Closes: #496

## Summary

- A url-type CustomObjectTypeField now expands into two real DB columns: the URL itself, and an optional <name>_title used as the visible link text on an object's detail page instead of the raw URL (falling back to the URL itself when no title is set). List/table views are unaffected -- still plain-text URL.
- Mirrors CoordinatesFieldType's existing two-column pattern, but unlike coordinates the primary URL column keeps behaving like any other single-value column: unique, default, and regex validation all still apply to it exactly as before.
- This required making three previously coordinates-only DDL/validation code paths in models.py dict-aware (the generic single-column schema helpers used by every field type, the unique-conversion probe in clean(), and the backing-column-collision guard), since URL is the first multi-column type that also needs to flow through the generic single-column path via its unique/default support.
- No new migration or upgrade script is needed for existing installations: the plugin's existing post_migrate schema-heal pass already covers any nullable non-mixin column whose attribute name doesn't match a user field's own name, which the new title column satisfies the same way coordinates' latitude/longitude columns already do. Documented this explicitly in mixin_migration.py.

<img width="1173" height="352" alt="Screenshot 2026-08-06 at 6 12 51 AM" src="https://github.com/user-attachments/assets/f292bc03-8d0e-4581-aa0d-21161e24efdb" />

<img width="744" height="384" alt="Screenshot 2026-08-06 at 6 13 01 AM" src="https://github.com/user-attachments/assets/c21edfdb-b798-4916-9860-25f108537383" />

## Upgrading

Existing `url` fields gain the new `<name>_title` column automatically — no manual migration is needed. On the main schema this happens the next time `manage.py migrate` runs (or immediately via `manage.py upgrade_custom_objects`, which also supports `--dry-run`). On a NetBox Branching branch it happens the next time that branch itself is migrated (its "Migrate branch" action, available whenever the branch's migration state lags behind main).

This will need to be captured in a release note for the next minor release in which this feature ships.

## Test plan

- [x] New/extended tests across test_field_types.py (URLFieldTypeTestCase: model generation, title-optional, unique still enforced, type-conversion rejection both directions, backing-column collision both directions), test_schema_operations.py (rename and delete both drop/rename the title column), test_api.py (serializer exposes both columns flat, create round-trip with and without a title), test_views.py (add form renders both inputs, create with and without a title).
- [x] ruff check clean across the whole package.
- [x] Ran the full plugin test suite (1109 tests) against a NetBox 4.6.6 checkout. All new/changed tests pass. The only pre-existing failures (20, unrelated to this change) trace to an environment gap in that test setup -- netbox_branching is importable but not enabled in PLUGINS, which breaks any test touching CustomObjectTypeField/CustomObjectType rename or delete, confirmed by the identical failure occurring on the unmodified, pre-existing coordinates rename test -- plus one unrelated csv_update_data scaffolding gap in generic view tests.