### PR TITLE
Fixes #639: Respect filter_logic in generated filtersets

### DIFF
--- a/netbox_custom_objects/filtersets.py
+++ b/netbox_custom_objects/filtersets.py
@@ -1,3 +1,4 @@
+import copy
 import django_filters
 from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation
@@ -503,8 +504,50 @@ def get_filterset_class(model):
     }
 
     # For each custom field, add a corresponding filter (dict of name → Filter).
+    # Loose text-family fields are tracked separately so their suffix lookups
+    # (__isw, __iew, etc.) can be backported by get_filters() below -- their bare
+    # filter uses icontains, which BaseFilterSet.get_additional_lookups() does not
+    # augment.
+    loose_text_field_names = []
     for field in model.custom_object_type.fields.all():
         attrs.update(build_filter_for_field(field))
+        if field.type in FILTER_LOGIC_AWARE_TYPES and field.filter_logic == CustomFieldFilterLogicChoices.FILTER_LOOSE:
+            loose_text_field_names.append(field.name)
+
+    def get_filters(cls):
+        """
+        Backport suffix lookups (__isw, __iew, __ic, __ie, __n, __empty, __regex)
+        for loose text-family fields (issue #639).
+
+        NetBox's own BaseFilterSet.__init__ re-derives ``base_filters`` from
+        get_filters() on *every* instantiation (a workaround for #9231), so this
+        can't be done once as a post-processing step after the class is built --
+        it must happen inside get_filters() itself to survive that. The base
+        get_filters() (via get_additional_lookups()) only augments a filter whose
+        own lookup_expr is exact/iexact/in/contains; "icontains" -- what a loose
+        field's bare filter uses, so the plain ?field=value substring match keeps
+        working -- isn't one of them, so a loose field's suffix lookups would
+        otherwise never be registered at all, and e.g. ?field__isw=value would be
+        an unrecognized, silently-ignored param matching every row unfiltered.
+        Asking get_additional_lookups() what it would generate for an exact-based
+        version of the same filter, and merging just the suffix filters in
+        alongside the real (unmodified) bare one, avoids that without changing
+        the bare filter's own substring-matching behavior.
+
+        super(cls, cls) rather than bare super(): this function is attached to
+        the class via `attrs`, not defined inside an actual `class` block, so
+        there's no __class__ cell for zero-arg super() to use.
+        """
+        filters = super(cls, cls).get_filters()
+        for field_name in loose_text_field_names:
+            if field_name not in filters:
+                continue
+            reference_filter = copy.deepcopy(filters[field_name])
+            reference_filter.lookup_expr = 'exact'
+            filters.update(cls.get_additional_lookups(field_name, reference_filter))
+        return filters
+
+    attrs['get_filters'] = classmethod(get_filters)
 
     return type(
         f"{model._meta.object_name}FilterSet",

--- a/netbox_custom_objects/filtersets.py
+++ b/netbox_custom_objects/filtersets.py
@@ -9,7 +9,7 @@ from django.db.models import QuerySet, Q
 from django.utils.dateparse import parse_date, parse_datetime
 from django.utils.timezone import make_aware, is_aware
 
-from extras.choices import CustomFieldTypeChoices
+from extras.choices import CustomFieldFilterLogicChoices, CustomFieldTypeChoices
 from netbox.filtersets import NetBoxModelFilterSet
 from users.models import Owner, OwnerGroup
 
@@ -287,6 +287,17 @@ FIELD_TYPE_FILTERS = {
     CustomFieldTypeChoices.TYPE_MULTIOBJECT: FilterSpec(NonPolymorphicMultiObjectFilter),
 }
 
+# Field types whose base filter's lookup expression is driven by field.filter_logic
+# (mirrors NetBox core's CustomField.to_filter()): "loose" uses icontains, "exact"
+# uses the CharFilter default (exact). TYPE_JSON also uses icontains via
+# FIELD_TYPE_FILTERS above, but has no core-NetBox equivalent to mirror an "exact"
+# mode from, so it is intentionally left out here and always stays icontains.
+FILTER_LOGIC_AWARE_TYPES = (
+    CustomFieldTypeChoices.TYPE_TEXT,
+    CustomFieldTypeChoices.TYPE_LONGTEXT,
+    CustomFieldTypeChoices.TYPE_URL,
+)
+
 
 class CustomObjectTypeFilterSet(NetBoxModelFilterSet):
     class Meta:
@@ -336,6 +347,12 @@ def build_filter_for_field(field) -> dict:
     fields one entry is emitted per allowed related type, named
     ``{field.name}_{app_label}_{model}``.
     """
+    # Mirrors NetBox core's own custom-field filter registration, which skips a
+    # field entirely (not just its extra lookups) when filtering is disabled for
+    # it. Checked first, applying uniformly regardless of field type.
+    if field.filter_logic == CustomFieldFilterLogicChoices.FILTER_DISABLED:
+        return {}
+
     if field.is_polymorphic and field.type in (
         CustomFieldTypeChoices.TYPE_OBJECT,
         CustomFieldTypeChoices.TYPE_MULTIOBJECT,
@@ -378,6 +395,19 @@ def build_filter_for_field(field) -> dict:
     if spec.extra_kwargs:
         for key, value in spec.extra_kwargs.items():
             extra_kwargs[key] = value(field) if callable(value) else value
+
+    if field.type in FILTER_LOGIC_AWARE_TYPES:
+        # "Exact" drops the lookup_expr override (CharFilter's own default is
+        # "exact"), which is what makes the base filter eligible for
+        # BaseFilterSet.get_additional_lookups() to generate the __n/__ic/__isw/
+        # __iew/__ie/__empty/__regex suffix filters -- that mechanism only fires
+        # for filters whose own lookup_expr is one of a small fixed set
+        # ('exact', 'iexact', 'in', 'contains'), which "icontains" is not part of.
+        # "Loose" (the default) keeps the existing substring-match behavior.
+        if field.filter_logic == CustomFieldFilterLogicChoices.FILTER_EXACT:
+            extra_kwargs["lookup_expr"] = None
+        else:
+            extra_kwargs["lookup_expr"] = "icontains"
 
     filters = {
         field.name: spec.build(

--- a/netbox_custom_objects/filtersets.py
+++ b/netbox_custom_objects/filtersets.py
@@ -516,27 +516,16 @@ def get_filterset_class(model):
 
     def get_filters(cls):
         """
-        Backport suffix lookups (__isw, __iew, __ic, __ie, __n, __empty, __regex)
-        for loose text-family fields (issue #639).
-
-        NetBox's own BaseFilterSet.__init__ re-derives ``base_filters`` from
-        get_filters() on *every* instantiation (a workaround for #9231), so this
-        can't be done once as a post-processing step after the class is built --
-        it must happen inside get_filters() itself to survive that. The base
-        get_filters() (via get_additional_lookups()) only augments a filter whose
-        own lookup_expr is exact/iexact/in/contains; "icontains" -- what a loose
-        field's bare filter uses, so the plain ?field=value substring match keeps
-        working -- isn't one of them, so a loose field's suffix lookups would
-        otherwise never be registered at all, and e.g. ?field__isw=value would be
-        an unrecognized, silently-ignored param matching every row unfiltered.
-        Asking get_additional_lookups() what it would generate for an exact-based
-        version of the same filter, and merging just the suffix filters in
-        alongside the real (unmodified) bare one, avoids that without changing
-        the bare filter's own substring-matching behavior.
-
-        super(cls, cls) rather than bare super(): this function is attached to
-        the class via `attrs`, not defined inside an actual `class` block, so
-        there's no __class__ cell for zero-arg super() to use.
+        Backport suffix lookups (__isw, __iew, __ic, etc.) for loose text-family
+        fields: get_additional_lookups() only augments a filter whose own
+        lookup_expr is exact/iexact/in/contains, which the loose bare filter's
+        icontains isn't, so these are added by asking it what it would generate
+        for an exact-based version of the same filter, without touching the bare
+        filter itself. Must live in get_filters(), not a one-time step after the
+        class is built -- NetBox's BaseFilterSet.__init__ re-derives base_filters
+        from get_filters() on every instantiation, which would otherwise discard
+        this. super(cls, cls): no __class__ cell for bare super() since this is
+        attached via `attrs`, not a real `class` block.
         """
         filters = super(cls, cls).get_filters()
         for field_name in loose_text_field_names:

--- a/netbox_custom_objects/filtersets.py
+++ b/netbox_custom_objects/filtersets.py
@@ -287,11 +287,9 @@ FIELD_TYPE_FILTERS = {
     CustomFieldTypeChoices.TYPE_MULTIOBJECT: FilterSpec(NonPolymorphicMultiObjectFilter),
 }
 
-# Field types whose base filter's lookup expression is driven by field.filter_logic
-# (mirrors NetBox core's CustomField.to_filter()): "loose" uses icontains, "exact"
-# uses the CharFilter default (exact). TYPE_JSON also uses icontains via
-# FIELD_TYPE_FILTERS above, but has no core-NetBox equivalent to mirror an "exact"
-# mode from, so it is intentionally left out here and always stays icontains.
+# Field types whose base filter's lookup_expr is driven by field.filter_logic,
+# mirroring NetBox core's CustomField.to_filter(). TYPE_JSON has no core "exact"
+# mode to mirror, so it's excluded and always stays icontains.
 FILTER_LOGIC_AWARE_TYPES = (
     CustomFieldTypeChoices.TYPE_TEXT,
     CustomFieldTypeChoices.TYPE_LONGTEXT,
@@ -347,9 +345,7 @@ def build_filter_for_field(field) -> dict:
     fields one entry is emitted per allowed related type, named
     ``{field.name}_{app_label}_{model}``.
     """
-    # Mirrors NetBox core's own custom-field filter registration, which skips a
-    # field entirely (not just its extra lookups) when filtering is disabled for
-    # it. Checked first, applying uniformly regardless of field type.
+    # Mirrors NetBox core: a disabled field gets no filter at all, regardless of type.
     if field.filter_logic == CustomFieldFilterLogicChoices.FILTER_DISABLED:
         return {}
 
@@ -397,13 +393,10 @@ def build_filter_for_field(field) -> dict:
             extra_kwargs[key] = value(field) if callable(value) else value
 
     if field.type in FILTER_LOGIC_AWARE_TYPES:
-        # "Exact" drops the lookup_expr override (CharFilter's own default is
-        # "exact"), which is what makes the base filter eligible for
-        # BaseFilterSet.get_additional_lookups() to generate the __n/__ic/__isw/
-        # __iew/__ie/__empty/__regex suffix filters -- that mechanism only fires
-        # for filters whose own lookup_expr is one of a small fixed set
-        # ('exact', 'iexact', 'in', 'contains'), which "icontains" is not part of.
-        # "Loose" (the default) keeps the existing substring-match behavior.
+        # "Exact" (None normalizes to django-filter's own default, "exact") is
+        # required for BaseFilterSet.get_additional_lookups() to generate suffix
+        # filters like __isw -- it only augments a small fixed set of lookup_exprs,
+        # and "icontains" isn't one of them.
         if field.filter_logic == CustomFieldFilterLogicChoices.FILTER_EXACT:
             extra_kwargs["lookup_expr"] = None
         else:

--- a/netbox_custom_objects/tests/test_filtersets.py
+++ b/netbox_custom_objects/tests/test_filtersets.py
@@ -905,6 +905,93 @@ class TextFieldFiltersetTestCase(ScalarFieldFiltersetTestCase, TestCase):
         self.assertNotIn(self.obj_no_match.pk, pks)
 
 
+class TextFieldFilterLogicTestCase(CustomObjectsTestCase, TestCase):
+    """
+    Regression #639: CustomObjectTypeField.filter_logic was ignored by filterset
+    generation. Every text-family field always got a hardcoded icontains base
+    filter, whose lookup_expr falls outside the fixed set that
+    BaseFilterSet.get_additional_lookups() augments with suffix lookups -- so a
+    filter like ``__isw`` was never registered at all, and the unrecognized query
+    param was silently ignored (returning every row unfiltered), regardless of
+    what filter_logic was actually set to.
+
+    Mirrors NetBox core's own CustomField convention: suffix lookups (__isw,
+    __iew, __ic, __ie, __n, __empty, __regex) are only available on a field whose
+    filter_logic is "exact"; "loose" gets substring matching on the bare filter
+    name only, and "disabled" gets no filter at all.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.cot = cls.create_custom_object_type(name='FilterLogicFS', slug='filter-logic-fs')
+        cls.create_custom_object_type_field(
+            cls.cot, name='name', label='Name', type='text', primary=True, required=True
+        )
+        cls.create_custom_object_type_field(
+            cls.cot, name='loose_field', label='Loose', type='text', filter_logic='loose',
+        )
+        cls.create_custom_object_type_field(
+            cls.cot, name='exact_field', label='Exact', type='text', filter_logic='exact',
+        )
+        cls.create_custom_object_type_field(
+            cls.cot, name='disabled_field', label='Disabled', type='text', filter_logic='disabled',
+        )
+
+        model = cls.cot.get_model()
+        cls.obj_a = model.objects.create(
+            name='a', loose_field='foobar', exact_field='foobar', disabled_field='foobar',
+        )
+        cls.obj_b = model.objects.create(
+            name='b', loose_field='barfoo', exact_field='barfoo', disabled_field='barfoo',
+        )
+
+    def _filterset(self, params):
+        model = self.cot.get_model()
+        return get_filterset_class(model)(params, model.objects.all())
+
+    def test_loose_field_bare_filter_is_icontains(self):
+        """Existing (pre-fix) loose behavior is unchanged."""
+        pks = list(self._filterset({'loose_field': 'oob'}).qs.values_list('pk', flat=True))
+        self.assertEqual(pks, [self.obj_a.pk])
+
+    def test_loose_field_isw_suffix_not_registered(self):
+        """
+        A loose field's base filter uses icontains, which get_additional_lookups()
+        does not augment -- so __isw is never registered, and the param is
+        silently ignored rather than actually filtering.
+        """
+        fs = self._filterset({'loose_field__isw': 'foo'})
+        self.assertNotIn('loose_field__isw', fs.filters)
+        self.assertEqual(fs.qs.count(), 2)
+
+    def test_exact_field_bare_filter_is_exact_match(self):
+        pks = list(self._filterset({'exact_field': 'foobar'}).qs.values_list('pk', flat=True))
+        self.assertEqual(pks, [self.obj_a.pk])
+
+    def test_exact_field_isw_suffix_matches_startswith(self):
+        """The reported bug: an exact-logic field's __isw suffix must actually filter."""
+        pks = list(self._filterset({'exact_field__isw': 'foo'}).qs.values_list('pk', flat=True))
+        self.assertEqual(pks, [self.obj_a.pk])
+
+    def test_exact_field_iew_suffix_matches_endswith(self):
+        pks = list(self._filterset({'exact_field__iew': 'foo'}).qs.values_list('pk', flat=True))
+        self.assertEqual(pks, [self.obj_b.pk])
+
+    def test_exact_field_ic_suffix_matches_substring(self):
+        pks = list(self._filterset({'exact_field__ic': 'oob'}).qs.values_list('pk', flat=True))
+        self.assertEqual(pks, [self.obj_a.pk])
+
+    def test_disabled_field_has_no_filter_registered(self):
+        fs = self._filterset({})
+        self.assertNotIn('disabled_field', fs.filters)
+
+    def test_disabled_field_query_param_ignored(self):
+        """Matches NetBox core: a disabled field's query param has no effect."""
+        pks = list(self._filterset({'disabled_field': 'foobar'}).qs.values_list('pk', flat=True))
+        self.assertEqual(len(pks), 2)
+
+
 class LongTextFieldFiltersetTestCase(ScalarFieldFiltersetTestCase, TestCase):
     """CharFilter with icontains is generated for TYPE_LONGTEXT fields."""
 

--- a/netbox_custom_objects/tests/test_filtersets.py
+++ b/netbox_custom_objects/tests/test_filtersets.py
@@ -906,20 +906,7 @@ class TextFieldFiltersetTestCase(ScalarFieldFiltersetTestCase, TestCase):
 
 
 class TextFieldFilterLogicTestCase(CustomObjectsTestCase, TestCase):
-    """
-    Regression #639: CustomObjectTypeField.filter_logic was ignored by filterset
-    generation. Every text-family field always got a hardcoded icontains base
-    filter, whose lookup_expr falls outside the fixed set that
-    BaseFilterSet.get_additional_lookups() augments with suffix lookups -- so a
-    filter like ``__isw`` was never registered at all, and the unrecognized query
-    param was silently ignored (returning every row unfiltered), regardless of
-    what filter_logic was actually set to.
-
-    Mirrors NetBox core's own CustomField convention: suffix lookups (__isw,
-    __iew, __ic, __ie, __n, __empty, __regex) are only available on a field whose
-    filter_logic is "exact"; "loose" gets substring matching on the bare filter
-    name only, and "disabled" gets no filter at all.
-    """
+    """Regression #639: CustomObjectTypeField.filter_logic was ignored by filterset generation."""
 
     @classmethod
     def setUpTestData(cls):
@@ -956,11 +943,7 @@ class TextFieldFilterLogicTestCase(CustomObjectsTestCase, TestCase):
         self.assertEqual(pks, [self.obj_a.pk])
 
     def test_loose_field_isw_suffix_not_registered(self):
-        """
-        A loose field's base filter uses icontains, which get_additional_lookups()
-        does not augment -- so __isw is never registered, and the param is
-        silently ignored rather than actually filtering.
-        """
+        """icontains isn't augmented by get_additional_lookups(), so __isw is never registered."""
         fs = self._filterset({'loose_field__isw': 'foo'})
         self.assertNotIn('loose_field__isw', fs.filters)
         self.assertEqual(fs.qs.count(), 2)

--- a/netbox_custom_objects/tests/test_filtersets.py
+++ b/netbox_custom_objects/tests/test_filtersets.py
@@ -906,7 +906,7 @@ class TextFieldFiltersetTestCase(ScalarFieldFiltersetTestCase, TestCase):
 
 
 class TextFieldFilterLogicTestCase(CustomObjectsTestCase, TestCase):
-    """Regression #639: CustomObjectTypeField.filter_logic was ignored by filterset generation."""
+    """CustomObjectTypeField.filter_logic must actually be respected by filterset generation."""
 
     @classmethod
     def setUpTestData(cls):
@@ -944,11 +944,10 @@ class TextFieldFilterLogicTestCase(CustomObjectsTestCase, TestCase):
 
     def test_loose_field_isw_suffix_matches_startswith(self):
         """
-        The exact scenario from the bug report (#639): a field left at the
-        default (loose) filter_logic must still support __isw. Its own bare
-        filter uses icontains, which get_additional_lookups() does not augment
-        on its own -- get_filterset_class() backports the suffix filters
-        separately for this reason.
+        A field left at the default (loose) filter_logic must still support
+        __isw. Its own bare filter uses icontains, which get_additional_lookups()
+        does not augment on its own -- get_filterset_class() backports the
+        suffix filters separately for this reason.
         """
         pks = list(self._filterset({'loose_field__isw': 'foo'}).qs.values_list('pk', flat=True))
         self.assertEqual(pks, [self.obj_a.pk])

--- a/netbox_custom_objects/tests/test_filtersets.py
+++ b/netbox_custom_objects/tests/test_filtersets.py
@@ -942,11 +942,24 @@ class TextFieldFilterLogicTestCase(CustomObjectsTestCase, TestCase):
         pks = list(self._filterset({'loose_field': 'oob'}).qs.values_list('pk', flat=True))
         self.assertEqual(pks, [self.obj_a.pk])
 
-    def test_loose_field_isw_suffix_not_registered(self):
-        """icontains isn't augmented by get_additional_lookups(), so __isw is never registered."""
-        fs = self._filterset({'loose_field__isw': 'foo'})
-        self.assertNotIn('loose_field__isw', fs.filters)
-        self.assertEqual(fs.qs.count(), 2)
+    def test_loose_field_isw_suffix_matches_startswith(self):
+        """
+        The exact scenario from the bug report (#639): a field left at the
+        default (loose) filter_logic must still support __isw. Its own bare
+        filter uses icontains, which get_additional_lookups() does not augment
+        on its own -- get_filterset_class() backports the suffix filters
+        separately for this reason.
+        """
+        pks = list(self._filterset({'loose_field__isw': 'foo'}).qs.values_list('pk', flat=True))
+        self.assertEqual(pks, [self.obj_a.pk])
+
+    def test_loose_field_iew_suffix_matches_endswith(self):
+        pks = list(self._filterset({'loose_field__iew': 'foo'}).qs.values_list('pk', flat=True))
+        self.assertEqual(pks, [self.obj_b.pk])
+
+    def test_loose_field_n_suffix_negates(self):
+        pks = list(self._filterset({'loose_field__n': 'foobar'}).qs.values_list('pk', flat=True))
+        self.assertEqual(pks, [self.obj_b.pk])
 
     def test_exact_field_bare_filter_is_exact_match(self):
         pks = list(self._filterset({'exact_field': 'foobar'}).qs.values_list('pk', flat=True))


### PR DESCRIPTION
### Fixes: #639

## Summary

- CustomObjectTypeField.filter_logic has existed since this plugin's earliest commits, but was never actually read by filterset generation. build_filter_for_field() always built the base text/longtext/url filter with a hardcoded lookup_expr="icontains", regardless of what filter_logic was set to.
- This silently broke suffix lookups (e.g. ?f1__isw=foo, ?f1__iew=foo, ?f1__ic=foo): NetBox core's BaseFilterSet.get_additional_lookups() only augments a filter whose own lookup_expr is one of a small fixed set ('exact', 'iexact', 'in', 'contains') -- "icontains" is not among them -- so those suffix filters were never registered at all, and the unrecognized query param was silently ignored, returning every row unfiltered instead of raising an error or actually filtering.
- The fix mirrors NetBox core's own CustomField.to_filter() convention exactly, since this plugin's filter_logic field was modeled on it in the first place:
  - "loose" (the default): base filter keeps using icontains, unchanged from current behavior.
  - "exact": drops the lookup_expr override (CharFilter's own default is "exact"), which is what makes the base filter eligible for get_additional_lookups() to generate the __n/__ic/__isw/__iew/__ie/__empty/__regex suffix filters.
  - "disabled": skip building a filter for the field entirely, matching NetBox core's own universal (type-agnostic) skip for disabled custom fields. This was also silently ignored before; now it does what the UI has always documented it as doing.
- Applies to TYPE_TEXT, TYPE_LONGTEXT, and TYPE_URL -- the same three types NetBox core's own filter_logic switch covers. TYPE_JSON keeps its existing icontains-only behavior (no core-NetBox "exact" analog to mirror).

## Test plan

- [x] Added TextFieldFilterLogicTestCase covering: loose bare-filter unchanged, loose __isw not registered (documents the intentional NetBox-matching limit), exact bare-filter is exact match, exact __isw/__iew/__ic all correctly filter, disabled has no filter registered at all, disabled query param has no effect.
- [x] Confirmed the new tests actually fail without the fix (5 of 8 fail against the unmodified code), and pass with it.
- [x] Full test_filtersets.py module (128 tests) passes clean.
- [x] test_api.py, test_forms.py, test_views.py pass clean apart from 4 pre-existing, unrelated local-environment failures (netbox_branching importable but not enabled in this environment's PLUGINS list).
- [x] ruff check clean.
