### PR TITLE
Fixes #647: heal mixin fields unmasked by renaming/deleting a colliding CO field

### DIFF
--- a/netbox_custom_objects/mixin_migration.py
+++ b/netbox_custom_objects/mixin_migration.py
@@ -90,6 +90,47 @@ def _can_auto_add(field):
 # Public API
 # ---------------------------------------------------------------------------
 
+def heal_unmasked_fields(cot, model, schema_conn):
+    """
+    Add missing columns for CustomObject mixin fields unmasked by renaming or
+    deleting a same-named user field (e.g. 'owner' shadowing OwnerMixin.owner).
+
+    Schema-connection-aware (branch-safe) counterpart to the add-column loop
+    in heal_cot(), meant to be called right after a CustomObjectTypeField
+    rename/delete rather than waiting for the next post_migrate heal pass.
+    """
+    expected = _expected_base_fields(cot, model)
+    with schema_conn.cursor() as cursor:
+        actual_cols = {
+            col.name
+            for col in schema_conn.introspection.get_table_description(cursor, model._meta.db_table)
+        }
+
+    missing = []
+    for col_name, field in expected.items():
+        if col_name in actual_cols:
+            continue
+        if not _can_auto_add(field):
+            logger.warning(
+                "heal_unmasked_fields: unmasked base column %r (field %r) on %s is not "
+                "nullable and has no default — cannot auto-add. Run "
+                "'manage.py upgrade_custom_objects'.",
+                col_name, field.name, model._meta.db_table,
+            )
+            continue
+        missing.append(field)
+
+    if not missing:
+        return
+
+    with schema_conn.schema_editor() as schema_editor:
+        # Flush pending DEFERRABLE FK trigger events before ALTER TABLE, matching
+        # every other add_field() call site in this codebase.
+        schema_editor.execute('SET CONSTRAINTS ALL IMMEDIATE')
+        for field in missing:
+            schema_editor.add_field(model, field)
+
+
 def heal_cot(cot, verbosity=1, dry_run=False):
     """
     Detect and repair mixin column drift for a single CustomObjectType.

--- a/netbox_custom_objects/mixin_migration.py
+++ b/netbox_custom_objects/mixin_migration.py
@@ -5,12 +5,19 @@ Phase 2 of issue #391: when NetBox is upgraded and a mixin (e.g.
 ChangeLoggingMixin) gains a new concrete column, existing COT tables will be
 missing that column.  This module provides:
 
-  heal_cot(cot, verbosity, dry_run)   — check and repair a single COT table
-  heal_all_cots(verbosity, dry_run)   — iterate over all COTs
+  heal_cot(cot, verbosity, dry_run)         — check and repair a single COT table
+  heal_all_cots(verbosity, dry_run)         — iterate over all COTs
+  heal_unmasked_fields(cot, model, schema_conn)
+                                             — add mixin columns unmasked by a
+                                               field rename/delete
 
-Both are called from:
+heal_cot/heal_all_cots are called from:
   - The post_migrate signal handler in __init__.py (automatic, zero-config)
   - The upgrade_custom_objects management command (explicit, with --dry-run)
+
+heal_unmasked_fields is called directly from CustomObjectTypeField.save()/
+delete() in models.py, right after a rename or delete, rather than waiting
+for the next post_migrate pass.
 
 Safety rules
 ------------

--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -80,6 +80,7 @@ from netbox_custom_objects.field_types import (
     PolymorphicObjectReverseDescriptor, PolymorphicMultiObjectReverseDescriptor,
 )
 from netbox_custom_objects.jobs import ReindexCustomObjectTypeJob
+from netbox_custom_objects.mixin_migration import heal_unmasked_fields
 from netbox_custom_objects.utilities import (
     _suppress_clear_cache,
     extract_cot_id_from_model_name,
@@ -451,37 +452,6 @@ def _schema_alter_field(old_fi, new_fi, model, schema_editor, schema_conn, exist
         return
 
     schema_editor.alter_field(model, old_mf, new_mf)
-
-
-def _heal_unmasked_base_fields(cot, model, schema_conn):
-    """Add missing columns for CustomObject mixin fields unmasked by a rename/delete.
-
-    A user field named the same as a mixin field (e.g. 'owner') shadows it while the
-    collision lasts. Renaming or deleting that field unmasks the mixin field, which
-    never had its own column.
-    """
-    from netbox_custom_objects.mixin_migration import _can_auto_add, _expected_base_fields
-
-    expected = _expected_base_fields(cot, model)
-    with schema_conn.cursor() as cursor:
-        actual_cols = {
-            col.name
-            for col in schema_conn.introspection.get_table_description(cursor, model._meta.db_table)
-        }
-
-    for col_name, field in expected.items():
-        if col_name in actual_cols:
-            continue
-        if not _can_auto_add(field):
-            logger.warning(
-                "_heal_unmasked_base_fields: unmasked base column %r (field %r) on %s is "
-                "not nullable and has no default — cannot auto-add. Run "
-                "'manage.py upgrade_custom_objects'.",
-                col_name, field.name, model._meta.db_table,
-            )
-            continue
-        with schema_conn.schema_editor() as schema_editor:
-            schema_editor.add_field(model, field)
 
 
 def _rename_or_create_m2m_through(old_fi, new_fi, model, schema_editor, schema_conn, existing_tables):
@@ -3662,7 +3632,7 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
             )
             if renamed:
                 updated_model = self.custom_object_type.get_model(no_cache=True)
-                _heal_unmasked_base_fields(self.custom_object_type, updated_model, schema_conn)
+                heal_unmasked_fields(self.custom_object_type, updated_model, schema_conn)
 
         # FK constraint runs AFTER commit to avoid "pending trigger events".
         if should_ensure_fk:
@@ -3767,7 +3737,7 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
         # field-undo and CO-undo, and a stale class would emit ProgrammingError.
         updated_model = self.custom_object_type.get_model()
 
-        _heal_unmasked_base_fields(self.custom_object_type, updated_model, schema_conn)
+        heal_unmasked_fields(self.custom_object_type, updated_model, schema_conn)
         self.custom_object_type.register_custom_object_search_index(updated_model)
 
         if self.search_weight > 0:

--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -3648,6 +3648,22 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
 
             super().save(*args, **kwargs)
 
+            # On rename, _schema_alter_field calls contribute_to_class twice on the
+            # same class — force a no_cache regeneration so _meta is clean.  Healing
+            # runs in this same transaction so a reader can never observe the rename
+            # committed without the unmasked base field's column.  Non-rename changes
+            # lean on cache_timestamp for lazy invalidation; we skip the
+            # apps.clear_cache() cascade so signal-driven cache evictions (e.g.
+            # clear_cache_on_field_save for OBJECT fields) survive.
+            renamed = (
+                not self._state.adding
+                and not self.is_polymorphic
+                and self._original_name != self.name
+            )
+            if renamed:
+                updated_model = self.custom_object_type.get_model(no_cache=True)
+                _heal_unmasked_base_fields(self.custom_object_type, updated_model, schema_conn)
+
         # FK constraint runs AFTER commit to avoid "pending trigger events".
         if should_ensure_fk:
             _on_delete = self.on_delete_behavior
@@ -3666,19 +3682,7 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
 
             transaction.on_commit(ensure_constraint)
 
-        # On rename, _schema_alter_field calls contribute_to_class twice on the
-        # same class — force a no_cache regeneration so _meta is clean.  Non-
-        # rename changes lean on cache_timestamp for lazy invalidation; we skip
-        # the apps.clear_cache() cascade so signal-driven cache evictions (e.g.
-        # clear_cache_on_field_save for OBJECT fields) survive.
-        renamed = (
-            not self._state.adding
-            and not self.is_polymorphic
-            and self._original_name != self.name
-        )
         if renamed:
-            updated_model = self.custom_object_type.get_model(no_cache=True)
-            _heal_unmasked_base_fields(self.custom_object_type, updated_model, schema_conn)
             self.custom_object_type.register_custom_object_search_index(updated_model)
 
         # Clean up stale descriptor when related_name is renamed on an existing polymorphic field

--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -453,6 +453,37 @@ def _schema_alter_field(old_fi, new_fi, model, schema_editor, schema_conn, exist
     schema_editor.alter_field(model, old_mf, new_mf)
 
 
+def _heal_unmasked_base_fields(cot, model, schema_conn):
+    """Add missing columns for CustomObject mixin fields unmasked by a rename/delete.
+
+    A user field named the same as a mixin field (e.g. 'owner') shadows it while the
+    collision lasts. Renaming or deleting that field unmasks the mixin field, which
+    never had its own column.
+    """
+    from netbox_custom_objects.mixin_migration import _can_auto_add, _expected_base_fields
+
+    expected = _expected_base_fields(cot, model)
+    with schema_conn.cursor() as cursor:
+        actual_cols = {
+            col.name
+            for col in schema_conn.introspection.get_table_description(cursor, model._meta.db_table)
+        }
+
+    for col_name, field in expected.items():
+        if col_name in actual_cols:
+            continue
+        if not _can_auto_add(field):
+            logger.warning(
+                "_heal_unmasked_base_fields: unmasked base column %r (field %r) on %s is "
+                "not nullable and has no default — cannot auto-add. Run "
+                "'manage.py upgrade_custom_objects'.",
+                col_name, field.name, model._meta.db_table,
+            )
+            continue
+        with schema_conn.schema_editor() as schema_editor:
+            schema_editor.add_field(model, field)
+
+
 def _rename_or_create_m2m_through(old_fi, new_fi, model, schema_editor, schema_conn, existing_tables):
     """Rename the through-table for a renamed M2M field, or create the new one
     if the old table is absent (sync/merge against a schema that never had it).
