### PR TITLE
Fixes #688: Re-register get_model()'s own class after a re-entrant regeneration

### DIFF
--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -1831,6 +1831,22 @@ class CustomObjectType(NetBoxModel):
             with self._global_lock:
                 self._after_model_generation(attrs, model)
 
+                # _after_model_generation() can trigger a re-entrant get_model() for this
+                # SAME (cot_id, branch_id) -- e.g. a polymorphic field's
+                # related_object_types.all() rebuilding Django's relation tree, which
+                # re-enters our get_models() override before the #685/#686 reentrancy
+                # guard is set (this call arrived directly, not via get_models()'s own
+                # loop) and regenerates+re-registers a *different* class object under the
+                # same apps.all_models key (#688). That nested call's own _model_cache
+                # write is superseded below by this call's, but nothing previously
+                # re-asserted apps.all_models afterward, so it could keep pointing at the
+                # nested call's class while _model_cache (and this call's return value)
+                # point at this one. Re-register this call's own model so both agree.
+                if branch_id is None and apps.all_models[APP_LABEL].get(model_key) is not model:
+                    if model_key in apps.all_models[APP_LABEL]:
+                        del apps.all_models[APP_LABEL][model_key]
+                    apps.register_model(APP_LABEL, model)
+
                 # When this COT's model is regenerated (cache miss), non-polymorphic through
                 # models owned by OTHER COTs that point to this COT as their M2M target keep
                 # their target FK stale (pointing at the old model class).  Django's deletion

--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -1832,9 +1832,9 @@ class CustomObjectType(NetBoxModel):
                 self._after_model_generation(attrs, model)
 
                 # _after_model_generation() can trigger a re-entrant get_model() for this
-                # same (cot_id, branch_id) (#688) -- e.g. a polymorphic field's
+                # same (cot_id, branch_id) -- e.g. a polymorphic field's
                 # related_object_types.all() rebuilding the relation tree and re-entering
-                # get_models() before the #685/#686 guard is set -- which re-registers a
+                # get_models() before the reentrancy guard is set -- which re-registers a
                 # different class under this key. Re-assert this call's own class so
                 # apps.all_models matches _model_cache and the return value below.
                 if branch_id is None and apps.all_models[APP_LABEL].get(model_key) is not model:

--- a/netbox_custom_objects/models.py
+++ b/netbox_custom_objects/models.py
@@ -1832,16 +1832,11 @@ class CustomObjectType(NetBoxModel):
                 self._after_model_generation(attrs, model)
 
                 # _after_model_generation() can trigger a re-entrant get_model() for this
-                # SAME (cot_id, branch_id) -- e.g. a polymorphic field's
-                # related_object_types.all() rebuilding Django's relation tree, which
-                # re-enters our get_models() override before the #685/#686 reentrancy
-                # guard is set (this call arrived directly, not via get_models()'s own
-                # loop) and regenerates+re-registers a *different* class object under the
-                # same apps.all_models key (#688). That nested call's own _model_cache
-                # write is superseded below by this call's, but nothing previously
-                # re-asserted apps.all_models afterward, so it could keep pointing at the
-                # nested call's class while _model_cache (and this call's return value)
-                # point at this one. Re-register this call's own model so both agree.
+                # same (cot_id, branch_id) (#688) -- e.g. a polymorphic field's
+                # related_object_types.all() rebuilding the relation tree and re-entering
+                # get_models() before the #685/#686 guard is set -- which re-registers a
+                # different class under this key. Re-assert this call's own class so
+                # apps.all_models matches _model_cache and the return value below.
                 if branch_id is None and apps.all_models[APP_LABEL].get(model_key) is not model:
                     if model_key in apps.all_models[APP_LABEL]:
                         del apps.all_models[APP_LABEL][model_key]

