### PR TITLE
Closes #645: Omit hidden fields from custom object create/edit and bulk edit forms

### DIFF
--- a/netbox_custom_objects/tests/test_views.py
+++ b/netbox_custom_objects/tests/test_views.py
@@ -617,6 +617,9 @@ class CustomObjectViewTestCase(
         self.create_custom_object_type_field(
             cot, name='hidden', label='Hidden', type='text', ui_editable='hidden',
         )
+        self.create_custom_object_type_field(
+            cot, name='readonly', label='Readonly', type='text', ui_editable='no',
+        )
 
         request = RequestFactory().get('/')
         request.user = self.user
@@ -625,6 +628,8 @@ class CustomObjectViewTestCase(
         view.setup(request, custom_object_type=cot.slug)
 
         self.assertNotIn('hidden', view.form.base_fields)
+        # A read-only (ui_editable=no) field is disabled, not omitted -- distinct from hidden.
+        self.assertIn('readonly', view.form.base_fields)
 
     def test_bulk_edit_form_omits_hidden_field(self):
         """Regression #645: same as above, for the bulk edit form."""
@@ -635,6 +640,9 @@ class CustomObjectViewTestCase(
         self.create_custom_object_type_field(
             cot, name='hidden', label='Hidden', type='text', ui_editable='hidden',
         )
+        self.create_custom_object_type_field(
+            cot, name='readonly', label='Readonly', type='text', ui_editable='no',
+        )
 
         request = RequestFactory().get('/')
         request.user = self.user
@@ -643,6 +651,45 @@ class CustomObjectViewTestCase(
         view.setup(request, custom_object_type=cot.slug)
 
         self.assertNotIn('hidden', view.form.base_fields)
+        self.assertIn('readonly', view.form.base_fields)
+
+    def test_edit_form_omits_hidden_coordinates_field(self):
+        """Regression #645: a hidden coordinates field must omit both its lat/long sub-fields."""
+        cot = self.create_custom_object_type(name='HiddenCoordsEditTest', slug='hidden-coords-edit-test')
+        self.create_custom_object_type_field(
+            cot, name='name', label='Name', type='text', primary=True,
+        )
+        self.create_custom_object_type_field(
+            cot, name='location', label='Location', type='coordinates', ui_editable='hidden',
+        )
+
+        request = RequestFactory().get('/')
+        request.user = self.user
+
+        view = views.CustomObjectEditView()
+        view.setup(request, custom_object_type=cot.slug)
+
+        self.assertNotIn('location_latitude', view.form.base_fields)
+        self.assertNotIn('location_longitude', view.form.base_fields)
+
+    def test_bulk_edit_form_omits_hidden_coordinates_field(self):
+        """Regression #645: same as above, for the bulk edit form."""
+        cot = self.create_custom_object_type(name='HiddenCoordsBulkEditTest', slug='hidden-coords-bulk-edit-test')
+        self.create_custom_object_type_field(
+            cot, name='name', label='Name', type='text', primary=True,
+        )
+        self.create_custom_object_type_field(
+            cot, name='location', label='Location', type='coordinates', ui_editable='hidden',
+        )
+
+        request = RequestFactory().get('/')
+        request.user = self.user
+
+        view = views.CustomObjectBulkEditView()
+        view.setup(request, custom_object_type=cot.slug)
+
+        self.assertNotIn('location_latitude', view.form.base_fields)
+        self.assertNotIn('location_longitude', view.form.base_fields)
 
     def test_bulk_edit_select_all_respects_full_queryset(self):
         """Regression #380: 'select all matching query' must edit all objects, not just the current page.

--- a/netbox_custom_objects/tests/test_views.py
+++ b/netbox_custom_objects/tests/test_views.py
@@ -608,6 +608,42 @@ class CustomObjectViewTestCase(
         instance = form.save()
         self.assertIsNone(instance.identifier)
 
+    def test_edit_form_omits_hidden_field(self):
+        """Regression #645: a hidden field must be omitted from the edit form, not just disabled."""
+        cot = self.create_custom_object_type(name='HiddenFieldEditTest', slug='hidden-field-edit-test')
+        self.create_custom_object_type_field(
+            cot, name='name', label='Name', type='text', primary=True,
+        )
+        self.create_custom_object_type_field(
+            cot, name='hidden', label='Hidden', type='text', ui_editable='hidden',
+        )
+
+        request = RequestFactory().get('/')
+        request.user = self.user
+
+        view = views.CustomObjectEditView()
+        view.setup(request, custom_object_type=cot.slug)
+
+        self.assertNotIn('hidden', view.form.base_fields)
+
+    def test_bulk_edit_form_omits_hidden_field(self):
+        """Regression #645: same as above, for the bulk edit form."""
+        cot = self.create_custom_object_type(name='HiddenFieldBulkEditTest', slug='hidden-field-bulk-edit-test')
+        self.create_custom_object_type_field(
+            cot, name='name', label='Name', type='text', primary=True,
+        )
+        self.create_custom_object_type_field(
+            cot, name='hidden', label='Hidden', type='text', ui_editable='hidden',
+        )
+
+        request = RequestFactory().get('/')
+        request.user = self.user
+
+        view = views.CustomObjectBulkEditView()
+        view.setup(request, custom_object_type=cot.slug)
+
+        self.assertNotIn('hidden', view.form.base_fields)
+
     def test_bulk_edit_select_all_respects_full_queryset(self):
         """Regression #380: 'select all matching query' must edit all objects, not just the current page.
 

--- a/netbox_custom_objects/tests/test_views.py
+++ b/netbox_custom_objects/tests/test_views.py
@@ -691,6 +691,78 @@ class CustomObjectViewTestCase(
         self.assertNotIn('location_latitude', view.form.base_fields)
         self.assertNotIn('location_longitude', view.form.base_fields)
 
+    def test_edit_form_applies_hidden_multiobject_default_on_create(self):
+        """
+        Regression #42/#645: a hidden non-polymorphic MultiObject field is a real M2M
+        model attribute, so omitting it from the rendered form must not also skip
+        applying its configured default when creating a new object.
+        """
+        from dcim.models import Site
+
+        site_a = Site.objects.create(name='Site A', slug='site-a-hidden-mo-create')
+        site_b = Site.objects.create(name='Site B', slug='site-b-hidden-mo-create')
+
+        cot = self.create_custom_object_type(name='HiddenMultiObjCreateTest', slug='hidden-multiobj-create-test')
+        self.create_custom_object_type_field(
+            cot, name='name', label='Name', type='text', primary=True,
+        )
+        self.create_custom_object_type_field(
+            cot, name='sites', label='Sites', type='multiobject',
+            related_object_type=self.get_site_object_type(),
+            ui_editable='hidden',
+            default=[site_a.pk, site_b.pk],
+        )
+
+        request = RequestFactory().post('/')
+        request.user = self.user
+
+        view = views.CustomObjectEditView()
+        view.setup(request, custom_object_type=cot.slug)
+
+        form = view.form(data={'name': 'New Instance'}, instance=view.object)
+        self.assertTrue(form.is_valid(), form.errors)
+        instance = form.save()
+
+        self.assertEqual(set(instance.sites.values_list('pk', flat=True)), {site_a.pk, site_b.pk})
+
+    def test_edit_form_preserves_hidden_multiobject_relation_on_edit(self):
+        """
+        Regression #645: editing an object must not clear a hidden MultiObject field's
+        existing relation -- there is no rendered input for it to come from, and a
+        hidden field is defined as neither displayed nor editable.
+        """
+        from dcim.models import Site
+
+        site_a = Site.objects.create(name='Site A', slug='site-a-hidden-mo-edit')
+        site_b = Site.objects.create(name='Site B', slug='site-b-hidden-mo-edit')
+
+        cot = self.create_custom_object_type(name='HiddenMultiObjEditTest', slug='hidden-multiobj-edit-test')
+        self.create_custom_object_type_field(
+            cot, name='name', label='Name', type='text', primary=True,
+        )
+        self.create_custom_object_type_field(
+            cot, name='sites', label='Sites', type='multiobject',
+            related_object_type=self.get_site_object_type(),
+            ui_editable='hidden',
+            default=[site_a.pk],
+        )
+
+        model = cot.get_model()
+        obj = model.objects.create(name='Existing Instance')
+        obj.sites.set([site_a.pk, site_b.pk])
+
+        request = RequestFactory().post('/')
+        request.user = self.user
+
+        view = views.CustomObjectEditView()
+        view.setup(request, custom_object_type=cot.slug, pk=obj.pk)
+
+        form = view.form(data={'name': 'Renamed Instance'}, instance=view.object)
+        self.assertTrue(form.is_valid(), form.errors)
+        instance = form.save()
+
+        self.assertEqual(set(instance.sites.values_list('pk', flat=True)), {site_a.pk, site_b.pk})
+
     def test_bulk_edit_select_all_respects_full_queryset(self):
         """Regression #380: 'select all matching query' must edit all objects, not just the current page.
 

--- a/netbox_custom_objects/views.py
+++ b/netbox_custom_objects/views.py
@@ -797,8 +797,14 @@ class CustomObjectEditView(generic.ObjectEditView):
 
         # Process custom object type fields (with grouping)
         for field in cot_fields:
-            # Hidden fields are omitted entirely, not just disabled.
+            # Hidden fields are omitted entirely, not just disabled -- but a
+            # non-polymorphic MultiObject field is a real M2M model attribute
+            # whose configured default must still be applied on create (#42).
+            # Track it in custom_object_type_fields (bookkeeping only, not
+            # rendered anywhere) so custom_init/custom_save still process it.
             if field.ui_editable == CustomFieldUIEditableChoices.HIDDEN:
+                if field.type == CustomFieldTypeChoices.TYPE_MULTIOBJECT and not field.is_polymorphic:
+                    attrs["custom_object_type_fields"][field.name] = field
                 continue
 
             field_type = field_types.FIELD_TYPE_CLASS[field.type]()
@@ -888,6 +894,10 @@ class CustomObjectEditView(generic.ObjectEditView):
             self.custom_object_type_poly_obj_ct_names = attrs["custom_object_type_poly_obj_ct_names"]
             self.custom_object_type_poly_obj_pairs = attrs["custom_object_type_poly_obj_pairs"]
             self.custom_object_type_coordinates_fields = attrs["custom_object_type_coordinates_fields"]
+            # A hidden MultiObject field has no rendered form field, so its resolved
+            # default can't reach cleaned_data via kwargs['initial'] below -- custom_save
+            # applies these directly on create instead. See the note in the loop above.
+            self._hidden_multiobject_defaults = {}
 
             instance = kwargs.get('instance', None)
 
@@ -918,6 +928,8 @@ class CustomObjectEditView(generic.ObjectEditView):
                                     .values_list('pk', flat=True)
                                 )
                                 kwargs['initial'][field_name] = initial_ids
+                                if field_obj.ui_editable == CustomFieldUIEditableChoices.HIDDEN:
+                                    self._hidden_multiobject_defaults[field_name] = initial_ids
                             except Exception:
                                 logger.debug(
                                     "Failed to load default initial values for field %r",
@@ -1009,6 +1021,7 @@ class CustomObjectEditView(generic.ObjectEditView):
         # Create a custom save method to properly handle M2M fields
         def custom_save(self, commit=True):
             instance = forms.NetBoxModelForm.save(self, commit=False)
+            is_new = instance.pk is None
 
             if commit:
                 # Set polymorphic GFK attributes before the first save so the row
@@ -1021,7 +1034,16 @@ class CustomObjectEditView(generic.ObjectEditView):
                 # Handle non-polymorphic M2M fields (require PK, so after save)
                 for field_name, field_obj in self.custom_object_type_fields.items():
                     if field_obj.type == CustomFieldTypeChoices.TYPE_MULTIOBJECT:
-                        current_value = self.cleaned_data.get(field_name, [])
+                        if field_obj.ui_editable == CustomFieldUIEditableChoices.HIDDEN:
+                            # No rendered input to read from cleaned_data: apply the
+                            # resolved default on create (see custom_init), and leave
+                            # existing relations alone on edit -- consistent with a
+                            # hidden field being neither displayed nor editable.
+                            if not is_new:
+                                continue
+                            current_value = self._hidden_multiobject_defaults.get(field_name, [])
+                        else:
+                            current_value = self.cleaned_data.get(field_name, [])
                         instance_field = getattr(instance, field_name)
                         if hasattr(instance_field, 'clear') and hasattr(instance_field, 'set'):
                             instance_field.clear()

--- a/netbox_custom_objects/views.py
+++ b/netbox_custom_objects/views.py
@@ -60,6 +60,23 @@ def _is_in_branch():
         return False
 
 
+def _hidden_field_raw_columns(fields):
+    """Return backing column name(s) for HIDDEN fields, for a ModelForm's Meta.exclude."""
+    columns = []
+    for f in fields:
+        if f.ui_editable != CustomFieldUIEditableChoices.HIDDEN:
+            continue
+        if f.type == CustomObjectFieldTypeChoices.TYPE_COORDINATES:
+            columns += [f"{f.name}_latitude", f"{f.name}_longitude"]
+        elif f.is_polymorphic and f.type == CustomFieldTypeChoices.TYPE_OBJECT:
+            columns += [f"{f.name}_content_type", f"{f.name}_object_id"]
+        elif f.is_polymorphic and f.type == CustomFieldTypeChoices.TYPE_MULTIOBJECT:
+            continue
+        else:
+            columns.append(f.name)
+    return columns
+
+
 # ---------------------------------------------------------------------------
 # Sub-field naming helpers for polymorphic form fields
 #
@@ -734,13 +751,15 @@ class CustomObjectEditView(generic.ObjectEditView):
         ):
             poly_obj_raw_exclude += [f"{f.name}_content_type", f"{f.name}_object_id"]
 
+        hidden_raw_exclude = _hidden_field_raw_columns(self.object.custom_object_type.fields.all())
+
         meta = type(
             "Meta",
             (),
             {
                 "model": model,
                 "fields": "__all__",
-                "exclude": poly_obj_raw_exclude,
+                "exclude": list(set(poly_obj_raw_exclude + hidden_raw_exclude)),
             },
         )
 
@@ -771,6 +790,10 @@ class CustomObjectEditView(generic.ObjectEditView):
         for field in self.object.custom_object_type.fields.prefetch_related(
             'related_object_types'
         ).order_by("group_name", "weight", "name"):
+            # Hidden fields are omitted entirely, not just disabled.
+            if field.ui_editable == CustomFieldUIEditableChoices.HIDDEN:
+                continue
+
             field_type = field_types.FIELD_TYPE_CLASS[field.type]()
             group_name = field.group_name or None
 
@@ -1160,13 +1183,15 @@ class CustomObjectBulkEditView(CustomObjectTableMixin, generic.BulkEditView):
         ):
             poly_obj_raw_exclude += [f"{f.name}_content_type", f"{f.name}_object_id"]
 
+        hidden_raw_exclude = _hidden_field_raw_columns(self.custom_object_type.fields.all())
+
         meta = type(
             "Meta",
             (),
             {
                 "model": queryset.model,
                 "fields": "__all__",
-                "exclude": poly_obj_raw_exclude,
+                "exclude": list(set(poly_obj_raw_exclude + hidden_raw_exclude)),
             },
         )
 
@@ -1206,6 +1231,10 @@ class CustomObjectBulkEditView(CustomObjectTableMixin, generic.BulkEditView):
         nullable_field_names = []
 
         for field in self.custom_object_type.fields.prefetch_related('related_object_types').all():
+            # Hidden fields are omitted entirely, not just disabled.
+            if field.ui_editable == CustomFieldUIEditableChoices.HIDDEN:
+                continue
+
             field_type = field_types.FIELD_TYPE_CLASS[field.type]()
 
             # Coordinates: two optional latitude/longitude inputs in bulk edit

--- a/netbox_custom_objects/views.py
+++ b/netbox_custom_objects/views.py
@@ -61,17 +61,21 @@ def _is_in_branch():
 
 
 def _hidden_field_raw_columns(fields):
-    """Return backing column name(s) for HIDDEN fields, for a ModelForm's Meta.exclude."""
+    """Return backing column name(s) for HIDDEN fields, for a ModelForm's Meta.exclude.
+
+    Polymorphic fields aren't handled here: TYPE_OBJECT's raw columns are
+    already excluded unconditionally by callers, and TYPE_MULTIOBJECT has
+    no raw column (backed by a through table).
+    """
     columns = []
     for f in fields:
-        if f.ui_editable != CustomFieldUIEditableChoices.HIDDEN:
+        if f.ui_editable != CustomFieldUIEditableChoices.HIDDEN or f.is_polymorphic:
             continue
         if f.type == CustomObjectFieldTypeChoices.TYPE_COORDINATES:
-            columns += [f"{f.name}_latitude", f"{f.name}_longitude"]
-        elif f.is_polymorphic and f.type == CustomFieldTypeChoices.TYPE_OBJECT:
-            columns += [f"{f.name}_content_type", f"{f.name}_object_id"]
-        elif f.is_polymorphic and f.type == CustomFieldTypeChoices.TYPE_MULTIOBJECT:
-            continue
+            columns += [
+                field_types.CoordinatesFieldType.latitude_field_name(f),
+                field_types.CoordinatesFieldType.longitude_field_name(f),
+            ]
         else:
             columns.append(f.name)
     return columns
@@ -742,16 +746,21 @@ class CustomObjectEditView(generic.ObjectEditView):
         return get_object_or_404(model.objects.all(), **self.kwargs)
 
     def get_form(self, model):
+        cot_fields = list(
+            self.object.custom_object_type.fields.prefetch_related(
+                'related_object_types'
+            ).order_by("group_name", "weight", "name")
+        )
+
         # Collect raw GFK column names to exclude from the auto-generated form fields.
         # For each polymorphic Object field "foo", Django adds "foo_content_type" and
         # "foo_object_id" as real model columns; we replace those with per-type selects.
         poly_obj_raw_exclude = []
-        for f in self.object.custom_object_type.fields.filter(
-            type=CustomFieldTypeChoices.TYPE_OBJECT, is_polymorphic=True
-        ):
-            poly_obj_raw_exclude += [f"{f.name}_content_type", f"{f.name}_object_id"]
+        for f in cot_fields:
+            if f.type == CustomFieldTypeChoices.TYPE_OBJECT and f.is_polymorphic:
+                poly_obj_raw_exclude += [f"{f.name}_content_type", f"{f.name}_object_id"]
 
-        hidden_raw_exclude = _hidden_field_raw_columns(self.object.custom_object_type.fields.all())
+        hidden_raw_exclude = _hidden_field_raw_columns(cot_fields)
 
         meta = type(
             "Meta",
@@ -787,9 +796,7 @@ class CustomObjectEditView(generic.ObjectEditView):
         }
 
         # Process custom object type fields (with grouping)
-        for field in self.object.custom_object_type.fields.prefetch_related(
-            'related_object_types'
-        ).order_by("group_name", "weight", "name"):
+        for field in cot_fields:
             # Hidden fields are omitted entirely, not just disabled.
             if field.ui_editable == CustomFieldUIEditableChoices.HIDDEN:
                 continue
@@ -1177,13 +1184,14 @@ class CustomObjectBulkEditView(CustomObjectTableMixin, generic.BulkEditView):
         return model.objects.all()
 
     def get_form(self, queryset):
-        poly_obj_raw_exclude = []
-        for f in self.custom_object_type.fields.filter(
-            type=CustomFieldTypeChoices.TYPE_OBJECT, is_polymorphic=True
-        ):
-            poly_obj_raw_exclude += [f"{f.name}_content_type", f"{f.name}_object_id"]
+        cot_fields = list(self.custom_object_type.fields.prefetch_related('related_object_types'))
 
-        hidden_raw_exclude = _hidden_field_raw_columns(self.custom_object_type.fields.all())
+        poly_obj_raw_exclude = []
+        for f in cot_fields:
+            if f.type == CustomFieldTypeChoices.TYPE_OBJECT and f.is_polymorphic:
+                poly_obj_raw_exclude += [f"{f.name}_content_type", f"{f.name}_object_id"]
+
+        hidden_raw_exclude = _hidden_field_raw_columns(cot_fields)
 
         meta = type(
             "Meta",
@@ -1198,9 +1206,9 @@ class CustomObjectBulkEditView(CustomObjectTableMixin, generic.BulkEditView):
         # Pre-build ct_pk → model_class lookup for each poly obj field so the
         # bulk edit __init__ can wire up the obj picker without a DB query.
         poly_obj_allowed = {}
-        for f in self.custom_object_type.fields.filter(
-            type=CustomFieldTypeChoices.TYPE_OBJECT, is_polymorphic=True
-        ).prefetch_related('related_object_types'):
+        for f in cot_fields:
+            if not (f.type == CustomFieldTypeChoices.TYPE_OBJECT and f.is_polymorphic):
+                continue
             poly_obj_allowed[f.name] = {
                 ot.pk: ot.model_class()
                 for ot in f.related_object_types.all()
@@ -1230,7 +1238,7 @@ class CustomObjectBulkEditView(CustomObjectTableMixin, generic.BulkEditView):
         # aren't real model fields, so core's generic nullify lookup can't resolve them.
         nullable_field_names = []
 
-        for field in self.custom_object_type.fields.prefetch_related('related_object_types').all():
+        for field in cot_fields:
             # Hidden fields are omitted entirely, not just disabled.
             if field.ui_editable == CustomFieldUIEditableChoices.HIDDEN:
                 continue


### PR DESCRIPTION
### Closes: #645

## Summary

- A `CustomObjectTypeField` with `ui_editable` set to "Hidden" was rendered as an (unlabeled-looking, but present) input on the object create/edit form and the bulk edit form, instead of being omitted entirely.
- Root cause: `get_annotated_form_field()` only ever sets `disabled = True` for any `ui_editable` value other than "Yes" -- it doesn't distinguish "Hidden" (should not be displayed at all) from "No"/read-only (should be displayed, but disabled). The templates render every field listed in `custom_object_type_field_groups` unconditionally, without checking `disabled`, so both `CustomObjectEditView.get_form()` and `CustomObjectBulkEditView.get_form()` ended up including hidden fields as still-visible inputs.
- This mirrors core NetBox's own convention (`extras.forms.mixins.NetBoxModelMixin._get_custom_fields`), which filters out `ui_editable=HIDDEN` custom fields before building the form, while leaving `NO` (read-only) fields in place as disabled.

## Changes

- Added `_hidden_field_raw_columns()` helper in `views.py`: given a queryset of fields, returns the backing model column name(s) for any field whose `ui_editable` is `HIDDEN` (handling coordinates' two-column and polymorphic-object raw-column cases).
- Both `CustomObjectEditView.get_form()` and `CustomObjectBulkEditView.get_form()` now:
  - Add those column(s) to `Meta.exclude`, so the `ModelForm` metaclass doesn't auto-generate a plain (non-disabled) field for them from `fields="__all__"`.
  - Skip hidden fields entirely in the per-field loop that builds `attrs`, so they're never added to `custom_object_type_fields`/`_field_groups`/`_rendered_names`.
- CSV bulk import already excluded hidden fields entirely (fixed under #626); this brings the interactive forms in line with the same behavior.

## Testing

- Added `test_edit_form_omits_hidden_field` and `test_bulk_edit_form_omits_hidden_field` in `test_views.py`, asserting a hidden field's name is absent from `form.base_fields`.
- Verified manually against netbox-community/netbox `main` (Django 6.0.7) and a `feature`-branch commit with Django 6.1 pinned.
