### PR TITLE
Fixes #677: Set polymorphic GFK field values before full_clean(), not after

### DIFF
--- a/netbox_custom_objects/api/serializers.py
+++ b/netbox_custom_objects/api/serializers.py
@@ -688,12 +688,10 @@ def get_serializer_class(model, skip_object_fields=False):
         if type(data) is not dict:
             return NetBoxModelSerializer.validate(self, data)
 
-        # NetBoxModelSerializer.validate() calls Model(**attrs) (create) or
-        # setattr(instance, k, v) per attrs key (update), then instance.full_clean()
-        # -- which is what runs CUSTOM_VALIDATORS. Polymorphic GFK and M2M fields
-        # aren't real Django model fields, so passing either straight through
-        # would raise TypeError. Pop them before delegating to the parent, then
-        # restore them afterward.
+        # NetBoxModelSerializer.validate() calls Model(**attrs)/setattr then
+        # instance.full_clean() (which runs CUSTOM_VALIDATORS). Polymorphic M2M
+        # fields aren't real Django model fields, so pop them before delegating
+        # and restore them after.
         # super() is unavailable here because this function is defined outside a
         # class body (no __class__ cell). The generated class has a single base
         # (NetBoxModelSerializer), so calling it directly is equivalent.
@@ -702,14 +700,11 @@ def get_serializer_class(model, skip_object_fields=False):
             if field_name in data:
                 saved[field_name] = data.pop(field_name)
 
-        # Polymorphic single-object (GFK) fields, unlike the M2M case above, ARE
-        # backed by two real scalar columns (<name>_content_type_id,
-        # <name>_object_id) that an unsaved instance can hold. Substitute those
-        # for the resolved object before delegating, so the instance
-        # full_clean() (and CUSTOM_VALIDATORS) actually validates sees the
-        # submitted value instead of a blank/stale one (#677); restore the
-        # resolved object under the original field name afterward, since
-        # create()/update() expect to find it there.
+        # Polymorphic single-object (GFK) fields ARE backed by two real scalar
+        # columns an unsaved instance can hold. Substitute those for the
+        # resolved object before delegating, so full_clean()/CUSTOM_VALIDATORS
+        # see the submitted value instead of a blank one (#677); restore the
+        # resolved object afterward for create()/update() to consume.
         poly_obj_originals = {}
         for field_name in _poly_obj_fields:
             if field_name in data:

--- a/netbox_custom_objects/api/serializers.py
+++ b/netbox_custom_objects/api/serializers.py
@@ -688,18 +688,45 @@ def get_serializer_class(model, skip_object_fields=False):
         if type(data) is not dict:
             return NetBoxModelSerializer.validate(self, data)
 
-        # NetBoxModelSerializer.validate() calls Model(**attrs) to check field
-        # values. Polymorphic GFK and M2M fields are not real Django model fields,
-        # so they'd cause a TypeError. Pop them before delegating to the parent,
-        # then restore them afterward.
+        # NetBoxModelSerializer.validate() calls Model(**attrs) (create) or
+        # setattr(instance, k, v) per attrs key (update), then instance.full_clean()
+        # -- which is what runs CUSTOM_VALIDATORS. Polymorphic GFK and M2M fields
+        # aren't real Django model fields, so passing either straight through
+        # would raise TypeError. Pop them before delegating to the parent, then
+        # restore them afterward.
         # super() is unavailable here because this function is defined outside a
         # class body (no __class__ cell). The generated class has a single base
         # (NetBoxModelSerializer), so calling it directly is equivalent.
         saved = {}
-        for field_name in (*_poly_obj_fields, *_poly_m2m_fields):
+        for field_name in _poly_m2m_fields:
             if field_name in data:
                 saved[field_name] = data.pop(field_name)
