### PR TITLE
Fix CustomObjectTypeField.from_db() for Django 6.1 compatibility

### DIFF
--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -3448,8 +3448,10 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
             raise ValidationError(_("Required field cannot be empty."))
 
     @classmethod
-    def from_db(cls, db, field_names, values):
-        instance = super().from_db(db, field_names, values)
+    def from_db(cls, db, field_names, values, **kwargs):
+        # **kwargs forwards Django 6.1+'s keyword-only fetch_mode to super()
+        # while staying compatible with older Django, which accepts no extra kwargs here.
+        instance = super().from_db(db, field_names, values, **kwargs)
 
         # save original values, when model is loaded from database,
         # in a separate attribute on the model

--- a/netbox_custom_objects/tests/test_models.py
+++ b/netbox_custom_objects/tests/test_models.py
@@ -648,6 +648,26 @@ class CustomObjectTypeFieldTestCase(CustomObjectsTestCase, TestCase):
                 )
                 field.full_clean()
 
+    def test_from_db_populates_original_snapshot(self):
+        """
+        Loading a field from the database (e.g. via a plain queryset fetch) must
+        succeed and populate .original from the row's own values -- this is what
+        save() diffs against to detect renames/type changes. Also guards
+        from_db()'s signature against Django versions that call it with extra
+        keyword arguments (e.g. Django 6.1's fetch_mode).
+        """
+        created = self.create_custom_object_type_field(
+            self.custom_object_type,
+            name="test_field",
+            label="Test Field",
+            type="text",
+        )
+
+        fetched = CustomObjectTypeField.objects.get(pk=created.pk)
+
+        self.assertEqual(fetched.original.name, "test_field")
+        self.assertEqual(fetched.original.label, "Test Field")
+
     def test_custom_object_type_field_unique_name_per_type(self):
         """Test that field names must be unique within a custom object type."""
         self.create_custom_object_type_field(


### PR DESCRIPTION
## Summary

- Django 6.1 added a keyword-only `fetch_mode=None` parameter to `Model.from_db()`. `CustomObjectTypeField.from_db()` overrode it with a fixed `(cls, db, field_names, values)` signature, so any fetch of a `CustomObjectTypeField` raised `TypeError: ... got an unexpected keyword argument 'fetch_mode'` under Django 6.1.
- Fix forwards `**kwargs` to `super().from_db()`, which is symmetric across versions: under Django 6.0.x no extra kwarg is passed (unchanged behavior), under 6.1+ `fetch_mode` is forwarded correctly.

## Testing

- Added `test_from_db_populates_original_snapshot` in `test_models.py`, which fetches a freshly-created `CustomObjectTypeField` back via a plain queryset `.get()` (forcing `from_db()`) and asserts `.original` is populated correctly.
- Verified manually against both:
  - netbox-community/netbox `main` (Django 6.0.7)
  - netbox-community/netbox `feature` at a commit with Django 6.1 already pinned (prior to the 4.7.0 version bump, so the plugin's own `max_version` gate doesn't get in the way)

Closes: #661
