### PR TITLE
Closes #642: Add missing test_bulk_update_objects_without_change_permission stub

### DIFF
--- a/netbox_custom_objects/tests/test_views.py
+++ b/netbox_custom_objects/tests/test_views.py
@@ -83,6 +83,9 @@ class CustomObjectTypeViewTestCase(CustomObjectsTestCase, ViewTestCases.PrimaryO
     def test_bulk_update_objects_with_permission(self):
         ...
 
+    def test_bulk_update_objects_without_change_permission(self):
+        ...
+
     def test_bulk_import_objects_with_permission(self):
         ...
 
@@ -203,6 +206,9 @@ class CustomObjectTypeFieldViewTestCase(CustomObjectsTestCase, ViewTestCases.Pri
         ...
 
     def test_bulk_update_objects_with_permission(self):
+        ...
+
+    def test_bulk_update_objects_without_change_permission(self):
         ...
 
     def test_bulk_import_objects_with_permission(self):
@@ -337,6 +343,9 @@ class CustomObjectViewTestCase(CustomObjectsTestCase, ViewTestCases.PrimaryObjec
         ...
 
     def test_bulk_update_objects_with_permission(self):
+        ...
+
+    def test_bulk_update_objects_without_change_permission(self):
         ...
 
     def test_bulk_import_objects_with_permission(self):
@@ -639,6 +648,9 @@ class ComplexCustomObjectViewTestCase(CustomObjectsTestCase, ViewTestCases.Prima
     def test_bulk_update_objects_with_permission(self):
         ...
 
+    def test_bulk_update_objects_without_change_permission(self):
+        ...
+
     def test_bulk_import_objects_with_permission(self):
         ...
 
@@ -888,6 +900,9 @@ class ObjectFieldViewTestCase(CustomObjectsTestCase, ViewTestCases.PrimaryObject
         ...
 
     def test_bulk_update_objects_with_permission(self):
+        ...
+
+    def test_bulk_update_objects_without_change_permission(self):
         ...
 
     def test_bulk_import_objects_with_permission(self):


### PR DESCRIPTION
### Closes: #642

## Summary

- NetBox core split its single generic test_bulk_update_objects_with_permission method into two separately-named tests on 2026-07-08 (fixing #22617: editing objects via bulk import form requires the change permission, not just add). Both new methods carry the same csv_update_data requirement the old single method had.
- The 5 view test classes in this repo (CustomObjectTypeViewTestCase, CustomObjectTypeFieldViewTestCase, CustomObjectViewTestCase, ComplexCustomObjectViewTestCase, ObjectFieldViewTestCase) only stub out the old method name as a no-op to suppress it, since dynamically generated Custom Object models do not fit the standard CSV-bulk-update test pattern (none of them define csv_update_data). The new method name is not covered by that stub, so it falls through to the real inherited implementation and raises NotImplementedError.
- main already carries an equivalent fix (added incidentally in c7a6965, bundled with unrelated branching CI matrix work, and never ported to feature since the branches diverged before that commit landed). This PR ports just the 5 stub-method additions to feature.

## Test plan

- [x] All 5 previously-failing test_bulk_update_objects_without_change_permission tests now pass.
- [x] Full test_views.py module run clean apart from 4 pre-existing, unrelated local-environment failures (netbox_branching importable but not enabled in this environment PLUGINS list -- confirmed identical on the unmodified base branch too).
- [x] ruff check clean.
- [x] Manually triggered the "Lint and tests" workflow directly on a clean feature checkout (no diff) to confirm this exact failure reproduces with zero netbox-custom-objects changes, isolating the cause to the NetBox core side. See issue #642 for the full root-cause writeup.