+
+        # Polymorphic single-object (GFK) fields, unlike the M2M case above, ARE
+        # backed by two real scalar columns (<name>_content_type_id,
+        # <name>_object_id) that an unsaved instance can hold. Substitute those
+        # for the resolved object before delegating, so the instance
+        # full_clean() (and CUSTOM_VALIDATORS) actually validates sees the
+        # submitted value instead of a blank/stale one (#677); restore the
+        # resolved object under the original field name afterward, since
+        # create()/update() expect to find it there.
+        poly_obj_originals = {}
+        for field_name in _poly_obj_fields:
+            if field_name in data:
+                obj = data.pop(field_name)
+                poly_obj_originals[field_name] = obj
+                ct_attname = f"{field_name}_content_type_id"
+                oid_attname = f"{field_name}_object_id"
+                data[ct_attname] = ContentType.objects.get_for_model(obj).pk if obj is not None else None
+                data[oid_attname] = obj.pk if obj is not None else None
+
         data = NetBoxModelSerializer.validate(self, data)
+
+        for field_name, obj in poly_obj_originals.items():
+            data.pop(f"{field_name}_content_type_id", None)
+            data.pop(f"{field_name}_object_id", None)
+            data[field_name] = obj
+
         data.update(saved)
 
         # Coordinates: latitude and longitude must both be set or both be empty.