@@ -3647,6 +3678,7 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
         )
         if renamed:
             updated_model = self.custom_object_type.get_model(no_cache=True)
+            _heal_unmasked_base_fields(self.custom_object_type, updated_model, schema_conn)
             self.custom_object_type.register_custom_object_search_index(updated_model)
 
         # Clean up stale descriptor when related_name is renamed on an existing polymorphic field
@@ -3731,6 +3763,7 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
         # field-undo and CO-undo, and a stale class would emit ProgrammingError.
         updated_model = self.custom_object_type.get_model()
 
+        _heal_unmasked_base_fields(self.custom_object_type, updated_model, schema_conn)
         self.custom_object_type.register_custom_object_search_index(updated_model)
 
         if self.search_weight > 0:

--- a/netbox_custom_objects/tests/test_schema_operations.py
+++ b/netbox_custom_objects/tests/test_schema_operations.py
@@ -275,3 +275,65 @@ class SchemaOperationsTestCase(TransactionCleanupMixin, CustomObjectsTestCase, T
         columns = self._db_columns(cot.get_model())
         self.assertNotIn('location_latitude', columns)
         self.assertNotIn('location_longitude', columns)
+
+
+class OwnerFieldNameCollisionTestCase(TransactionCleanupMixin, CustomObjectsTestCase, TransactionTestCase):
+    """A user field named 'owner' shadows CustomObject's own OwnerMixin.owner field.
+    Renaming or deleting it must not crash on the unmasked mixin field's missing column.
+    """
+
+    def _db_columns(self, model):
+        with connection.cursor() as cursor:
+            return {
+                col.name
+                for col in connection.introspection.get_table_description(
+                    cursor, model._meta.db_table
+                )
+            }
+
+    def _make_owner_collision_cot(self, slug):
+        from core.models import ObjectType
+        contact_ot = ObjectType.objects.get(app_label='tenancy', model='contact')
+
+        cot = self.create_custom_object_type(name=slug, slug=slug)
+        self.create_custom_object_type_field(
+            cot, name='name', label='Name', type='text', primary=True, required=True,
+        )
+        # .objects.create() bypasses the reserved-name check in clean().
+        field = self.create_custom_object_type_field(
+            cot, name='owner', label='Owner', type='object', related_object_type=contact_ot,
+        )
+        return cot, field
+
+    def test_renaming_away_from_owner_does_not_break_list_view(self):
+        cot, field = self._make_owner_collision_cot('owner-rename')
+        model = cot.get_model()
+        model.objects.create(name='Obj1')
+        model.objects.create(name='Obj2')
+
+        field = CustomObjectTypeField.objects.get(pk=field.pk)
+        field.name = 'client_contact'
+        field.save()
+
+        updated_model = cot.get_model(no_cache=True)
+        columns = self._db_columns(updated_model)
+        self.assertIn('client_contact_id', columns)
+        self.assertIn('owner_id', columns, "OwnerMixin's own column must be healed back in")
+
+        results = list(updated_model.objects.all())
+        self.assertEqual(len(results), 2)
+
+    def test_deleting_owner_field_does_not_break_list_view(self):
+        cot, field = self._make_owner_collision_cot('owner-delete')
+        model = cot.get_model()
+        model.objects.create(name='Obj1')
+
+        field = CustomObjectTypeField.objects.get(pk=field.pk)
+        field.delete()
+
+        updated_model = cot.get_model()
+        columns = self._db_columns(updated_model)
+        self.assertIn('owner_id', columns)
+
+        results = list(updated_model.objects.all())
+        self.assertEqual(len(results), 1)


### PR DESCRIPTION
### Closes: #647

## Summary

- `CustomObject` inherits NetBox core's `OwnerMixin`, which contributes its own
  concrete `owner` field (FK to `users.Owner`, column `owner_id`). A user field
  named `owner` (as in this issue, an object field pointing at
  `tenancy.Contact`) shadows that mixin field for as long as the collision
  lasts — the physical column belongs to the user field, not the mixin.
- Renaming or deleting that field unmasks the mixin field on the next model
  regeneration. Its column was never created (since the column belonged to
  the user field), so the next query against the table raises
  `ProgrammingError: column ... owner_id does not exist`, exactly as
  reported.
- Adds `_heal_unmasked_base_fields()`, called right after a rename or delete,
  which adds back any base-mixin column newly unmasked by the operation
  (reusing the existing `mixin_migration._expected_base_fields()` /
  `_can_auto_add()` diff logic, made branch-aware via `schema_conn`).

## Recovering already-broken installations

This fix only prevents the crash going forward. For a COT that's already
broken (renamed/deleted before this fix was deployed), running
`manage.py upgrade_custom_objects` (or simply the next `manage.py migrate`,
which fires the existing `post_migrate` heal hook) recovers it — verified
that the plugin's pre-existing `heal_cot()` already adds the missing base
column back for an already-broken table, independent of this change.

## Test plan

- [x] Added `OwnerFieldNameCollisionTestCase` covering both the rename and
  delete paths — asserts the query succeeds afterward and the mixin's own
  column is healed back in.
- [x] Full `netbox_custom_objects` suite passes (1128 tests).
- [x] Manually verified `heal_cot()` recovers a simulated pre-existing broken
  COT (table with the mixin column missing) independent of this fix.
