### PR TITLE
Fixes #629: Delete stale model registration before regenerating, not after

### DIFF
--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -1738,19 +1738,10 @@ class CustomObjectType(NetBoxModel):
 
         # Delete any stale registration for this model name *before* generating
         # the replacement class, not after (issue #629). TagsMixin's 'tags' field
-        # resolves its 'through' model lazily: contribute_to_class() (which runs
-        # mid-construction, while Django's ModelBase.__new__() is still adding
-        # fields to the new class) calls lazy_related_operation(), which treats
-        # the OWNING class itself as a dependency, satisfied by looking it up in
-        # apps.all_models under this exact model name. If the *old* class was
-        # still registered under that name at that point, the lookup resolves
-        # immediately against the stale class instead of deferring — so the new
-        # field's post_through_setup() runs with cls=<old, about-to-be-replaced
-        # class>, and the new class's own 'tags' field never gets its
-        # tagged_items GenericRelation set up. Without that GenericRelation,
-        # Django's deletion collector has no way to cascade-delete a custom
-        # object's TaggedItem rows, leaving orphaned ("phantom") tagged items
-        # behind whenever a custom object is deleted.
+        # resolves its 'through' model lazily against whatever's registered under
+        # this model name at contribute_to_class() time; leaving the old class
+        # registered there let the new field's setup bind to the old class
+        # instead of itself, silently breaking tag cascade-delete.
         if branch_id is None:
             model_key = model_name.lower()
             with _suppress_clear_cache():
@@ -1796,11 +1787,8 @@ class CustomObjectType(NetBoxModel):
             # would return a class with the wrong column set across contexts.
             model_key = model_name.lower()
             if branch_id is None:
-                # generate_model()'s own type() call already registered this class
-                # under model_key (the pre-deletion above ensured nothing else held
-                # that slot). This call is a safety net for the (unexpected) case
-                # where it didn't -- skip it when redundant to avoid a spurious
-                # "already registered" RuntimeWarning.
+                # generate_model() already registered this class; skip the
+                # redundant call to avoid a spurious "already registered" warning.
                 if apps.all_models[APP_LABEL].get(model_key) is not model:
                     apps.register_model(APP_LABEL, model)
             else:

--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -1736,6 +1736,27 @@ class CustomObjectType(NetBoxModel):
         # Wrap the existing post_through_setup method to handle ValueError exceptions
         from taggit.managers import TaggableManager as TM
 
+        # Delete any stale registration for this model name *before* generating
+        # the replacement class, not after (issue #629). TagsMixin's 'tags' field
+        # resolves its 'through' model lazily: contribute_to_class() (which runs
+        # mid-construction, while Django's ModelBase.__new__() is still adding
+        # fields to the new class) calls lazy_related_operation(), which treats
+        # the OWNING class itself as a dependency, satisfied by looking it up in
+        # apps.all_models under this exact model name. If the *old* class was
+        # still registered under that name at that point, the lookup resolves
+        # immediately against the stale class instead of deferring — so the new
+        # field's post_through_setup() runs with cls=<old, about-to-be-replaced
+        # class>, and the new class's own 'tags' field never gets its
+        # tagged_items GenericRelation set up. Without that GenericRelation,
+        # Django's deletion collector has no way to cascade-delete a custom
+        # object's TaggedItem rows, leaving orphaned ("phantom") tagged items
+        # behind whenever a custom object is deleted.
+        if branch_id is None:
+            model_key = model_name.lower()
+            with _suppress_clear_cache():
+                if model_key in apps.all_models[APP_LABEL]:
+                    del apps.all_models[APP_LABEL][model_key]
+
         # TM.post_through_setup is class-level state; serialize concurrent
         # generations so save/restore can't interleave across threads.
         with _taggable_manager_patch_lock:
@@ -1775,9 +1796,13 @@ class CustomObjectType(NetBoxModel):
             # would return a class with the wrong column set across contexts.
             model_key = model_name.lower()
             if branch_id is None:
