### PR TITLE
Closes: #637 - Fix model-registry errors when get_model() runs outside ready()'s two-pass loop

### DIFF
--- a/netbox_custom_objects/__init__.py
+++ b/netbox_custom_objects/__init__.py
@@ -282,17 +282,27 @@ class CustomObjectsPluginConfig(PluginConfig):
     graphql_schema = "graphql.schema.schema"
 
     @staticmethod
-    def should_skip_dynamic_model_creation():
+    def should_skip_dynamic_model_creation(include_test_skip=True):
         """
         Determine if dynamic model creation should be skipped.
 
         Returns True if dynamic models should not be created/loaded due to:
         - Currently running migrations
-        - Running tests
+        - Running tests (if include_test_skip)
         - All migrations not yet applied
         - Running collectstatic
 
         Returns False if it's safe to proceed with dynamic model creation.
+
+        :param include_test_skip: Also skip when "test" is in sys.argv. The
+            plugin's own startup-time entry points (ready(), PluginConfig.get_model/
+            get_models) never need to run during tests -- test code generates COT
+            models directly via CustomObjectType.get_model() instead. That method
+            also consults this check (to avoid #637: a dangling cross-COT FK
+            reference when get_model() runs outside ready()'s two-pass resolution,
+            e.g. a third-party plugin importing it at migrate time), but must pass
+            False here since it's the one entry point tests DO rely on for a fully
+            hydrated model.
         """
         global _migrations_checked, _checking_migrations
 
@@ -300,17 +310,17 @@ class CustomObjectsPluginConfig(PluginConfig):
         if _is_migrating.get():
             return True
 
-        skip_commands = (
+        skip_commands = [
             # Running migrations should skip.
             "makemigrations",
             "migrate",
 
             # The database isn't accessible during collect static so should skip.
             "collectstatic",
-
+        ]
+        if include_test_skip:
             # Skip during tests.
-            "test",
-        )
+            skip_commands.append("test")
 
         if any(cmd in sys.argv for cmd in skip_commands):
             return True

--- a/netbox_custom_objects/__init__.py
+++ b/netbox_custom_objects/__init__.py
@@ -284,18 +284,11 @@ class CustomObjectsPluginConfig(PluginConfig):
     @staticmethod
     def _dynamic_model_creation_unsafe():
         """
-        True if the DB can't safely be queried yet to generate a dynamic COT model:
-        mid-migration, running makemigrations/migrate/collectstatic (schema may be
-        incomplete or absent), or this app's own migrations aren't fully applied.
-
-        Deliberately excludes "test" -- unlike should_skip_dynamic_model_creation()
-        below, this is the check CustomObjectType.get_model() itself uses (#637: a
-        bare get_model() call outside ready()'s two-pass cross-COT FK resolution,
-        e.g. a third-party plugin importing it at migrate time, leaves a dangling
-        LazyForeignKey that Django's system checks flag). By the time get_model()
-        runs on an already-fetched COT instance inside a test method, the test
-        database is fully migrated and safe to query -- and test code relies on
-        get_model() returning a fully-hydrated model, not a degraded one.
+        True if the DB can't safely be queried to generate a dynamic COT model:
+        mid-migration, running makemigrations/migrate/collectstatic, or this
+        app's own migrations aren't fully applied. Unlike
+        should_skip_dynamic_model_creation() below, deliberately excludes "test" --
+        this is the narrower check CustomObjectType.get_model() itself uses (#637).
         """
         global _migrations_checked, _checking_migrations
 
@@ -375,11 +368,6 @@ class CustomObjectsPluginConfig(PluginConfig):
         - Running collectstatic
 
         Returns False if it's safe to proceed with dynamic model creation.
-
-        Used by ready(), PluginConfig.get_model()/get_models(), and navigation --
-        none of these need to run during a test process, since test code drives
-        dynamic model generation directly via CustomObjectType.get_model() instead.
-        That method has its own narrower check; see _dynamic_model_creation_unsafe().
         """
         if "test" in sys.argv:
             return True

--- a/netbox_custom_objects/__init__.py
+++ b/netbox_custom_objects/__init__.py
@@ -282,27 +282,20 @@ class CustomObjectsPluginConfig(PluginConfig):
     graphql_schema = "graphql.schema.schema"
 
     @staticmethod
-    def should_skip_dynamic_model_creation(include_test_skip=True):
+    def _dynamic_model_creation_unsafe():
         """
-        Determine if dynamic model creation should be skipped.
+        True if the DB can't safely be queried yet to generate a dynamic COT model:
+        mid-migration, running makemigrations/migrate/collectstatic (schema may be
+        incomplete or absent), or this app's own migrations aren't fully applied.
 