--- a/netbox_custom_objects/tests/test_polymorphic_fields.py
+++ b/netbox_custom_objects/tests/test_polymorphic_fields.py
@@ -346,6 +346,57 @@ class PolymorphicFieldAPITest(TransactionCleanupMixin, CustomObjectsTestCase, Tr
         obj.refresh_from_db()
         self.assertIsNone(obj.poly_obj)
 
+    def test_custom_validator_sees_gfk_value_on_api_create(self):
+        """A CUSTOM_VALIDATORS validate() call during API create must see the
+        submitted polymorphic GFK value, not None (#677)."""
+        from django.contrib.contenttypes.models import ContentType
+        from extras.validators import CustomValidator
+
+        _grant_perm(self.user, "add", self.model, "co-add-validator")
+        seen = {}
+
+        class _CaptureValidator(CustomValidator):
+            def validate(self, instance, request):
+                seen['poly_obj'] = instance.poly_obj
+
+        site_ct = ContentType.objects.get_for_model(Site)
+        data = {
+            "name": "validator-api-create-obj",
+            "poly_obj": {"content_type_id": site_ct.pk, "object_id": self.site.pk},
+        }
+        with self.settings(CUSTOM_VALIDATORS={f'{APP_LABEL}.{self.cot.slug}': [_CaptureValidator()]}):
+            response = self.client.post(
+                self._obj_list_url(), json.dumps(data), content_type="application/json", **self.header
+            )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+        self.assertEqual(seen.get('poly_obj'), self.site)
+
+    def test_custom_validator_sees_updated_gfk_value_on_api_update(self):
+        """A CUSTOM_VALIDATORS validate() call during an API PATCH that changes the
+        polymorphic GFK value must see the new value, not the pre-update one (#677)."""
+        from django.contrib.contenttypes.models import ContentType
+        from extras.validators import CustomValidator
+
+        _grant_perm(self.user, "change", self.model, "co-change-validator")
+        obj = self.model.objects.create(name="validator-api-update-obj")
+        obj.poly_obj = self.site
+        obj.save()
+
+        seen = {}
+
+        class _CaptureValidator(CustomValidator):
+            def validate(self, instance, request):
+                seen['poly_obj'] = instance.poly_obj
+
+        prefix_ct = ContentType.objects.get_for_model(Prefix)
+        data = {"poly_obj": {"content_type_id": prefix_ct.pk, "object_id": self.prefix.pk}}
+        with self.settings(CUSTOM_VALIDATORS={f'{APP_LABEL}.{self.cot.slug}': [_CaptureValidator()]}):
+            response = self.client.patch(
+                self._obj_detail_url(obj.pk), json.dumps(data), content_type="application/json", **self.header
+            )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        self.assertEqual(seen.get('poly_obj'), self.prefix)
+
     # --- Custom object CRUD with polymorphic M2M ---
 
     def test_create_custom_object_with_polymorphic_m2m_via_api(self):
@@ -959,6 +1010,62 @@ class PolymorphicFieldUITest(TransactionCleanupMixin, CustomObjectsTestCase, Tra
 
         response = self.client.get(self._field_delete_url(self.gfk_field.pk))
         self.assertEqual(response.status_code, 200)
+
+    # --- CUSTOM_VALIDATORS visibility of polymorphic GFK values (#677) ---
+
+    def test_custom_validator_sees_gfk_value_on_create(self):
+        """A CUSTOM_VALIDATORS validate() call during form-based create must see the
+        submitted polymorphic GFK value on the instance, not None. Before the fix,
+        custom_save() set the GFK attribute only after Django's full_clean() (and
+        therefore CUSTOM_VALIDATORS) had already run against the unsaved instance."""
+        from django.contrib.contenttypes.models import ContentType
+        from extras.validators import CustomValidator
+
+        seen = {}
+
+        class _CaptureValidator(CustomValidator):
+            def validate(self, instance, request):
+                seen['poly_obj'] = instance.poly_obj
+
+        site_ct = ContentType.objects.get_for_model(Site)
+        data = {
+            "name": "validator-create-obj",
+            "poly_obj__ct": site_ct.pk,
+            "poly_obj__obj": self.site1.pk,
+            "csrfmiddlewaretoken": "fake",
+        }
+        with self.settings(CUSTOM_VALIDATORS={f'{APP_LABEL}.{self.cot.slug}': [_CaptureValidator()]}):
+            response = self.client.post(self._add_url(), data, follow=True)
+        self.assertNotIn(response.status_code, [400, 403, 500])
+        self.assertEqual(seen.get('poly_obj'), self.site1)
+
+    def test_custom_validator_sees_updated_gfk_value_on_edit(self):
+        """Editing an object and changing its polymorphic GFK value must be visible
+        to CUSTOM_VALIDATORS during that same request, not the pre-edit value."""
+        from django.contrib.contenttypes.models import ContentType
+        from extras.validators import CustomValidator
+
+        obj = self.model.objects.create(name="validator-edit-obj")
+        obj.poly_obj = self.site1
+        obj.save()
+
+        seen = {}
+
+        class _CaptureValidator(CustomValidator):
+            def validate(self, instance, request):
+                seen['poly_obj'] = instance.poly_obj
+
+        prefix_ct = ContentType.objects.get_for_model(Prefix)
+        data = {
+            "name": "validator-edit-obj",
+            "poly_obj__ct": prefix_ct.pk,
+            "poly_obj__obj": self.prefix1.pk,
+            "csrfmiddlewaretoken": "fake",
+        }
+        with self.settings(CUSTOM_VALIDATORS={f'{APP_LABEL}.{self.cot.slug}': [_CaptureValidator()]}):
+            response = self.client.post(self._edit_url(obj.pk), data, follow=True)
+        self.assertNotIn(response.status_code, [400, 403, 500])
+        self.assertEqual(seen.get('poly_obj'), self.prefix1)
 
 
 # ---------------------------------------------------------------------------

--- a/netbox_custom_objects/tests/test_polymorphic_fields.py
+++ b/netbox_custom_objects/tests/test_polymorphic_fields.py
@@ -1014,10 +1014,8 @@ class PolymorphicFieldUITest(TransactionCleanupMixin, CustomObjectsTestCase, Tra
     # --- CUSTOM_VALIDATORS visibility of polymorphic GFK values (#677) ---
 
     def test_custom_validator_sees_gfk_value_on_create(self):
-        """A CUSTOM_VALIDATORS validate() call during form-based create must see the
-        submitted polymorphic GFK value on the instance, not None. Before the fix,
-        custom_save() set the GFK attribute only after Django's full_clean() (and
-        therefore CUSTOM_VALIDATORS) had already run against the unsaved instance."""
+        """CUSTOM_VALIDATORS must see the submitted GFK value during form-based
+        create, not None (#677)."""
         from django.contrib.contenttypes.models import ContentType
         from extras.validators import CustomValidator
 

--- a/netbox_custom_objects/tests/test_polymorphic_fields.py
+++ b/netbox_custom_objects/tests/test_polymorphic_fields.py
@@ -397,6 +397,36 @@ class PolymorphicFieldAPITest(TransactionCleanupMixin, CustomObjectsTestCase, Tr
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
         self.assertEqual(seen.get('poly_obj'), self.prefix)
 
+    def test_custom_validator_sees_cleared_gfk_value_on_api_update(self):
+        """PATCHing poly_obj to null must clear it on the instance validate() runs
+        against, and the None restore after validate() must still round-trip
+        correctly into update()."""
+        from extras.validators import CustomValidator
+
+        _grant_perm(self.user, "change", self.model, "co-change-validator-null")
+        obj = self.model.objects.create(name="validator-api-clear-obj")
+        obj.poly_obj = self.site
+        obj.save()
+
+        seen = {}
+        called = []
+
+        class _CaptureValidator(CustomValidator):
+            def validate(self, instance, request):
+                called.append(True)
+                seen['poly_obj'] = instance.poly_obj
+
+        data = {"poly_obj": None}
+        with self.settings(CUSTOM_VALIDATORS={f'{APP_LABEL}.{self.cot.slug}': [_CaptureValidator()]}):
+            response = self.client.patch(
+                self._obj_detail_url(obj.pk), json.dumps(data), content_type="application/json", **self.header
+            )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        self.assertTrue(called, "validator was never invoked")
+        self.assertIsNone(seen.get('poly_obj'))
+        obj.refresh_from_db()
+        self.assertIsNone(obj.poly_obj)
+
     # --- Custom object CRUD with polymorphic M2M ---
 
     def test_create_custom_object_with_polymorphic_m2m_via_api(self):

--- a/netbox_custom_objects/views.py
+++ b/netbox_custom_objects/views.py
@@ -1077,11 +1077,12 @@ class CustomObjectEditView(generic.ObjectEditView):
                         obj_sub,
                         _("Please select an object of the chosen type."),
                     )
-                # Set here too (custom_save() sets it again before the DB write):
-                # _post_clean() calls instance.full_clean() -- and therefore
-                # CUSTOM_VALIDATORS -- right after this method returns, so waiting
-                # until custom_save() left validators seeing a blank value (#677).
-                setattr(self.instance, field_name, obj_val)
+                else:
+                    # Set here too (custom_save() sets it again before the DB write):
+                    # _post_clean() calls instance.full_clean() -- and therefore
+                    # CUSTOM_VALIDATORS -- right after this method returns, so waiting
+                    # until custom_save() left validators seeing a blank value (#677).
+                    setattr(self.instance, field_name, obj_val)
             # Coordinates: latitude and longitude must both be set or both be empty.
             for field_name, (lat_name, lon_name) in self.custom_object_type_coordinates_fields.items():
                 latitude = self.cleaned_data.get(lat_name)

--- a/netbox_custom_objects/views.py
+++ b/netbox_custom_objects/views.py
@@ -1077,6 +1077,13 @@ class CustomObjectEditView(generic.ObjectEditView):
                         obj_sub,
                         _("Please select an object of the chosen type."),
                     )
+                # Also set on self.instance here (custom_save() sets it again before
+                # the DB write), not just in custom_save(): Django's _post_clean()
+                # calls self.instance.full_clean() -- and therefore CUSTOM_VALIDATORS
+                # -- right after this method returns, using self.instance as it
+                # stands at that point. Waiting until custom_save() left every
+                # validator seeing this field as blank/stale (#677).
+                setattr(self.instance, field_name, obj_val)
             # Coordinates: latitude and longitude must both be set or both be empty.
             for field_name, (lat_name, lon_name) in self.custom_object_type_coordinates_fields.items():
                 latitude = self.cleaned_data.get(lat_name)

--- a/netbox_custom_objects/views.py
+++ b/netbox_custom_objects/views.py
@@ -1077,12 +1077,10 @@ class CustomObjectEditView(generic.ObjectEditView):
                         obj_sub,
                         _("Please select an object of the chosen type."),
                     )
-                # Also set on self.instance here (custom_save() sets it again before
-                # the DB write), not just in custom_save(): Django's _post_clean()
-                # calls self.instance.full_clean() -- and therefore CUSTOM_VALIDATORS
-                # -- right after this method returns, using self.instance as it
-                # stands at that point. Waiting until custom_save() left every
-                # validator seeing this field as blank/stale (#677).
+                # Set here too (custom_save() sets it again before the DB write):
+                # _post_clean() calls instance.full_clean() -- and therefore
+                # CUSTOM_VALIDATORS -- right after this method returns, so waiting
+                # until custom_save() left validators seeing a blank value (#677).
                 setattr(self.instance, field_name, obj_val)
             # Coordinates: latitude and longitude must both be set or both be empty.
             for field_name, (lat_name, lon_name) in self.custom_object_type_coordinates_fields.items():


### PR DESCRIPTION
### Fixes: #677

## Summary

Fixes #677: a `CUSTOM_VALIDATORS` validator's `validate(instance, request)` always saw a polymorphic single-object (GFK) field as blank on create, or as its pre-edit value on update — regardless of what was actually submitted in the request.

## Root cause

`CUSTOM_VALIDATORS` runs inside `instance.clean()`, called by Django's `full_clean()`. In both the form and API paths, the polymorphic field's value was applied to the instance strictly *after* `full_clean()` had already run:

- **Form path**: `custom_save()` (called by `form.save()`, itself called *after* `form.is_valid()` — which already triggers `full_clean()` via `ModelForm._post_clean()`) was the only place that did `setattr(instance, field_name, obj_val)` for the field.
- **API path**: the serializer's `validate()` popped the polymorphic field entirely out of the data dict *before* delegating to `ValidatedModelSerializer.validate()` (which builds/mutates the instance and calls `instance.full_clean()`), only restoring the field to the data dict *after* that call returned.

## Fix

- `views.py`: `custom_clean()` (the form's own `clean()`, which runs *before* Django's `_post_clean()` calls `instance.full_clean()`) now also sets the polymorphic field's value on `self.instance`. `custom_save()`'s existing assignment stays in place — reapplying the same value there is a harmless no-op.
- `api/serializers.py`: `validate()` now substitutes the field's two real backing scalar columns (`<name>_content_type_id`, `<name>_object_id`) for the resolved object before delegating to the parent `validate()`, then restores the resolved object under the original field name afterward for `create()`/`update()` to consume as before. Those two columns are real Django model fields (unlike the field itself, a private/virtual GFK descriptor), so an unsaved instance can hold them fine — unlike the polymorphic M2M case (left unchanged), which genuinely has no home on an instance without a PK yet.

## Testing

Added 4 regression tests in `test_polymorphic_fields.py`, covering create and edit/update through both the form and API paths. All 4 fail without the fix — reproducing the exact reported symptom (`None` on create, stale pre-edit value on update) — and pass with it.

Verified:
- `test_polymorphic_fields.py`: 82 tests, 0 real failures (1 error is the confirmed pre-existing, unrelated `netbox_branching` shared-environment artifact, present on unmodified `main` too).
- Full plugin suite in a clean venv: 1165 tests, 0 failures/errors, 2 skipped.