-                if model_key in apps.all_models[APP_LABEL]:
-                    del apps.all_models[APP_LABEL][model_key]
-                apps.register_model(APP_LABEL, model)
+                # generate_model()'s own type() call already registered this class
+                # under model_key (the pre-deletion above ensured nothing else held
+                # that slot). This call is a safety net for the (unexpected) case
+                # where it didn't -- skip it when redundant to avoid a spurious
+                # "already registered" RuntimeWarning.
+                if apps.all_models[APP_LABEL].get(model_key) is not model:
+                    apps.register_model(APP_LABEL, model)
             else:
                 main_class = self.get_cached_model(self.id, branch_id=None)
                 if main_class is not None:

--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -1673,7 +1673,10 @@ class CustomObjectType(NetBoxModel):
         # Lock guards the cache check, not the miss → re-cache window.  Two
         # threads can regenerate the same (cot_id, branch_id) in parallel;
         # both produce equivalent classes, so the duplication is wasteful but
-        # not incorrect.  Worth it to avoid serialising all generation.
+        # not incorrect.  Worth it to avoid serialising all generation.  This
+        # window also means a concurrent, unrelated apps.get_model() call can
+        # transiently see this model name as unregistered while a regeneration
+        # is in progress (see the pre-deletion below, issue #629).
         with self._global_lock:
             if self.is_model_cached(self.id, branch_id) and not no_cache:
                 cached_timestamp = self.get_cached_timestamp(self.id, branch_id)
@@ -1742,11 +1745,9 @@ class CustomObjectType(NetBoxModel):
         # this model name at contribute_to_class() time; leaving the old class
         # registered there let the new field's setup bind to the old class
         # instead of itself, silently breaking tag cascade-delete.
-        if branch_id is None:
-            model_key = model_name.lower()
-            with _suppress_clear_cache():
-                if model_key in apps.all_models[APP_LABEL]:
-                    del apps.all_models[APP_LABEL][model_key]
+        model_key = model_name.lower()
+        if branch_id is None and model_key in apps.all_models[APP_LABEL]:
+            del apps.all_models[APP_LABEL][model_key]
 
         # TM.post_through_setup is class-level state; serialize concurrent
         # generations so save/restore can't interleave across threads.
@@ -1785,7 +1786,6 @@ class CustomObjectType(NetBoxModel):
             # Main's class is the canonical registration in apps.all_models;
             # branch's class is cached only.  Without this, content_type.model_class()
             # would return a class with the wrong column set across contexts.
-            model_key = model_name.lower()
             if branch_id is None:
                 # generate_model() already registered this class; skip the
                 # redundant call to avoid a spurious "already registered" warning.

--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -1673,10 +1673,7 @@ class CustomObjectType(NetBoxModel):
         # Lock guards the cache check, not the miss → re-cache window.  Two
         # threads can regenerate the same (cot_id, branch_id) in parallel;
         # both produce equivalent classes, so the duplication is wasteful but
-        # not incorrect.  Worth it to avoid serialising all generation.  This
-        # window also means a concurrent, unrelated apps.get_model() call can
-        # transiently see this model name as unregistered while a regeneration
-        # is in progress (see the pre-deletion below, issue #629).
+        # not incorrect.  Worth it to avoid serialising all generation.
         with self._global_lock:
             if self.is_model_cached(self.id, branch_id) and not no_cache:
                 cached_timestamp = self.get_cached_timestamp(self.id, branch_id)
@@ -1739,24 +1736,25 @@ class CustomObjectType(NetBoxModel):
         # Wrap the existing post_through_setup method to handle ValueError exceptions
         from taggit.managers import TaggableManager as TM
 
-        # Delete any stale registration for this model name *before* generating
-        # the replacement class, not after (issue #629). TagsMixin's 'tags' field
-        # resolves its 'through' model lazily against whatever's registered under
-        # this model name at contribute_to_class() time; leaving the old class
-        # registered there let the new field's setup bind to the old class
-        # instead of itself, silently breaking tag cascade-delete.
-        model_key = model_name.lower()
-        if branch_id is None and model_key in apps.all_models[APP_LABEL]:
-            del apps.all_models[APP_LABEL][model_key]
-
         # TM.post_through_setup is class-level state; serialize concurrent
         # generations so save/restore can't interleave across threads.
         with _taggable_manager_patch_lock:
             original_post_through_setup = TM.post_through_setup
 
