### PR TITLE
Fixes #678: Fall back to generic/object.html for models without a detail template

### DIFF
--- a/netbox_custom_objects/related_tabs/views/combined.py
+++ b/netbox_custom_objects/related_tabs/views/combined.py
@@ -20,7 +20,7 @@ from netbox_custom_objects.models import CustomObjectTypeField
 from netbox_custom_objects.utilities import restrict_to_viewable
 from utilities.htmx import htmx_partial
 from utilities.paginator import EnhancedPaginator, get_paginate_count
-from utilities.views import ConditionalLoginRequiredMixin, ViewTab, register_model_view
+from utilities.views import ConditionalLoginRequiredMixin, ViewTab, get_default_template, register_model_view
 
 logger = logging.getLogger('netbox_custom_objects.related_tabs')
 
@@ -37,7 +37,7 @@ def _get_base_template(instance):
     """Return the correct base_template for an object's detail page."""
     if instance._meta.app_label == _CUSTOM_OBJECTS_APP:
         return _CO_BASE_TEMPLATE
-    return f'{instance._meta.app_label}/{instance._meta.model_name}.html'
+    return get_default_template(instance._meta.model)
 
 
 def _restrict_or_warn(qs, user, *, label):

--- a/netbox_custom_objects/tests/test_related_tabs.py
+++ b/netbox_custom_objects/tests/test_related_tabs.py
@@ -27,6 +27,7 @@ from extras.choices import CustomFieldTypeChoices
 from netbox.registry import registry
 
 from dcim.models import Site
+from ipam.models import VRF
 
 from netbox_custom_objects.constants import APP_LABEL
 from netbox_custom_objects.related_tabs.registry import _public_host_model_classes
@@ -35,6 +36,7 @@ from netbox_custom_objects.related_tabs.views.combined import (
     COMBINED_WEIGHT,
     _count_linked_custom_objects,
     _filter_linked_objects,
+    _get_base_template,
     _get_field_value,
     _get_linked_custom_objects,
     _max_multiobject_display,
@@ -80,6 +82,25 @@ class ReferenceQTests(TestCase):
         with self.assertLogs('netbox_custom_objects.related_tabs', level='ERROR'):
             q = reference_q(1, 42, 'x', CustomFieldTypeChoices.TYPE_MULTIOBJECT, True, 'Through_does_not_exist')
         self.assertFalse(q.children)
+
+
+class GetBaseTemplateTests(TestCase):
+    """
+    ``_get_base_template()`` must fall back to ``generic/object.html`` for models
+    without an ``{app}/{model}.html`` detail template (e.g. ipam.VRF,
+    dcim.MACAddress) — otherwise the tab template's ``{% extends base_template %}``
+    raises TemplateDoesNotExist (HTTP 500) on those models' tab pages.
+    """
+
+    def test_model_with_detail_template(self):
+        self.assertEqual(_get_base_template(Site()), 'dcim/site.html')
+
+    def test_model_without_detail_template_falls_back_to_generic(self):
+        self.assertEqual(_get_base_template(VRF()), 'generic/object.html')
+
+    def test_custom_object_app_uses_shared_template(self):
+        instance = SimpleNamespace(_meta=SimpleNamespace(app_label=APP_LABEL))
+        self.assertEqual(_get_base_template(instance), 'netbox_custom_objects/customobject.html')
 
 
 class PublicHostModelsTests(TestCase):


### PR DESCRIPTION
Closes #678

`_get_base_template()` built `"{app_label}/{model_name}.html"` unconditionally, but not every model has one (`ipam/vrf.html` and `dcim/macaddress.html` don't exist), so the combined tab's `{% extends base_template %}` raised `TemplateDoesNotExist` (HTTP 500) on those models' tab pages.

Delegate to `utilities.views.get_default_template()` — the same resolution NetBox's Journal/Changelog tab views use; it falls back to `generic/object.html` when no `<app>/<model>.html` detail template exists.

Adds regression tests in `test_related_tabs.py`; full module (34 tests) passes.