--- a/netbox_custom_objects/tests/test_polymorphic_fields.py
+++ b/netbox_custom_objects/tests/test_polymorphic_fields.py
@@ -2165,7 +2165,7 @@ class PolymorphicReverseDescriptorRecursionTestCase(
         # Look up the registered class directly rather than trusting `model`:
         # a nested get_models() call triggered mid-generation (as above) can
         # leave get_model()'s return value out of sync with what's actually
-        # registered in the app registry -- see #688.
+        # registered in the app registry.
         registered_model = django_apps.get_model(APP_LABEL, model.__name__)
         self.assertIn(
             registered_model,
@@ -2182,9 +2182,8 @@ class PolymorphicReverseDescriptorRecursionTestCase(
 class GetModelCacheRegistryConsistencyTestCase(
     TransactionCleanupMixin, CustomObjectsTestCase, TransactionTestCase
 ):
-    """Regression test for issue #688: a re-entrant get_model() (#685/#686)
-    could leave _model_cache and apps.all_models pointing at two different
-    classes for the same COT."""
+    """Regression test: a re-entrant get_model() for the same COT could leave
+    _model_cache and apps.all_models pointing at two different classes."""
 
     def test_get_model_registers_the_same_class_it_returns_and_caches(self):
         from unittest import mock
@@ -2211,7 +2210,7 @@ class GetModelCacheRegistryConsistencyTestCase(
         )
         field.related_object_types.set([site_ot, prefix_ot])
 
-        # Same setup as the #686 recursion test, to force the re-entrant path.
+        # Same setup as the sibling recursion test, to force the re-entrant path.
         cot.clear_model_cache(cot.id)
         django_apps.clear_cache()
 
@@ -2231,7 +2230,7 @@ class GetModelCacheRegistryConsistencyTestCase(
         self.assertIs(
             registered_model, model,
             "apps.all_models must register the same class get_model() returned/cached, not a stray "
-            "class from a re-entrant regeneration (#688)",
+            "class from a re-entrant regeneration",
         )
         self.assertIn(
             registered_model,

--- a/netbox_custom_objects/tests/test_polymorphic_fields.py
+++ b/netbox_custom_objects/tests/test_polymorphic_fields.py
@@ -2182,9 +2182,9 @@ class PolymorphicReverseDescriptorRecursionTestCase(
 class GetModelCacheRegistryConsistencyTestCase(
     TransactionCleanupMixin, CustomObjectsTestCase, TransactionTestCase
 ):
-    """Regression test for issue #688: a re-entrant get_model() for the same
-    COT, triggered mid-generation (see #685/#686), could leave _model_cache
-    and apps.all_models pointing at two different classes for that COT."""
+    """Regression test for issue #688: a re-entrant get_model() (#685/#686)
+    could leave _model_cache and apps.all_models pointing at two different
+    classes for the same COT."""
 
     def test_get_model_registers_the_same_class_it_returns_and_caches(self):
         from unittest import mock
@@ -2211,10 +2211,7 @@ class GetModelCacheRegistryConsistencyTestCase(
         )
         field.related_object_types.set([site_ot, prefix_ot])
 
-        # Same setup as the #686 recursion test: force the model out of cache
-        # and the relation-tree cold, so get_model() -> _after_model_generation()
-        # -> related_object_types.all() hits the "first access" path that
-        # triggers apps.get_models() re-entrantly for this same COT.
+        # Same setup as the #686 recursion test, to force the re-entrant path.
         cot.clear_model_cache(cot.id)
         django_apps.clear_cache()
 
@@ -2229,12 +2226,7 @@ class GetModelCacheRegistryConsistencyTestCase(
         cached_model = CustomObjectType.get_cached_model(cot.id)
         registered_model = django_apps.get_model(APP_LABEL, model.__name__)
 
-        # All three -- the return value, the per-COT cache, and the app
-        # registry -- must be the exact same class object. Before the #688
-        # fix, a re-entrant regeneration during _after_model_generation()
-        # could leave the app registry holding a different class than the one
-        # returned/cached, so `isinstance`/identity checks against one would
-        # silently fail against the other.
+        # Must be the exact same class object, not just an equal one.
         self.assertIs(cached_model, model, "get_cached_model() must return the same class get_model() returned")
         self.assertIs(
             registered_model, model,

--- a/netbox_custom_objects/tests/test_polymorphic_fields.py
+++ b/netbox_custom_objects/tests/test_polymorphic_fields.py
@@ -2177,3 +2177,72 @@ class PolymorphicReverseDescriptorRecursionTestCase(
             "Reverse descriptor must still be set on Site after get_model()",
         )
         self.assertIsNotNone(model)
+
+
+class GetModelCacheRegistryConsistencyTestCase(
+    TransactionCleanupMixin, CustomObjectsTestCase, TransactionTestCase
+):
+    """Regression test for issue #688: a re-entrant get_model() for the same
+    COT, triggered mid-generation (see #685/#686), could leave _model_cache
+    and apps.all_models pointing at two different classes for that COT."""
+
+    def test_get_model_registers_the_same_class_it_returns_and_caches(self):
+        from unittest import mock
+
+        from django.apps import apps as django_apps
+
+        import netbox_custom_objects as nco_pkg
+
+        site_ot = ObjectType.objects.get(app_label="dcim", model="site")
+        prefix_ot = ObjectType.objects.get(app_label="ipam", model="prefix")
+
+        cot = CustomObjectType.objects.create(
+            name="CacheRegistryTest", slug="cache-registry-test",
+            verbose_name_plural="Cache Registry Tests",
+        )
+        CustomObjectTypeField.objects.create(
+            custom_object_type=cot, name="name", type="text", primary=True, required=True,
+        )
+        field = CustomObjectTypeField.objects.create(
+            custom_object_type=cot,
+            name="target_obj", label="Target", type="object",
+            is_polymorphic=True,
+            related_name="rev_cache_registry_test",
+        )
+        field.related_object_types.set([site_ot, prefix_ot])
+
+        # Same setup as the #686 recursion test: force the model out of cache
+        # and the relation-tree cold, so get_model() -> _after_model_generation()
+        # -> related_object_types.all() hits the "first access" path that
+        # triggers apps.get_models() re-entrantly for this same COT.
+        cot.clear_model_cache(cot.id)
+        django_apps.clear_cache()
+
+        app_config = django_apps.get_app_config('netbox_custom_objects')
+        with (
+            mock.patch.object(nco_pkg, '_app_ready', True),
+            mock.patch.object(app_config, 'should_skip_dynamic_model_creation', return_value=False),
+        ):
+            model = cot.get_model()
+        self.assertFalse(nco_pkg._generating_models.get())
+
+        cached_model = CustomObjectType.get_cached_model(cot.id)
+        registered_model = django_apps.get_model(APP_LABEL, model.__name__)
+
+        # All three -- the return value, the per-COT cache, and the app
+        # registry -- must be the exact same class object. Before the #688
+        # fix, a re-entrant regeneration during _after_model_generation()
+        # could leave the app registry holding a different class than the one
+        # returned/cached, so `isinstance`/identity checks against one would
+        # silently fail against the other.
+        self.assertIs(cached_model, model, "get_cached_model() must return the same class get_model() returned")
+        self.assertIs(
+            registered_model, model,
+            "apps.all_models must register the same class get_model() returned/cached, not a stray "
+            "class from a re-entrant regeneration (#688)",
+        )
+        self.assertIn(
+            registered_model,
+            django_apps.get_models(),
+            "Generated model should be returned by apps.get_models().",
+        )


### PR DESCRIPTION
### Fixes: #688

## Summary

`CustomObjectType._model_cache` and Django's app registry (`apps.all_models`) could end up holding two different Python classes for the same `CustomObjectType`, when generating that COT's model triggers a re-entrant `apps.get_models()` call (e.g. via a polymorphic field's `related_object_types.all()` query in `_wire_polymorphic_reverse_descriptors()`, per #686) while the COT's model isn't cached yet. The #685/#686 reentrancy guard correctly prevents this from recursing infinitely, but doesn't prevent the underlying interleaving hazard it exposes -- discovered while adding a regression test for #685/#686 in #687, per @jnovinger's review suggestion to assert the generated model is actually returned by `apps.get_models()`.

Full root-cause writeup with instrumented repro output is in #688.

## Root cause (recap)

In `CustomObjectType.get_model()`, `apps.register_model()` runs *before* `_after_model_generation()`, and the per-COT `_model_cache` write runs *after* it completes. When `_after_model_generation()` triggers a re-entrant `get_model()` call for the *same* COT (via the relation-tree-rebuild path described above), that nested call generates and registers a second, different class under the same `apps.all_models` key -- clobbering the outer call's registration. The outer call's own `_model_cache` write happens last and correctly ends up holding the outer call's class, but nothing re-asserts `apps.all_models` afterward, so it's left pointing at the nested call's stray class instead.

End state: `_model_cache` (and `get_model()`'s return value) hold one class; `apps.all_models` / `apps.get_models()` (what the ORM, `ContentType.model_class()`, serializers, etc. actually resolve) hold a different one.

## Fix

Implements the first of #688's two suggested fix directions: re-register the outer call's own `model` in `apps.all_models` immediately after `_after_model_generation()` completes (guarded to the `branch_id is None` case, matching the existing registration logic just above it -- branch contexts never register their own class in `apps.all_models` in the first place). This guarantees the final registered class always matches what's about to be cached and returned, regardless of any nested regeneration that happened in between.

The alternative direction (a finer-grained, per-COT "already generating" guard so the nested call sees the outer's in-progress generation instead of racing it) would also work, but is more invasive -- it would need to thread per-COT state through the reentrancy guard rather than the whole-loop flag added in #687. Re-asserting the final registration is a smaller, more localized change with the same effect: whichever call the caller is actually waiting on becomes the canonical class everywhere, deterministically, rather than "whichever regeneration happened to run last" winning based on incidental Django-internals ordering.

## Testing

Added `GetModelCacheRegistryConsistencyTestCase` in `test_polymorphic_fields.py`, reusing the exact reproduction scenario from #686/#688 (a polymorphic field with a `related_name`, model cache and relation-tree forced cold). Asserts `get_model()`'s return value, `CustomObjectType.get_cached_model()`, and `apps.get_model()` are all the *same* class object (`assertIs`, not just equal).

Verified:
- Against unfixed code, the test fails with exactly the divergence #688 describes (`<class 'database.models.Table1Model'> is not <class 'database.models.Table1Model'>` -- two distinct objects of the same name).
- With this fix, it passes.
- Full `test_polymorphic_fields.py` suite (85 tests) against `netbox.configuration_co_testing`: 0 new failures (1 pre-existing, unrelated error in `ReferencedObjectDeletionTest` -- `CustomObjectType.delete()`'s `netbox_branching` import guard catches `ImportError` but this config's shared dev venv has `netbox_branching` importable-but-not-in-`INSTALLED_APPS`, raising `RuntimeError` instead; confirmed present on `main` with no code changes).