-            def wrapped_post_through_setup(self, cls):
+            def wrapped_post_through_setup(manager, _resolved_model):
+                # contribute_to_class() sets manager.model to the actual class
+                # under construction *before* scheduling this call via
+                # lazy_related_operation(); _resolved_model instead comes from
+                # re-resolving the model by name through the app registry at
+                # call time. If a prior generation for the same COT is still
+                # registered under this model name when this fires, that
+                # lookup resolves immediately against the stale class instead
+                # of the one actually being built, so the new 'tags' field
+                # never gets its own tagged_items GenericRelation -- silently
+                # breaking tag cascade-delete (issue #629). manager.model is
+                # never subject to that staleness, so use it instead.
                 try:
-                    return original_post_through_setup(self, cls)
+                    return original_post_through_setup(manager, manager.model)
                 except ValueError:
                     pass
 
@@ -1786,11 +1784,11 @@ class CustomObjectType(NetBoxModel):
             # Main's class is the canonical registration in apps.all_models;
             # branch's class is cached only.  Without this, content_type.model_class()
             # would return a class with the wrong column set across contexts.
+            model_key = model_name.lower()
             if branch_id is None:
-                # generate_model() already registered this class; skip the
-                # redundant call to avoid a spurious "already registered" warning.
-                if apps.all_models[APP_LABEL].get(model_key) is not model:
-                    apps.register_model(APP_LABEL, model)
+                if model_key in apps.all_models[APP_LABEL]:
+                    del apps.all_models[APP_LABEL][model_key]
+                apps.register_model(APP_LABEL, model)
             else:
                 main_class = self.get_cached_model(self.id, branch_id=None)
                 if main_class is not None:

--- a/netbox_custom_objects/tests/test_models.py
+++ b/netbox_custom_objects/tests/test_models.py
@@ -2652,24 +2652,8 @@ class DisplayExpressionFormValidationTestCase(CustomObjectsTestCase, TestCase):
 
 
 class PhantomTaggedObjectsTestCase(CustomObjectsTestCase, TestCase):
-    """Regression tests for issue #629 (Phantom Tagged Objects).
-
-    CustomObjectType.get_model() deletes the old apps.all_models entry for a
-    COT's dynamic model *after* generating its replacement (generate_model()
-    runs first, then the stale entry is deleted and the new class registered).
-    TagsMixin's 'tags' field resolves its 'through' model lazily: taggit's
-    contribute_to_class() runs mid-construction (before the new class itself
-    is registered) and treats the *owning class* as a lazy dependency,
-    resolved by looking it up in apps.all_models under this model's name. With
-    the old class still registered under that name at that point, the lookup
-    resolved immediately against the stale, about-to-be-replaced class instead
-    of deferring -- so the new class's own 'tags' field never got its
-    tagged_items GenericRelation set up, and Django's deletion collector had
-    no way to cascade-delete a custom object's TaggedItem rows. Deleting a
-    tagged custom object therefore left its TaggedItem rows behind: the tag
-    page reported a nonzero item count, but filtering by that tag returned no
-    results, since the referenced object no longer existed.
-    """
+    """Regression tests for issue #629 (Phantom Tagged Objects): deleting a
+    tagged custom object left its TaggedItem row behind."""
 
     def setUp(self):
         super().setUp()
@@ -2684,9 +2668,6 @@ class PhantomTaggedObjectsTestCase(CustomObjectsTestCase, TestCase):
         return TaggedItem.objects.filter(tag=self.tag, content_type=ct).count()
 
     def test_generated_model_has_tagged_items_generic_relation(self):
-        """The root cause: the generated model's 'tags' field must complete its
-        setup, giving the class a 'tagged_items' GenericRelation the deletion
-        collector can use to cascade-delete TaggedItem rows."""
         model = self.cot.get_model()
         private_field_names = [f.name for f in model._meta.private_fields]
         self.assertIn('tagged_items', private_field_names)
@@ -2712,9 +2693,6 @@ class PhantomTaggedObjectsTestCase(CustomObjectsTestCase, TestCase):
         self.assertEqual(self._tagged_item_count(), 0)
 
     def test_delete_after_model_regeneration_removes_tagged_item(self):
