### PR TITLE
Closes #655: Surface context fields as attributes in global search results

### DIFF
--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -1639,15 +1639,28 @@ class CustomObjectType(NetBoxModel):
             | {f.name for f in model._meta.local_many_to_many}
         )
         fields = []
-        for field in self.fields.filter(search_weight__gt=0):
+        display_attrs = []
+        for field in self.fields.all():
             if field.name not in present:
                 continue
-            fields.append((field.name, field.search_weight))
+            if field.search_weight > 0:
+                fields.append((field.name, field.search_weight))
+            # Context fields surface as supplementary "attributes" on global search
+            # results (issue #655), via the same generic CachedValue.display_attrs
+            # mechanism every other NetBox model's SearchIndex uses. That mechanism
+            # renders a field with plain getattr() (falling back to
+            # get_<field>_display() for Django choices=), so it has no way to render
+            # a MultiObject field's RelatedManager as anything meaningful -- exclude
+            # those. Polymorphic and coordinates fields need no such exclusion: they
+            # have no real backing column under the field's own name, so `present`
+            # already filters them out above.
+            if field.context and field.type != CustomFieldTypeChoices.TYPE_MULTIOBJECT:
+                display_attrs.append(field.name)
 
         attrs = {
             "model": model,
             "fields": tuple(fields),
-            "display_attrs": tuple(),
+            "display_attrs": tuple(display_attrs),
         }
         search_index = type(
             f"{self.name}SearchIndex",

--- a/netbox_custom_objects/tests/test_models.py
+++ b/netbox_custom_objects/tests/test_models.py
@@ -246,6 +246,51 @@ class CustomObjectTypeTestCase(CustomObjectsTestCase, TestCase):
         # Must not raise FieldDoesNotExist, RecursionError, or any other exception.
         cot.register_custom_object_search_index(stub_model)
 
+    def test_register_search_index_includes_context_fields_in_display_attrs(self):
+        """Fields marked context=True surface as display_attrs (issue #655), so
+        NetBox's global search shows them as supplementary "attributes" alongside
+        each result, the same as any other model's SearchIndex.display_attrs."""
+        cot = self.create_custom_object_type(name="ContextSearchTest", slug="context-search-test")
+        self.create_custom_object_type_field(
+            cot, name="name", label="Name", type="text", primary=True, search_weight=1000,
+        )
+        self.create_custom_object_type_field(
+            cot, name="status", label="Status", type="text", context=True,
+        )
+        cot.clear_model_cache(cot.id)
+        model = cot.get_model()
+        cot.register_custom_object_search_index(model)
+
+        label = f"{APP_LABEL}.{cot.get_table_model_name(cot.id).lower()}"
+        search_index = registry["search"][label]
+        self.assertIn("status", search_index.display_attrs)
+
+    def test_register_search_index_excludes_multiobject_context_fields(self):
+        """A context field of type multiobject must not reach display_attrs.
+
+        NetBox core's CachedValue.display_attrs (the only consumer of this
+        attribute) renders each entry via plain getattr() on the instance --
+        for a real ManyToManyField that returns the RelatedManager itself, not
+        its contents, so the search UI would show a broken object repr instead
+        of the related objects. Excluding multiobject context fields here avoids
+        surfacing that.
+        """
+        cot = self.create_custom_object_type(name="ContextM2MTest", slug="context-m2m-test")
+        self.create_custom_object_type_field(
+            cot, name="name", label="Name", type="text", primary=True, search_weight=1000,
+        )
+        self.create_custom_object_type_field(
+            cot, name="related_sites", label="Related Sites", type="multiobject",
+            related_object_type=self.get_site_object_type(), context=True,
+        )
+        cot.clear_model_cache(cot.id)
+        model = cot.get_model()
+        cot.register_custom_object_search_index(model)
+
+        label = f"{APP_LABEL}.{cot.get_table_model_name(cot.id).lower()}"
+        search_index = registry["search"][label]
+        self.assertNotIn("related_sites", search_index.display_attrs)
+
     def test_skipped_object_field_with_stale_content_type_logs_warning(self):
         """When get_model_field raises NotImplementedError for an object field whose
         related_object_type_id is non-null (stale/deleted ContentType), a WARNING must

--- a/netbox_custom_objects/tests/test_models.py
+++ b/netbox_custom_objects/tests/test_models.py
@@ -264,6 +264,29 @@ class CustomObjectTypeTestCase(CustomObjectsTestCase, TestCase):
         label = f"{APP_LABEL}.{cot.get_table_model_name(cot.id).lower()}"
         search_index = registry["search"][label]
         self.assertIn("status", search_index.display_attrs)
+        self.assertNotIn("name", search_index.display_attrs)
+
+    def test_register_search_index_includes_object_context_fields(self):
+        """A context field of type object (a single real FK, unlike multiobject's
+        M2M) IS included in display_attrs -- getattr() on it returns the related
+        instance directly, not a manager, so NetBox's generic renderer handles it
+        correctly. Confirms the TYPE_MULTIOBJECT exclusion is scoped to just that
+        one type, not object fields generally."""
+        cot = self.create_custom_object_type(name="ContextObjectTest", slug="context-object-test")
+        self.create_custom_object_type_field(
+            cot, name="name", label="Name", type="text", primary=True, search_weight=1000,
+        )
+        self.create_custom_object_type_field(
+            cot, name="related_site", label="Related Site", type="object",
+            related_object_type=self.get_site_object_type(), context=True,
+        )
+        cot.clear_model_cache(cot.id)
+        model = cot.get_model()
+        cot.register_custom_object_search_index(model)
+
+        label = f"{APP_LABEL}.{cot.get_table_model_name(cot.id).lower()}"
+        search_index = registry["search"][label]
+        self.assertIn("related_site", search_index.display_attrs)
 
     def test_register_search_index_excludes_multiobject_context_fields(self):
         """A context field of type multiobject must not reach display_attrs.


### PR DESCRIPTION
### Closes: #655

## Summary

Global search results for custom objects only ever showed a bare link to the object — none of its "context" fields appeared in the Attributes column the way core NetBox models do. This wires `CustomObjectType`'s dynamically generated `SearchIndex` to surface `context=True` fields there, via NetBox core's existing `SearchIndex.display_attrs` mechanism.

## Credit

This builds directly on [#656](https://github.com/netboxlabs/netbox-custom-objects/pull/656) by @biwhite, who filed #655 and correctly identified `display_attrs` as the right hook. His PR is out of sync with `main` and failing CI as a result — not because of any problem with his approach (see the comment thread on #655) — and I don't have push access to his fork to rebase it directly, so I'm opening this instead.

## What changed vs. #656

Reviewing #656 for correctness turned up two issues, both addressed here:

1. **Dead code**: #656 added a `get_display_attrs` classmethod to the dynamically generated `SearchIndex` class, but nothing in NetBox core or this plugin ever calls a method by that name. The actual renderer is [`CachedValue.display_attrs`](https://github.com/netbox-community/netbox/blob/main/netbox/extras/models/search.py) (a core `@property`), which only reads the plain `display_attrs` tuple on the indexer class and does its own `getattr()` / `get_<field>_display()` dispatch per entry — the added method was inert.
2. **A real correctness gap**: nothing prevents `context=True` from being set on a `multiobject` (real M2M) field. `CachedValue.display_attrs`'s `getattr()`-based renderer has no per-type dispatch — for a real `ManyToManyField` it returns the `RelatedManager` instance itself, not its contents, so a multiobject context field would leak a broken object repr into search results instead of the related objects. This PR excludes multiobject context fields from `display_attrs` to avoid that. Polymorphic and coordinates fields need no equivalent exclusion — they have no real backing column under the field's own name, so the existing `present`-set guard (already in place to protect stub models generated with `skip_object_fields=True`) filters them out automatically.

Also consolidated the two separate `self.fields` queries (one filtered by `search_weight`, one by `context`) into a single pass.

## Testing

Adds two regression tests to `test_models.py`:
- a `context=True` text field appears in the generated `SearchIndex.display_attrs`
- a `context=True` multiobject field does not

Full plugin suite verified in a clean venv: 1173 tests, 0 failures/errors, 2 skipped.