### PR TITLE
Fixes #653: Fix Branch.sync() cross-connection deadlock on ChangeDiff rewrites

### DIFF
--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -2229,9 +2229,14 @@ def _rename_objectchange_field_key(fi, old_name, new_name):
         'SET {col} = ({col} - %s) || jsonb_build_object(%s, {col}->%s) '
         'WHERE object_type_id = %s AND {col} IS NOT NULL AND {col} ? %s'
     )
+    # Unlike core.ObjectChange, ChangeDiff has no per-branch schema copy, so every
+    # other access to it (including netbox-branching's own record_change_diff
+    # receiver) uses DEFAULT_DB_ALIAS. Writing it via the branch connection here
+    # instead introduced a second connection into sync()'s open transaction,
+    # causing a same-process cross-connection deadlock (issue #653).
     try:
-        with transaction.atomic(using=conn.alias):
-            with conn.cursor() as cursor:
+        with transaction.atomic(using=DEFAULT_DB_ALIAS):
+            with connections[DEFAULT_DB_ALIAS].cursor() as cursor:
                 for json_col in ('original', 'modified', 'current'):
                     cursor.execute(
                         cd_sql.format(col=json_col),


### PR DESCRIPTION
### Fixes: #653

## Summary

Fixes a same-process, cross-connection deadlock in `Branch.sync()` reported in #653. `_rename_objectchange_field_key()`'s `ChangeDiff` block wrote via the branch connection — the same connection already correctly used for `ObjectChange`, which *is* per-branch-replicated. `ChangeDiff` has no per-branch schema copy: it's a plain `models.Model`, not a `ChangeLoggingMixin` subclass, so `BranchAwareRouter.supports_branching()` returns `False` for it and every other access to it (including netbox-branching's own `record_change_diff` signal receiver) always resolves to `DEFAULT_DB_ALIAS`.

## Root cause

`Branch.sync()` holds two simultaneously-open transactions for its whole duration — `DEFAULT_DB_ALIAS` and the branch connection. Writing `ChangeDiff` via the branch connection introduced a second, unrelated connection into that pair:

1. A field rename replayed onto the branch calls `_rename_objectchange_field_key()`, which does a raw `UPDATE netbox_branching_changediff ...` via the **branch connection**, taking a row lock held until `sync()` returns.
2. Later in the *same* `sync()` call, `_flush_sync_buffer()` creates `ObjectChange` rows, each synchronously firing `record_change_diff`, which writes the *same* `ChangeDiff` row via the **default connection** (plain ORM access, no `.using()`).
3. If that row is already locked by step 1, step 2 blocks waiting for the branch connection's transaction to commit — which can't happen until `sync()` returns, which needs step 2 to finish first.

Postgres's own deadlock detector never fires here: only one session is actually waiting on a lock; the other is idle (`idle in transaction`), passively holding its lock while its owning thread (the same Python thread, in this single-threaded scenario) is blocked elsewhere. From Postgres's perspective there's no lock cycle to detect.

## Fix

Route the `ChangeDiff` write through `DEFAULT_DB_ALIAS`, matching every other `ChangeDiff` access in the codebase. Since `sync()` already holds `transaction.atomic(using=DEFAULT_DB_ALIAS)` open for its whole duration, this becomes a plain savepoint within that existing transaction rather than a second, independent one — removing the cross-connection reference entirely.

## Testing

Verified against a disposable NetBox `main` checkout (Django 6.0.7, matching `netbox_branching`'s `max_version` pin) with `netbox-branching` 1.1.2:

- The exact reproduction from the issue (`test_sequential_renames_both_sides_sync`), which previously hung indefinitely (confirmed hung 22+ minutes via `pg_stat_activity`/`pg_locks`/a live thread dump before being killed), now completes in a few seconds and passes.
- Full `test_branching.py` module: 61 tests, 0 failures/errors — no regression from moving this write off the branch connection.