-        """Deleting through a freshly regenerated class (a fresh Python class
-        for the same COT, as happens whenever the cache is invalidated) must
-        still clean up the tag -- the fix isn't specific to one class instance."""
         model = self.cot.get_model()
         obj = model.objects.create(name="profile-c")
         obj.tags.set([self.tag])
@@ -2727,8 +2705,6 @@ class PhantomTaggedObjectsTestCase(CustomObjectsTestCase, TestCase):
         self.assertEqual(self._tagged_item_count(), 0)
 
     def test_filtering_by_tag_matches_actual_object_count(self):
-        """The user-visible symptom: after deleting a tagged object, filtering
-        by that tag must not still count/return the deleted object."""
         model = self.cot.get_model()
         kept = model.objects.create(name="profile-kept")
         kept.tags.set([self.tag])

--- a/netbox_custom_objects/tests/test_models.py
+++ b/netbox_custom_objects/tests/test_models.py
@@ -20,7 +20,7 @@ import netbox_custom_objects as nco
 from core.choices import JobStatusChoices
 from core.models import ObjectType
 from dcim.models import Site
-from extras.models import CachedValue
+from extras.models import CachedValue, Tag, TaggedItem
 from netbox.search import registry
 from netbox.search.backends import get_backend
 from netbox_custom_objects.api.serializers import get_serializer_class
@@ -2649,3 +2649,92 @@ class DisplayExpressionFormValidationTestCase(CustomObjectsTestCase, TestCase):
         form = self._form('{% if make %}{{ make }}')  # missing {% endif %}
         form.is_valid()
         self.assertIn('display_expression', form.errors)
+
+
+class PhantomTaggedObjectsTestCase(CustomObjectsTestCase, TestCase):
+    """Regression tests for issue #629 (Phantom Tagged Objects).
+
+    CustomObjectType.get_model() deletes the old apps.all_models entry for a
+    COT's dynamic model *after* generating its replacement (generate_model()
+    runs first, then the stale entry is deleted and the new class registered).
+    TagsMixin's 'tags' field resolves its 'through' model lazily: taggit's
+    contribute_to_class() runs mid-construction (before the new class itself
+    is registered) and treats the *owning class* as a lazy dependency,
+    resolved by looking it up in apps.all_models under this model's name. With
+    the old class still registered under that name at that point, the lookup
+    resolved immediately against the stale, about-to-be-replaced class instead
+    of deferring -- so the new class's own 'tags' field never got its
+    tagged_items GenericRelation set up, and Django's deletion collector had
+    no way to cascade-delete a custom object's TaggedItem rows. Deleting a
+    tagged custom object therefore left its TaggedItem rows behind: the tag
+    page reported a nonzero item count, but filtering by that tag returned no
+    results, since the referenced object no longer existed.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.cot = self.create_custom_object_type(name="SslProfile", slug="ssl-profiles")
+        self.create_custom_object_type_field(
+            self.cot, name="name", label="Name", type="text", primary=True, required=True,
+        )
+        self.tag = Tag.objects.create(name="unbound", slug="unbound")
+
+    def _tagged_item_count(self):
+        ct = ContentType.objects.get_for_model(self.cot.get_model())
+        return TaggedItem.objects.filter(tag=self.tag, content_type=ct).count()
+
+    def test_generated_model_has_tagged_items_generic_relation(self):
+        """The root cause: the generated model's 'tags' field must complete its
+        setup, giving the class a 'tagged_items' GenericRelation the deletion
+        collector can use to cascade-delete TaggedItem rows."""
+        model = self.cot.get_model()
+        private_field_names = [f.name for f in model._meta.private_fields]
+        self.assertIn('tagged_items', private_field_names)
+
+    def test_direct_delete_removes_tagged_item(self):
+        model = self.cot.get_model()
+        obj = model.objects.create(name="profile-a")
+        obj.tags.set([self.tag])
+        self.assertEqual(self._tagged_item_count(), 1)
+
+        obj.delete()
+
+        self.assertEqual(self._tagged_item_count(), 0)
+
+    def test_queryset_bulk_delete_removes_tagged_item(self):
+        model = self.cot.get_model()
+        obj = model.objects.create(name="profile-b")
+        obj.tags.set([self.tag])
+        self.assertEqual(self._tagged_item_count(), 1)
+
+        model.objects.filter(pk=obj.pk).delete()
+
+        self.assertEqual(self._tagged_item_count(), 0)
+
+    def test_delete_after_model_regeneration_removes_tagged_item(self):
+        """Deleting through a freshly regenerated class (a fresh Python class
+        for the same COT, as happens whenever the cache is invalidated) must
+        still clean up the tag -- the fix isn't specific to one class instance."""
+        model = self.cot.get_model()
+        obj = model.objects.create(name="profile-c")
+        obj.tags.set([self.tag])
+        self.assertEqual(self._tagged_item_count(), 1)
+
+        fresh_model = self.cot.get_model(no_cache=True)
+        self.assertIsNot(fresh_model, model)
+        fresh_model.objects.get(pk=obj.pk).delete()
+
+        self.assertEqual(self._tagged_item_count(), 0)
+
+    def test_filtering_by_tag_matches_actual_object_count(self):
+        """The user-visible symptom: after deleting a tagged object, filtering
+        by that tag must not still count/return the deleted object."""
+        model = self.cot.get_model()
+        kept = model.objects.create(name="profile-kept")
+        kept.tags.set([self.tag])
+        deleted = model.objects.create(name="profile-deleted")
+        deleted.tags.set([self.tag])
+        deleted.delete()
+
+        self.assertEqual(model.objects.filter(tags=self.tag).count(), 1)
+        self.assertEqual(self._tagged_item_count(), 1)


