### PR TITLE
Fixes #649: Refresh query_counts.json baseline for current NetBox main

### DIFF
--- a/netbox_custom_objects/tests/query_counts.json
+++ b/netbox_custom_objects/tests/query_counts.json
@@ -1,6 +1,6 @@
 {
-  "customobject-complex:list_objects_with_permission": 41,
-  "customobject-objectfields:list_objects_with_permission": 50,
-  "customobject-simple:list_objects_with_permission": 33,
-  "customobjecttype:list_objects_with_permission": 34
+  "customobject-complex:list_objects_with_permission": 39,
+  "customobject-objectfields:list_objects_with_permission": 48,
+  "customobject-simple:list_objects_with_permission": 31,
+  "customobjecttype:list_objects_with_permission": 32
 }


### PR DESCRIPTION
### Closes: #649

## Summary

- The `tests (main)` CI leg was failing on 4 `list_objects_with_permission` query-count assertions, expecting 2 more queries than NetBox's current `main` branch actually issues for those views. Confirmed this is pre-existing drift, not caused by any specific PR: it reproduces identically on an unmodified `netbox-custom-objects` `main` (see [run 31199832224](https://github.com/netboxlabs/netbox-custom-objects/actions/runs/31199832224)) — an upstream query-count optimization on `netbox-community/netbox` `main` shaved 2 queries off these checks since the baselines were last recorded.
- Regenerated `netbox_custom_objects/tests/query_counts.json` via `UPDATE_QUERY_COUNTS=1`, run against a clean worktree of NetBox's actual `main` tip (not a locally cached/stale checkout) to match what CI fetches.
- All four affected keys (`customobject-simple`, `customobject-objectfields`, `customobject-complex`, `customobjecttype`) dropped by exactly 2 queries each — matching the CI failure precisely. No other baseline keys changed.

## Test plan

- `python netbox/manage.py test netbox_custom_objects.tests.test_views` passes against current NetBox `main` with the refreshed baseline.
- Re-ran the full plugin suite (1126 tests) against the same environment — no other regressions.
- `ruff check` clean.