-        Returns True if dynamic models should not be created/loaded due to:
-        - Currently running migrations
-        - Running tests (if include_test_skip)
-        - All migrations not yet applied
-        - Running collectstatic
-
-        Returns False if it's safe to proceed with dynamic model creation.
-
-        :param include_test_skip: Also skip when "test" is in sys.argv. The
-            plugin's own startup-time entry points (ready(), PluginConfig.get_model/
-            get_models) never need to run during tests -- test code generates COT
-            models directly via CustomObjectType.get_model() instead. That method
-            also consults this check (to avoid #637: a dangling cross-COT FK
-            reference when get_model() runs outside ready()'s two-pass resolution,
-            e.g. a third-party plugin importing it at migrate time), but must pass
-            False here since it's the one entry point tests DO rely on for a fully
-            hydrated model.
+        Deliberately excludes "test" -- unlike should_skip_dynamic_model_creation()
+        below, this is the check CustomObjectType.get_model() itself uses (#637: a
+        bare get_model() call outside ready()'s two-pass cross-COT FK resolution,
+        e.g. a third-party plugin importing it at migrate time, leaves a dangling
+        LazyForeignKey that Django's system checks flag). By the time get_model()
+        runs on an already-fetched COT instance inside a test method, the test
+        database is fully migrated and safe to query -- and test code relies on
+        get_model() returning a fully-hydrated model, not a degraded one.
         """
         global _migrations_checked, _checking_migrations
 
@@ -310,17 +303,14 @@ class CustomObjectsPluginConfig(PluginConfig):
         if _is_migrating.get():
             return True
 
-        skip_commands = [
+        skip_commands = (
             # Running migrations should skip.
             "makemigrations",
             "migrate",
 
             # The database isn't accessible during collect static so should skip.
             "collectstatic",
-        ]
-        if include_test_skip:
-            # Skip during tests.
-            skip_commands.append("test")
+        )
 
         if any(cmd in sys.argv for cmd in skip_commands):
             return True
@@ -372,6 +362,28 @@ class CustomObjectsPluginConfig(PluginConfig):
         finally:
             # Always clear the recursion flag
             _checking_migrations = False
+
+    @staticmethod
+    def should_skip_dynamic_model_creation():
+        """
+        Determine if dynamic model creation should be skipped.
+
+        Returns True if dynamic models should not be created/loaded due to:
+        - Currently running migrations
+        - Running tests
+        - All migrations not yet applied
+        - Running collectstatic
+
+        Returns False if it's safe to proceed with dynamic model creation.
+
+        Used by ready(), PluginConfig.get_model()/get_models(), and navigation --
+        none of these need to run during a test process, since test code drives
+        dynamic model generation directly via CustomObjectType.get_model() instead.
+        That method has its own narrower check; see _dynamic_model_creation_unsafe().
+        """
+        if "test" in sys.argv:
+            return True
+        return CustomObjectsPluginConfig._dynamic_model_creation_unsafe()
 
     def _call_super_ready_once(self):
         """Call ``super().ready()`` once; subsequent calls are no-ops.

--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -1363,6 +1363,7 @@ class CustomObjectType(NetBoxModel):
         self,
         fields,
         skip_object_fields=False,
+        skip_cot_object_fields=False,
     ):
         field_attrs = {
             "_primary_field_id": -1,
@@ -1380,8 +1381,13 @@ class CustomObjectType(NetBoxModel):
         fields = list(fields) + [field for field in fields_query]
 
         for field in fields:
-            if skip_object_fields:
-                if field.type in [CustomFieldTypeChoices.TYPE_OBJECT, CustomFieldTypeChoices.TYPE_MULTIOBJECT]:
+            if field.type in [CustomFieldTypeChoices.TYPE_OBJECT, CustomFieldTypeChoices.TYPE_MULTIOBJECT]:
+                if skip_object_fields:
+                    continue
+                # Only a COT target produces a LazyForeignKey that needs ready()'s
+                # second pass; core-model targets and polymorphic GFKs resolve on
+                # their own, so they stay even in the unsafe window (#637).
+                if skip_cot_object_fields and field.targets_custom_object_type:
                     continue
 
             field_type = FIELD_TYPE_CLASS[field.type]()
@@ -1692,9 +1698,12 @@ class CustomObjectType(NetBoxModel):
 
         # Avoid a dangling cross-COT FK reference when get_model() runs outside
         # ready()'s two-pass resolution, e.g. a plugin importing it at migrate
-        # time (#637). Never cached (see below), so a later call regenerates in full.
-        if apps.get_app_config(APP_LABEL)._dynamic_model_creation_unsafe():
-            skip_object_fields = True
+        # time (#637). Only COT-targeting Object/Multi-object fields can dangle
+        # like this (core-model targets and polymorphic GFKs resolve on their
+        # own), so this narrower flag is kept separate from the caller's own
+        # skip_object_fields. Never cached (see below), so a later call
+        # regenerates in full.
+        skip_cot_object_fields = apps.get_app_config(APP_LABEL)._dynamic_model_creation_unsafe()
 
         # Generate the model outside the lock to avoid holding it during expensive operations
         model_name = self.get_table_model_name(self.pk)
@@ -1729,6 +1738,7 @@ class CustomObjectType(NetBoxModel):
         field_attrs = self._fetch_and_generate_field_attrs(
             fields,
             skip_object_fields=skip_object_fields,
+            skip_cot_object_fields=skip_cot_object_fields,
         )
 
         attrs.update(**field_attrs)
@@ -1852,10 +1862,11 @@ class CustomObjectType(NetBoxModel):
                     fk_field.__dict__.pop('reverse_path_infos', None)
 
                 # Only cache fully-generated models.  Models generated with
-                # skip_object_fields=True omit FK fields to other COTs; caching them
-                # would permanently hide those fields if a dependent COT triggers
-                # generation before this one in the startup loop (issue #408).
-                if not skip_object_fields:
+                # skip_object_fields=True or skip_cot_object_fields=True omit FK
+                # fields to other COTs; caching them would permanently hide those
+                # fields if a dependent COT triggers generation before this one in
+                # the startup loop (issue #408), or after a migrate-time call (#637).
+                if not (skip_object_fields or skip_cot_object_fields):
                     self._model_cache[(self.id, branch_id)] = (model, self.cache_timestamp)
 
         apps.clear_cache()
@@ -2584,6 +2595,24 @@ class CustomObjectTypeField(CloningMixin, ExportTemplatesMixin, ChangeLoggedMode
             getter = getattr(self.choice_set, 'get_choice_color', None)
             return getter(value) if getter else None
         return None
+
+    @property
+    def targets_custom_object_type(self):
+        """
+        True when this field points at another COT's dynamic model, i.e. its FK is a
+        LazyForeignKey that only resolves once the target is in the app registry.
+        Polymorphic fields use a GFK and need no resolution, so they are excluded.
+        """
+        if self.is_polymorphic or not self.related_object_type_id:
+            return False
+        try:
+            object_type = ContentType.objects.get_for_id(self.related_object_type_id)
+        except ContentType.DoesNotExist:
+            return False
+        return (
+            object_type.app_label == APP_LABEL
+            and extract_cot_id_from_model_name(object_type.model) is not None
+        )
 
     @property
     def related_object_type_label(self):

--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -1667,6 +1667,17 @@ class CustomObjectType(NetBoxModel):
         :return: The generated model.
         :rtype: Model
         """
+        # Every other dynamic-model entry point (PluginConfig.get_model/get_models,
+        # ready()) already guards against generating models before migrations have
+        # run. This is the one path that didn't: a module-level get_model() call in
+        # a third-party plugin (or anything else bypassing ready()'s two-pass FK
+        # resolution) leaves a cross-COT Object/MultiObject field's target
+        # unregistered, which Django's system checks flag as fields.E300/E307 (#637).
+        # Falling back to skip_object_fields avoids ever creating that dangling
+        # reference; the resulting model is never cached (see the cache-store
+        # guard below), so a normal request after startup regenerates it in full.
+        if apps.get_app_config(APP_LABEL).should_skip_dynamic_model_creation(include_test_skip=False):
+            skip_object_fields = True
 
         branch_id = self._active_branch_id()
 

--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -1667,15 +1667,9 @@ class CustomObjectType(NetBoxModel):
         :return: The generated model.
         :rtype: Model
         """
-        # Every other dynamic-model entry point (PluginConfig.get_model/get_models,
-        # ready()) already guards against generating models before migrations have
-        # run. This is the one path that didn't: a module-level get_model() call in
-        # a third-party plugin (or anything else bypassing ready()'s two-pass FK
-        # resolution) leaves a cross-COT Object/MultiObject field's target
-        # unregistered, which Django's system checks flag as fields.E300/E307 (#637).
-        # Falling back to skip_object_fields avoids ever creating that dangling
-        # reference; the resulting model is never cached (see the cache-store
-        # guard below), so a normal request after startup regenerates it in full.
+        # Avoid a dangling cross-COT FK reference when get_model() runs outside
+        # ready()'s two-pass resolution, e.g. a plugin importing it at migrate
+        # time (#637). Never cached (see below), so a later call regenerates in full.
         if apps.get_app_config(APP_LABEL)._dynamic_model_creation_unsafe():
             skip_object_fields = True
 

--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -1676,7 +1676,7 @@ class CustomObjectType(NetBoxModel):
         # Falling back to skip_object_fields avoids ever creating that dangling
         # reference; the resulting model is never cached (see the cache-store
         # guard below), so a normal request after startup regenerates it in full.
-        if apps.get_app_config(APP_LABEL).should_skip_dynamic_model_creation(include_test_skip=False):
+        if apps.get_app_config(APP_LABEL)._dynamic_model_creation_unsafe():
             skip_object_fields = True
 
         branch_id = self._active_branch_id()

--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -1667,12 +1667,6 @@ class CustomObjectType(NetBoxModel):
         :return: The generated model.
         :rtype: Model
         """
-        # Avoid a dangling cross-COT FK reference when get_model() runs outside
-        # ready()'s two-pass resolution, e.g. a plugin importing it at migrate
-        # time (#637). Never cached (see below), so a later call regenerates in full.
-        if apps.get_app_config(APP_LABEL)._dynamic_model_creation_unsafe():
-            skip_object_fields = True
-
         branch_id = self._active_branch_id()
 
         # Lock guards the cache check, not the miss → re-cache window.  Two
@@ -1695,6 +1689,12 @@ class CustomObjectType(NetBoxModel):
                     # bumped cache_timestamp to branches via change-capture, so
                     # they'll re-evaluate against their own row independently.
                     self.clear_model_cache(self.id)
+
+        # Avoid a dangling cross-COT FK reference when get_model() runs outside
+        # ready()'s two-pass resolution, e.g. a plugin importing it at migrate
+        # time (#637). Never cached (see below), so a later call regenerates in full.
+        if apps.get_app_config(APP_LABEL)._dynamic_model_creation_unsafe():
+            skip_object_fields = True
 
         # Generate the model outside the lock to avoid holding it during expensive operations
         model_name = self.get_table_model_name(self.pk)

--- a/netbox_custom_objects/tests/test_models.py
+++ b/netbox_custom_objects/tests/test_models.py
@@ -1772,15 +1772,7 @@ class PluginConfigGetModelTestCase(CustomObjectsTestCase, TestCase):
             nco._migrations_checked = original_checked
 
     def test_dynamic_model_creation_unsafe_excludes_test(self):
-        """
-        _dynamic_model_creation_unsafe() -- the narrower check CustomObjectType.
-        get_model() uses -- must not treat 'test' in sys.argv as unsafe, so
-        ordinary test-suite runs (which always have 'test' in sys.argv) still
-        generate fully-hydrated models. should_skip_dynamic_model_creation()
-        itself must still treat 'test' as a skip reason, since ready()/
-        PluginConfig.get_model()/get_models() never need to run their
-        dynamic-model logic during a test process at all.
-        """
+        """_dynamic_model_creation_unsafe() must not treat 'test' in sys.argv as unsafe."""
         original_argv = sys.argv[:]
         original_checked = nco._migrations_checked
         try:
@@ -1799,26 +1791,12 @@ class PluginConfigGetModelTestCase(CustomObjectsTestCase, TestCase):
 
 
 class CrossCOTGetModelOutsideReadyTestCase(CustomObjectsTestCase, TestCase):
-    """
-    Regression tests for CustomObjectType.get_model() called directly (bypassing
-    ready()'s two-pass cross-COT FK resolution), reproducing issue #637: a
-    third-party plugin's module-level `CustomObjectType.objects.get(...).get_model()`
-    call fires during `manage.py migrate` (before ready()'s dynamic-model loop has
-    run, since _dynamic_model_creation_unsafe() short-circuits it). Only the
-    requested COT gets registered; a cross-COT Object-type field's LazyForeignKey
-    target is left as an unresolved string reference, which Django's system checks
-    flag as fields.E300/E307.
-
-    See: https://github.com/netboxlabs/netbox-custom-objects/issues/637
-    """
+    """Regression tests for CustomObjectType.get_model() bypassing ready()'s two-pass
+    cross-COT FK resolution (#637)."""
 
     def _make_cross_cot_pair(self, suffix):
-        """
-        Build a fresh target/source COT pair with a cross-COT Object field,
-        named uniquely per call so registry mutations in one test method (each
-        gets its own pair) can't bleed into another -- app registry state,
-        unlike DB rows, isn't rolled back between test methods.
-        """
+        """Build a fresh target/source COT pair, uniquely named so registry
+        mutations in one test method can't bleed into another."""
         target_type = CustomObjectType.objects.create(
             name=f"ForwarderProfile637{suffix}", slug=f"forwarder-profile-637-{suffix}",
         )
@@ -1848,11 +1826,8 @@ class CrossCOTGetModelOutsideReadyTestCase(CustomObjectsTestCase, TestCase):
             CustomObjectType.clear_model_cache(cot.id)
 
     def test_get_model_omits_cross_cot_field_when_unsafe(self):
-        """
-        get_model() must omit an unregistered cross-COT Object field (rather than
-        leaving a dangling LazyForeignKey) when _dynamic_model_creation_unsafe()
-        is True, and must not cache the resulting degraded model.
-        """
+        """Omits an unregistered cross-COT field rather than leaving a dangling
+        LazyForeignKey, and doesn't cache the degraded model."""
         target_type, source_type = self._make_cross_cot_pair("a")
         self._unregister(target_type, source_type)
         config = django_apps.get_app_config(APP_LABEL)
@@ -1865,11 +1840,7 @@ class CrossCOTGetModelOutsideReadyTestCase(CustomObjectsTestCase, TestCase):
         self.assertFalse(CustomObjectType.is_model_cached(source_type.id))
 
     def test_get_model_system_checks_pass_after_migrate_time_call(self):
-        """
-        Reproduces the exact reported symptom: Django's system checks must not
-        raise fields.E300/E307 for the cross-COT field after a get_model() call
-        made while _dynamic_model_creation_unsafe() is True.
-        """
+        """Reproduces the reported symptom: system checks must not raise E300/E307."""
         from django.core.checks.registry import registry as checks_registry
 
         target_type, source_type = self._make_cross_cot_pair("b")
@@ -1884,13 +1855,8 @@ class CrossCOTGetModelOutsideReadyTestCase(CustomObjectsTestCase, TestCase):
         self.assertEqual(relevant, [])
 
     def test_get_model_regenerates_in_full_on_next_normal_call(self):
-        """
-        Because the degraded model is never cached, a subsequent normal-context
-        get_model() call must fully re-resolve the cross-COT field once its target
-        is registered again -- mirroring a real restart, where a fresh worker
-        process's ready() registers every COT (via its own two-pass loop) rather
-        than the single COT this test's "migrate" call touched.
-        """
+        """Once the degraded model's target is registered again, a later call
+        fully re-resolves the cross-COT field."""
         target_type, source_type = self._make_cross_cot_pair("c")
         self._unregister(target_type, source_type)
         config = django_apps.get_app_config(APP_LABEL)
@@ -1904,13 +1870,7 @@ class CrossCOTGetModelOutsideReadyTestCase(CustomObjectsTestCase, TestCase):
         self.assertFalse(isinstance(field.remote_field.model, str))
 
     def test_get_model_unaffected_during_ordinary_test_run(self):
-        """
-        Sanity check that get_model()'s own narrower check (which excludes "test")
-        keeps ordinary test-suite get_model() calls fully hydrated -- 'test' is in
-        sys.argv for this entire process, so this would fail if get_model() used
-        should_skip_dynamic_model_creation() (which includes "test") instead of
-        _dynamic_model_creation_unsafe().
-        """
+        """Ordinary test-suite get_model() calls stay fully hydrated."""
         target_type, source_type = self._make_cross_cot_pair("d")
         model = source_type.get_model(no_cache=True)
         field = model._meta.get_field('forwarder_profile')

--- a/netbox_custom_objects/tests/test_models.py
+++ b/netbox_custom_objects/tests/test_models.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 from django.apps import apps as django_apps
 from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import ValidationError
+from django.core.exceptions import FieldDoesNotExist, ValidationError
 from django.db import connection, transaction
 from django.db.utils import OperationalError, ProgrammingError
 from django.test import TestCase, override_settings, tag
@@ -1835,7 +1835,7 @@ class CrossCOTGetModelOutsideReadyTestCase(CustomObjectsTestCase, TestCase):
         with patch.object(config.__class__, '_dynamic_model_creation_unsafe', return_value=True):
             model = source_type.get_model()
 
-        with self.assertRaises(Exception):
+        with self.assertRaises(FieldDoesNotExist):
             model._meta.get_field('forwarder_profile')
         self.assertFalse(CustomObjectType.is_model_cached(source_type.id))
 

--- a/netbox_custom_objects/tests/test_models.py
+++ b/netbox_custom_objects/tests/test_models.py
@@ -1771,6 +1771,150 @@ class PluginConfigGetModelTestCase(CustomObjectsTestCase, TestCase):
         finally:
             nco._migrations_checked = original_checked
 
+    def test_should_skip_excludes_test_when_requested(self):
+        """
+        include_test_skip=False must not treat 'test' in sys.argv as a skip
+        reason -- CustomObjectType.get_model() relies on this so that ordinary
+        test-suite runs (which always have 'test' in sys.argv) still generate
+        fully-hydrated models, while still catching a real migrate/makemigrations/
+        collectstatic run.  include_test_skip defaults to True for every other
+        caller (ready(), PluginConfig.get_model/get_models), which never need to
+        run during tests at all.
+        """
+        original_argv = sys.argv[:]
+        original_checked = nco._migrations_checked
+        try:
+            sys.argv = ['manage.py', 'test']
+            nco._migrations_checked = None
+            self.assertTrue(self.config.should_skip_dynamic_model_creation())
+            nco._migrations_checked = None
+            self.assertFalse(self.config.should_skip_dynamic_model_creation(include_test_skip=False))
+
+            sys.argv = ['manage.py', 'migrate']
+            nco._migrations_checked = None
+            self.assertTrue(self.config.should_skip_dynamic_model_creation(include_test_skip=False))
+        finally:
+            sys.argv = original_argv
+            nco._migrations_checked = original_checked
+
+
+class CrossCOTGetModelOutsideReadyTestCase(CustomObjectsTestCase, TestCase):
+    """
+    Regression tests for CustomObjectType.get_model() called directly (bypassing
+    ready()'s two-pass cross-COT FK resolution), reproducing issue #637: a
+    third-party plugin's module-level `CustomObjectType.objects.get(...).get_model()`
+    call fires during `manage.py migrate` (before ready()'s dynamic-model loop has
+    run, since should_skip_dynamic_model_creation() short-circuits it). Only the
+    requested COT gets registered; a cross-COT Object-type field's LazyForeignKey
+    target is left as an unresolved string reference, which Django's system checks
+    flag as fields.E300/E307.
+
+    See: https://github.com/netboxlabs/netbox-custom-objects/issues/637
+    """
+
+    def _make_cross_cot_pair(self, suffix):
+        """
+        Build a fresh target/source COT pair with a cross-COT Object field,
+        named uniquely per call so registry mutations in one test method (each
+        gets its own pair) can't bleed into another -- app registry state,
+        unlike DB rows, isn't rolled back between test methods.
+        """
+        target_type = CustomObjectType.objects.create(
+            name=f"ForwarderProfile637{suffix}", slug=f"forwarder-profile-637-{suffix}",
+        )
+        CustomObjectTypeField.objects.create(
+            custom_object_type=target_type, name="name", label="Name",
+            type="text", primary=True,
+        )
+        source_type = CustomObjectType.objects.create(
+            name=f"DnsZone637{suffix}", slug=f"dns-zone-637-{suffix}",
+        )
+        CustomObjectTypeField.objects.create(
+            custom_object_type=source_type, name="name", label="Name",
+            type="text", primary=True,
+        )
+        target_ct = ObjectType.objects.get_for_model(target_type.get_model())
+        CustomObjectTypeField.objects.create(
+            custom_object_type=source_type, name="forwarder_profile",
+            label="Forwarder Profile", type="object", related_object_type=target_ct,
+        )
+        return target_type, source_type
+
+    def _unregister(self, *cots):
+        """Simulate a fresh process where none of the given COT models are registered yet."""
+        for cot in cots:
+            model_name = cot.get_table_model_name(cot.id).lower()
+            django_apps.all_models.get(APP_LABEL, {}).pop(model_name, None)
+            CustomObjectType.clear_model_cache(cot.id)
+
+    def test_get_model_omits_cross_cot_field_when_should_skip(self):
+        """
+        get_model() must omit an unregistered cross-COT Object field (rather than
+        leaving a dangling LazyForeignKey) when should_skip_dynamic_model_creation()
+        is True, and must not cache the resulting degraded model.
+        """
+        target_type, source_type = self._make_cross_cot_pair("a")
+        self._unregister(target_type, source_type)
+        config = django_apps.get_app_config(APP_LABEL)
+
+        with patch.object(config.__class__, 'should_skip_dynamic_model_creation', return_value=True):
+            model = source_type.get_model()
+
+        with self.assertRaises(Exception):
+            model._meta.get_field('forwarder_profile')
+        self.assertFalse(CustomObjectType.is_model_cached(source_type.id))
+
+    def test_get_model_system_checks_pass_after_migrate_time_call(self):
+        """
+        Reproduces the exact reported symptom: Django's system checks must not
+        raise fields.E300/E307 for the cross-COT field after a get_model() call
+        made while should_skip_dynamic_model_creation() is True.
+        """
+        from django.core.checks.registry import registry as checks_registry
+
+        target_type, source_type = self._make_cross_cot_pair("b")
+        self._unregister(target_type, source_type)
+        config = django_apps.get_app_config(APP_LABEL)
+
+        with patch.object(config.__class__, 'should_skip_dynamic_model_creation', return_value=True):
+            source_type.get_model()
+
+        errors = checks_registry.run_checks()
+        relevant = [e for e in errors if 'forwarder_profile' in str(e)]
+        self.assertEqual(relevant, [])
+
+    def test_get_model_regenerates_in_full_on_next_normal_call(self):
+        """
+        Because the degraded model is never cached, a subsequent normal-context
+        get_model() call must fully re-resolve the cross-COT field once its target
+        is registered again -- mirroring a real restart, where a fresh worker
+        process's ready() registers every COT (via its own two-pass loop) rather
+        than the single COT this test's "migrate" call touched.
+        """
+        target_type, source_type = self._make_cross_cot_pair("c")
+        self._unregister(target_type, source_type)
+        config = django_apps.get_app_config(APP_LABEL)
+
+        with patch.object(config.__class__, 'should_skip_dynamic_model_creation', return_value=True):
+            source_type.get_model()
+
+        target_type.get_model()  # simulates ready()'s Pass 1 registering every COT
+        full_model = source_type.get_model()
+        field = full_model._meta.get_field('forwarder_profile')
+        self.assertFalse(isinstance(field.remote_field.model, str))
+
+    def test_get_model_unaffected_during_ordinary_test_run(self):
+        """
+        Sanity check that the fix's own guard (include_test_skip=False) keeps
+        ordinary test-suite get_model() calls fully hydrated -- 'test' is in
+        sys.argv for this entire process, so this would fail if get_model() used
+        the default include_test_skip=True.
+        """
+        target_type, source_type = self._make_cross_cot_pair("d")
+        model = source_type.get_model(no_cache=True)
+        field = model._meta.get_field('forwarder_profile')
+        self.assertFalse(isinstance(field.remote_field.model, str))
+
 
 class CrossCOTStubSearchIndexRegressionTestCase(CustomObjectsTestCase, TestCase):
     """Regression tests for the search-index crash on stub models.

--- a/netbox_custom_objects/tests/test_models.py
+++ b/netbox_custom_objects/tests/test_models.py
@@ -1771,15 +1771,15 @@ class PluginConfigGetModelTestCase(CustomObjectsTestCase, TestCase):
         finally:
             nco._migrations_checked = original_checked
 
-    def test_should_skip_excludes_test_when_requested(self):
+    def test_dynamic_model_creation_unsafe_excludes_test(self):
         """
-        include_test_skip=False must not treat 'test' in sys.argv as a skip
-        reason -- CustomObjectType.get_model() relies on this so that ordinary
-        test-suite runs (which always have 'test' in sys.argv) still generate
-        fully-hydrated models, while still catching a real migrate/makemigrations/
-        collectstatic run.  include_test_skip defaults to True for every other
-        caller (ready(), PluginConfig.get_model/get_models), which never need to
-        run during tests at all.
+        _dynamic_model_creation_unsafe() -- the narrower check CustomObjectType.
+        get_model() uses -- must not treat 'test' in sys.argv as unsafe, so
+        ordinary test-suite runs (which always have 'test' in sys.argv) still
+        generate fully-hydrated models. should_skip_dynamic_model_creation()
+        itself must still treat 'test' as a skip reason, since ready()/
+        PluginConfig.get_model()/get_models() never need to run their
+        dynamic-model logic during a test process at all.
         """
         original_argv = sys.argv[:]
         original_checked = nco._migrations_checked
@@ -1788,11 +1788,11 @@ class PluginConfigGetModelTestCase(CustomObjectsTestCase, TestCase):
             nco._migrations_checked = None
             self.assertTrue(self.config.should_skip_dynamic_model_creation())
             nco._migrations_checked = None
-            self.assertFalse(self.config.should_skip_dynamic_model_creation(include_test_skip=False))
+            self.assertFalse(self.config._dynamic_model_creation_unsafe())
 
             sys.argv = ['manage.py', 'migrate']
             nco._migrations_checked = None
-            self.assertTrue(self.config.should_skip_dynamic_model_creation(include_test_skip=False))
+            self.assertTrue(self.config._dynamic_model_creation_unsafe())
         finally:
             sys.argv = original_argv
             nco._migrations_checked = original_checked
@@ -1804,7 +1804,7 @@ class CrossCOTGetModelOutsideReadyTestCase(CustomObjectsTestCase, TestCase):
     ready()'s two-pass cross-COT FK resolution), reproducing issue #637: a
     third-party plugin's module-level `CustomObjectType.objects.get(...).get_model()`
     call fires during `manage.py migrate` (before ready()'s dynamic-model loop has
-    run, since should_skip_dynamic_model_creation() short-circuits it). Only the
+    run, since _dynamic_model_creation_unsafe() short-circuits it). Only the
     requested COT gets registered; a cross-COT Object-type field's LazyForeignKey
     target is left as an unresolved string reference, which Django's system checks
     flag as fields.E300/E307.
@@ -1847,17 +1847,17 @@ class CrossCOTGetModelOutsideReadyTestCase(CustomObjectsTestCase, TestCase):
             django_apps.all_models.get(APP_LABEL, {}).pop(model_name, None)
             CustomObjectType.clear_model_cache(cot.id)
 
-    def test_get_model_omits_cross_cot_field_when_should_skip(self):
+    def test_get_model_omits_cross_cot_field_when_unsafe(self):
         """
         get_model() must omit an unregistered cross-COT Object field (rather than
-        leaving a dangling LazyForeignKey) when should_skip_dynamic_model_creation()
+        leaving a dangling LazyForeignKey) when _dynamic_model_creation_unsafe()
         is True, and must not cache the resulting degraded model.
         """
         target_type, source_type = self._make_cross_cot_pair("a")
         self._unregister(target_type, source_type)
         config = django_apps.get_app_config(APP_LABEL)
 
-        with patch.object(config.__class__, 'should_skip_dynamic_model_creation', return_value=True):
+        with patch.object(config.__class__, '_dynamic_model_creation_unsafe', return_value=True):
             model = source_type.get_model()
 
         with self.assertRaises(Exception):
@@ -1868,7 +1868,7 @@ class CrossCOTGetModelOutsideReadyTestCase(CustomObjectsTestCase, TestCase):
         """
         Reproduces the exact reported symptom: Django's system checks must not
         raise fields.E300/E307 for the cross-COT field after a get_model() call
-        made while should_skip_dynamic_model_creation() is True.
+        made while _dynamic_model_creation_unsafe() is True.
         """
         from django.core.checks.registry import registry as checks_registry
 
@@ -1876,7 +1876,7 @@ class CrossCOTGetModelOutsideReadyTestCase(CustomObjectsTestCase, TestCase):
         self._unregister(target_type, source_type)
         config = django_apps.get_app_config(APP_LABEL)
 
-        with patch.object(config.__class__, 'should_skip_dynamic_model_creation', return_value=True):
+        with patch.object(config.__class__, '_dynamic_model_creation_unsafe', return_value=True):
             source_type.get_model()
 
         errors = checks_registry.run_checks()
@@ -1895,7 +1895,7 @@ class CrossCOTGetModelOutsideReadyTestCase(CustomObjectsTestCase, TestCase):
         self._unregister(target_type, source_type)
         config = django_apps.get_app_config(APP_LABEL)
 
-        with patch.object(config.__class__, 'should_skip_dynamic_model_creation', return_value=True):
+        with patch.object(config.__class__, '_dynamic_model_creation_unsafe', return_value=True):
             source_type.get_model()
 
         target_type.get_model()  # simulates ready()'s Pass 1 registering every COT
@@ -1905,10 +1905,11 @@ class CrossCOTGetModelOutsideReadyTestCase(CustomObjectsTestCase, TestCase):
 
     def test_get_model_unaffected_during_ordinary_test_run(self):
         """
-        Sanity check that the fix's own guard (include_test_skip=False) keeps
-        ordinary test-suite get_model() calls fully hydrated -- 'test' is in
+        Sanity check that get_model()'s own narrower check (which excludes "test")
+        keeps ordinary test-suite get_model() calls fully hydrated -- 'test' is in
         sys.argv for this entire process, so this would fail if get_model() used
-        the default include_test_skip=True.
+        should_skip_dynamic_model_creation() (which includes "test") instead of
+        _dynamic_model_creation_unsafe().
         """
         target_type, source_type = self._make_cross_cot_pair("d")
         model = source_type.get_model(no_cache=True)

--- a/netbox_custom_objects/tests/test_models.py
+++ b/netbox_custom_objects/tests/test_models.py
@@ -1876,6 +1876,102 @@ class CrossCOTGetModelOutsideReadyTestCase(CustomObjectsTestCase, TestCase):
         field = model._meta.get_field('forwarder_profile')
         self.assertFalse(isinstance(field.remote_field.model, str))
 
+    def test_get_model_keeps_core_model_field_when_unsafe(self):
+        """A field targeting a core NetBox model (not another COT) can't dangle
+        the way a cross-COT LazyForeignKey can, so it must not be dropped during
+        the unsafe window (review of #664)."""
+        source_type = CustomObjectType.objects.create(
+            name="DnsZone637e", slug="dns-zone-637-e",
+        )
+        CustomObjectTypeField.objects.create(
+            custom_object_type=source_type, name="name", label="Name",
+            type="text", primary=True,
+        )
+        CustomObjectTypeField.objects.create(
+            custom_object_type=source_type, name="device", label="Device",
+            type="object", related_object_type=self.get_device_object_type(),
+        )
+        self._unregister(source_type)
+        config = django_apps.get_app_config(APP_LABEL)
+
+        with patch.object(config.__class__, '_dynamic_model_creation_unsafe', return_value=True):
+            model = source_type.get_model()
+
+        field = model._meta.get_field('device')
+        self.assertFalse(isinstance(field.remote_field.model, str))
+
+    def test_get_model_keeps_polymorphic_field_when_unsafe(self):
+        """A polymorphic Object field uses a GFK, which needs no app-registry
+        resolution, so it must not be dropped during the unsafe window either."""
+        source_type = CustomObjectType.objects.create(
+            name="DnsZone637f", slug="dns-zone-637-f",
+        )
+        CustomObjectTypeField.objects.create(
+            custom_object_type=source_type, name="name", label="Name",
+            type="text", primary=True,
+        )
+        CustomObjectTypeField.objects.create(
+            custom_object_type=source_type, name="owner", label="Owner",
+            type="object", is_polymorphic=True,
+        )
+        self._unregister(source_type)
+        config = django_apps.get_app_config(APP_LABEL)
+
+        with patch.object(config.__class__, '_dynamic_model_creation_unsafe', return_value=True):
+            model = source_type.get_model()
+
+        # A GFK field is a virtual field, not a concrete one — get_field() still
+        # finds it, but the important thing is that it's present at all.
+        self.assertIsNotNone(model._meta.get_field('owner'))
+
+
+class TargetsCustomObjectTypeTestCase(CustomObjectsTestCase, TestCase):
+    """Unit tests for CustomObjectTypeField.targets_custom_object_type (#664 review)."""
+
+    def test_true_for_field_targeting_another_cot(self):
+        target_type = self.create_custom_object_type(name="TargetsCOTTarget", slug="targets-cot-target")
+        source_type = self.create_custom_object_type(name="TargetsCOTSource", slug="targets-cot-source")
+        target_ct = ObjectType.objects.get_for_model(target_type.get_model())
+        field = self.create_custom_object_type_field(
+            source_type, name="ref", type="object", related_object_type=target_ct,
+        )
+        self.assertTrue(field.targets_custom_object_type)
+
+    def test_false_for_field_targeting_core_model(self):
+        source_type = self.create_custom_object_type(name="TargetsCoreSource", slug="targets-core-source")
+        field = self.create_custom_object_type_field(
+            source_type, name="device", type="object",
+            related_object_type=self.get_device_object_type(),
+        )
+        self.assertFalse(field.targets_custom_object_type)
+
+    def test_false_for_polymorphic_field(self):
+        source_type = self.create_custom_object_type(name="TargetsPolySource", slug="targets-poly-source")
+        field = self.create_custom_object_type_field(
+            source_type, name="owner", type="object", is_polymorphic=True,
+        )
+        self.assertFalse(field.targets_custom_object_type)
+
+    def test_false_for_field_targeting_custom_object_type_model_itself(self):
+        # netbox_custom_objects.customobjecttype shares APP_LABEL with dynamic
+        # COT models but isn't one -- extract_cot_id_from_model_name() must
+        # return None for it, not raise. Building this in memory rather than
+        # saving: a real save() rejects this related_object_type outright, since
+        # CustomObjectType itself isn't a "table<id>model" dynamic model, but the
+        # property's own guard against it is worth testing directly.
+        source_type = self.create_custom_object_type(name="TargetsCOTModelSource", slug="targets-cot-model-source")
+        cot_ct = ObjectType.objects.get_for_model(CustomObjectType)
+        field = CustomObjectTypeField(
+            custom_object_type=source_type, name="cot_ref", type="object",
+            related_object_type=cot_ct,
+        )
+        self.assertFalse(field.targets_custom_object_type)
+
+    def test_false_for_no_related_object_type(self):
+        source_type = self.create_custom_object_type(name="TargetsNoneSource", slug="targets-none-source")
+        field = self.create_custom_object_type_field(source_type, name="label", type="text")
+        self.assertFalse(field.targets_custom_object_type)
+
 
 class CrossCOTStubSearchIndexRegressionTestCase(CustomObjectsTestCase, TestCase):
     """Regression tests for the search-index crash on stub models.


### PR DESCRIPTION
### Closes: #637

## Summary

A COT with a cross-COT Object-type field, when `.get_model()` is called directly on the model instance (the pattern shown in `docs/index.md` -- a module-level `CustomObjectType.objects.get(...).get_model()`) while it's unsafe to touch the DB (e.g. during `manage.py migrate`), left the field's `LazyForeignKey` target unresolved. Django's system checks then raised `fields.E300`/`fields.E307` for that field, aborting the upgrade.

Root cause: every other dynamic-model entry point (`ready()`, `PluginConfig.get_model()`/`get_models()`) already guards against generating COT models before migrations have completed. `CustomObjectType.get_model()` -- the one method third-party plugins call directly -- didn't check this at all, so it could register a COT model outside of `ready()`'s two-pass cross-COT FK resolution, leaving a dangling reference that nothing else ever re-resolves during that `migrate` process.

## Changes

- `CustomObjectType.get_model()` now checks a new `_dynamic_model_creation_unsafe()` predicate and forces `skip_object_fields=True` when it's set, omitting the cross-COT field entirely rather than leaving a dangling lazy reference. The resulting degraded model is never cached (existing behavior for `skip_object_fields=True`), so a real request after startup regenerates it in full via `ready()`'s normal two-pass path in the actual (separate) worker process.
- `_dynamic_model_creation_unsafe()` is the actual DB-readiness check (mid-migration, `migrate`/`makemigrations`/`collectstatic`, or this app's own migrations incomplete) -- deliberately excluding `"test"`, since `get_model()` is the method tests use directly and the test database is always fully migrated by the time a test body runs.
- `should_skip_dynamic_model_creation()` -- used by `ready()`, `PluginConfig.get_model()`/`get_models()`, and `navigation` -- keeps its existing public signature and behavior, now expressed as `_dynamic_model_creation_unsafe()` OR `"test"` in `sys.argv`.

## Testing

- New `CrossCOTGetModelOutsideReadyTestCase` in `test_models.py`:
  - `test_get_model_omits_cross_cot_field_when_unsafe` -- the field is omitted, and the degraded model isn't cached.
  - `test_get_model_system_checks_pass_after_migrate_time_call` -- reproduces the exact `fields.E300`/`E307` symptom and confirms it's gone.
  - `test_get_model_regenerates_in_full_on_next_normal_call` -- once the target COT is registered again (mirroring a real restart's `ready()` pass), a subsequent call fully resolves the field.
  - `test_get_model_unaffected_during_ordinary_test_run` -- ordinary test-suite `get_model()` calls stay fully hydrated.
- New `test_dynamic_model_creation_unsafe_excludes_test` in `PluginConfigGetModelTestCase`.
- Verified locally against netbox-community/netbox `main` (Django 6.0.7) and `feature` (Django 6.1), plus the broader `test_models`/`test_api`/`test_filtersets`/`test_polymorphic_fields`/`test_field_types`/`test_views` suites.