### PR DESCRIPTION
### Closes: #629

## Summary

Reproduces and fixes #629 (Phantom Tagged Objects): deleting a tagged custom object left its `TaggedItem` row behind. The tag's detail page reported a nonzero item count, but filtering by that tag returned zero results, since the referenced object no longer existed.

## Root cause

`CustomObjectType.get_model()` deleted the old `apps.all_models` registry entry for a COT's dynamic model *after* `generate_model()` had already built the replacement class, not before.

`TagsMixin`'s `tags` field resolves its `through` model lazily: taggit's `contribute_to_class()` runs mid-construction, while Django's `ModelBase.__new__()` is still adding fields to the new class — well before the new class itself gets registered. It calls `lazy_related_operation()`, which treats the *owning class* as a dependency, resolved by looking it up in `apps.all_models` under the model's name (not the literal class object passed in). Since the *old* class was still registered under that name at that exact moment, the lookup resolved immediately against the stale, about-to-be-replaced class instead of deferring — so the new class's own `tags` field's `post_through_setup()` never ran against itself, and it never got a `tagged_items` `GenericRelation`. Without that `GenericRelation`, Django's deletion collector has no way to cascade-delete a custom object's `TaggedItem` rows on delete — regardless of whether the object is deleted via a single instance's `.delete()`, a bulk `queryset.delete()`, or a freshly-regenerated class.

## Fix

Delete the stale registry entry *before* calling `generate_model()` instead of after, so `generate_model()`'s own `type()` call is what correctly registers (and satisfies the lazy dependency for) the new class. The now-redundant explicit `apps.register_model()` call afterward is guarded to skip re-registering when `generate_model()` already did so, avoiding a spurious "already registered" `RuntimeWarning`.

## Testing

New `PhantomTaggedObjectsTestCase` in `test_models.py`:
- `test_generated_model_has_tagged_items_generic_relation` — the root cause: the generated model must actually have a `tagged_items` `GenericRelation`.
- `test_direct_delete_removes_tagged_item` / `test_queryset_bulk_delete_removes_tagged_item` / `test_delete_after_model_regeneration_removes_tagged_item` — all three deletion paths must clean up the `TaggedItem` row.
- `test_filtering_by_tag_matches_actual_object_count` — the user-visible symptom: filtering by tag after deleting a tagged object must return the correct count.

All 5 fail without the fix (reproducing the exact reported symptom) and pass with it.

Full suite verified in a clean venv (fresh install, no stray environment state): 1154 tests, 0 failures/errors, 8 skipped.
